### PR TITLE
Push collect down to just filenames instead of index values when join…

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Additional format-specific options can be provided via `readOptions` when creati
 <dependency>
     <groupId>dev.cjfravel</groupId>
     <artifactId>ariadne</artifactId>
-    <version>0.0.1-alpha-22</version>
+    <version>0.0.1-alpha-23</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>dev.cjfravel</groupId>
     <artifactId>ariadne</artifactId>
-    <version>0.0.1-alpha-22</version>
+    <version>0.0.1-alpha-23</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/scala/dev/cjfravel/ariadne/AriadneContext.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/AriadneContext.scala
@@ -21,7 +21,7 @@ trait AriadneContextUser {
     */
   lazy val storagePath: Path = {
     val path = new Path(spark.conf.get("spark.ariadne.storagePath"))
-    logger.trace(s"storagePath initialized: $path")
+    logger.warn(s"storagePath initialized: $path")
     println(s"Ariadne storage path: $path")
     path
   }
@@ -31,7 +31,7 @@ trait AriadneContextUser {
     */
   lazy val largeIndexLimit: Long = {
     val limit = spark.conf.get("spark.ariadne.largeIndexLimit", "500000").toLong
-    logger.trace(s"largeIndexLimit initialized: $limit")
+    logger.warn(s"largeIndexLimit initialized: $limit")
     limit
   }
 
@@ -41,7 +41,7 @@ trait AriadneContextUser {
       storagePath.getParent.toUri,
       spark.sparkContext.hadoopConfiguration
     )
-    logger.trace(s"FileSystem initialized for: ${storagePath.getParent}")
+    logger.warn(s"FileSystem initialized for: ${storagePath.getParent}")
     filesystem
   }
 

--- a/src/main/scala/dev/cjfravel/ariadne/FileList.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/FileList.scala
@@ -64,7 +64,7 @@ case class FileList private (
 
     _files = _files.union(newFiles)
     write
-    logger.trace(s"Added ${toAdd.size} files")
+    logger.warn(s"Added ${toAdd.size} files")
   }
 
   def addFile(fileNames: String*): Unit = addFile(spark, fileNames: _*)
@@ -90,7 +90,7 @@ case class FileList private (
           .save(storagePath.toString)
     }
     _files = null
-    logger.trace(s"Wrote out FileList $name")
+    logger.warn(s"Wrote out FileList $name")
   }
 
 }

--- a/src/main/scala/dev/cjfravel/ariadne/Index.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/Index.scala
@@ -119,7 +119,7 @@ case class Index private (
   def update: Unit = {
     val unindexed = unindexedFiles
     if (unindexed.nonEmpty) {
-      logger.trace(s"Updating index for ${unindexed.size} files")
+      logger.warn(s"Updating index for ${unindexed.size} files")
 
       // Read base data
       val baseDf = createBaseDataFrame(unindexed)

--- a/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
@@ -69,11 +69,6 @@ trait IndexJoinOperations extends IndexBuildOperations {
       throw new IllegalStateException(s"Index not found for $name")
     )
 
-    // Use exists with array_contains for efficient membership checking
-    // This avoids exploding large arrays and works with distributed DataFrames
-
-    // For large indexes stored in consolidated tables, we need a different strategy
-    // We'll use arrays_overlap if available, or fall back to a distributed join approach
 
     val matchingFilesDf = if (joinColumnsToUse.length == 1) {
       // Single column case - simpler and more efficient

--- a/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
@@ -49,7 +49,7 @@ trait IndexJoinOperations extends IndexBuildOperations {
     val columnMappings = mapJoinColumnsToStorage(usingColumns)
 
     val storageColumnsToUse = columnMappings.values.toSet.intersect(this.storageColumns)
-    logger.trace(s"Found indexes for ${storageColumnsToUse.mkString(",")}")
+    logger.warn(s"Found indexes for ${storageColumnsToUse.mkString(",")}")
 
     // Get columns to use for join
     val joinColumnsToUse = usingColumns.filter(col =>
@@ -85,7 +85,7 @@ trait IndexJoinOperations extends IndexBuildOperations {
 
     val files = matchingFilesDf.collect().map(_.getString(0)).toSet
     val totalFiles = indexDf.select("filename").distinct.count()
-    logger.info(s"Found ${files.size} matching files from $totalFiles total files")
+    logger.warn(s"Found ${files.size} matching files from $totalFiles total files")
 
     if (files.isEmpty) {
       logger.warn(s"No files found matching join criteria")

--- a/src/main/scala/dev/cjfravel/ariadne/IndexMetadataOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexMetadataOperations.scala
@@ -40,7 +40,7 @@ trait IndexMetadataOperations extends AriadneContextUser {
     } else {
       throw new MetadataMissingOrCorruptException()
     }
-    logger.trace(s"Read metadata from ${metadataFilePath.toString}")
+    logger.warn(s"Read metadata from ${metadataFilePath.toString}")
   }
 
   /** Retrieves the stored metadata for the index.
@@ -71,7 +71,7 @@ trait IndexMetadataOperations extends AriadneContextUser {
     outputStream.flush()
     outputStream.close()
     _metadata = metadata // Update in-memory cache
-    logger.trace(s"Wrote metadata to ${metadataFilePath.toString}")
+    logger.warn(s"Wrote metadata to ${metadataFilePath.toString}")
   }
 
   /** Returns the format of the stored data. */


### PR DESCRIPTION
Performance optimization, remove collect on indexed values, which could be in the millions, and focus on filenames instead.