### PR TITLE
Add multi-version Spark/Delta support via Maven profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,18 @@ Additional format-specific options can be provided via `readOptions` when creati
 ### Example Usage
 
 ```xml
+<!-- Spark 3.4 / Delta 2.4 (Azure Synapse) -->
 <dependency>
     <groupId>dev.cjfravel</groupId>
-    <artifactId>ariadne</artifactId>
-    <version>0.0.1-alpha-39</version>
+    <artifactId>ariadne-spark34_2.12</artifactId>
+    <version>0.0.1-alpha-40</version>
+</dependency>
+
+<!-- Spark 3.5 / Delta 3.2 -->
+<dependency>
+    <groupId>dev.cjfravel</groupId>
+    <artifactId>ariadne-spark35_2.12</artifactId>
+    <version>0.0.1-alpha-40</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>dev.cjfravel</groupId>
-    <artifactId>ariadne</artifactId>
-    <version>0.0.1-alpha-39</version>
+    <artifactId>ariadne-spark${spark.suffix}_2.12</artifactId>
+    <version>0.0.1-alpha-40</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -35,8 +35,41 @@
 
     <properties>
         <scala.version>2.12.17</scala.version>
-        <spark.version>3.4.1</spark.version>
     </properties>
+
+    <profiles>
+        <profile>
+            <id>spark34</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <spark.suffix>34</spark.suffix>
+                <spark.version>3.4.1</spark.version>
+                <delta.artifactId>delta-core_2.12</delta.artifactId>
+                <delta.version>2.4.0</delta.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>spark35</id>
+            <properties>
+                <spark.suffix>35</spark.suffix>
+                <spark.version>3.5.5</spark.version>
+                <delta.artifactId>delta-spark_2.12</delta.artifactId>
+                <delta.version>3.2.1</delta.version>
+            </properties>
+            <dependencyManagement>
+                <dependencies>
+                    <!-- Force jackson-core 2.15.2 to match jackson-databind from Spark 3.5 -->
+                    <dependency>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                        <version>2.15.2</version>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+        </profile>
+    </profiles>
 
     <dependencies>
         <!-- Spark Core and SQL for DataFrame API -->
@@ -56,8 +89,8 @@
         <!-- Delta Lake -->
         <dependency>
             <groupId>io.delta</groupId>
-            <artifactId>delta-core_2.12</artifactId>
-            <version>2.4.0</version>
+            <artifactId>${delta.artifactId}</artifactId>
+            <version>${delta.version}</version>
         </dependency>
 
         <!-- Gson -->


### PR DESCRIPTION
- Add spark34 (default) and spark35 Maven profiles
- Spark 3.4.1 / Delta 2.4.0 and Spark 3.5.5 / Delta 3.2.1
- Artifact ID now includes Spark version suffix (ariadne-spark34_2.12, ariadne-spark35_2.12)
- Pin jackson-core 2.15.2 in spark35 profile to fix StreamReadConstraints ClassNotFoundException
- Bump version to 0.0.1-alpha-40
- Update README with both dependency variants