### PR TITLE
0.0.1-alpha-38: Remove .cache() in joinDf, let Spark optimize

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Additional format-specific options can be provided via `readOptions` when creati
 <dependency>
     <groupId>dev.cjfravel</groupId>
     <artifactId>ariadne</artifactId>
-    <version>0.0.1-alpha-37</version>
+    <version>0.0.1-alpha-38</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>dev.cjfravel</groupId>
     <artifactId>ariadne</artifactId>
-    <version>0.0.1-alpha-37</version>
+    <version>0.0.1-alpha-38</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
The .cache() on the file read in joinDf forced materialization of ALL rows from pruned files before the join filter could be applied. The typedCache map was a local variable that was immediately GC'd, so the cache served no reuse purpose while consuming executor memory.

Without .cache(), Spark optimizes the full plan (file read → join) in a single pass, discarding non-matching rows immediately.