### PR TITLE
add per-index locking with auto-heal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ Additional format-specific options can be provided via `readOptions` when creati
 <dependency>
     <groupId>dev.cjfravel</groupId>
     <artifactId>ariadne-spark34_2.12</artifactId>
-    <version>0.0.1-alpha-41</version>
+    <version>0.0.1-alpha-42</version>
 </dependency>
 
 <!-- Spark 3.5 / Delta 3.2 -->
 <dependency>
     <groupId>dev.cjfravel</groupId>
     <artifactId>ariadne-spark35_2.12</artifactId>
-    <version>0.0.1-alpha-41</version>
+    <version>0.0.1-alpha-42</version>
 </dependency>
 ```
 
@@ -163,6 +163,10 @@ All configuration is done via Spark configuration properties. Set them before cr
 | `spark.ariadne.indexRepartitionCount`         | Int     | _(not set)_  | Number of partitions to repartition the index metadata DataFrame to during file lookup. Helps avoid `FetchFailedException` when exploding large index arrays. |
 | `spark.ariadne.repartitionDataFiles`          | Boolean | `false`      | When `true`, also applies `indexRepartitionCount` repartitioning to data files read during joins. When `false` (default), data files keep their natural parquet partitioning. |
 | `spark.ariadne.debug`                         | Boolean | `false`      | Enables detailed diagnostics during join operations: per-phase timing, file sizes, physical plans, and cache materialization stats. |
+| `spark.ariadne.lockTimeout`                   | Long    | `1800`       | Seconds after last lock refresh before a lock is considered stale and eligible for auto-healing. Default is 30 minutes. |
+| `spark.ariadne.lockRetryInterval`             | Long    | `60`         | Base interval in seconds between lock acquisition retries. Exponential backoff is applied up to a 60-second cap per retry. |
+| `spark.ariadne.lockMaxWait`                   | Long    | `3600`       | Maximum total seconds to wait for lock acquisition before throwing `IndexLockException`. Default is 1 hour. |
+| `spark.ariadne.lockRefreshInterval`           | Int     | `1`          | Refresh the update lock every N batches during `update`. Keeps the lock from appearing stale during long-running updates. |
 
 ### Example
 
@@ -182,4 +186,22 @@ spark.conf.set("spark.ariadne.repartitionDataFiles", "true")
 
 // Optional: enable debug logging
 spark.conf.set("spark.ariadne.debug", "true")
+
+// Optional: tune lock behavior for concurrent jobs
+spark.conf.set("spark.ariadne.lockTimeout", "1800")        // 30 min stale threshold
+spark.conf.set("spark.ariadne.lockRetryInterval", "60")     // 1 min base retry interval
+spark.conf.set("spark.ariadne.lockMaxWait", "3600")         // 1 hr max wait
 ```
+
+### Concurrency & Locking
+
+Ariadne uses per-index file-based locks to prevent concurrent updates from corrupting index data. Locks are automatically acquired and released during `addFile()` and `update()` operations.
+
+**How it works:**
+
+- **Two separate locks per index:** `.filelist.lock` (for `addFile`) and `.update.lock` (for `update`)
+- **Automatic refresh:** During `update`, the lock is refreshed every N batches (configurable via `spark.ariadne.lockRefreshInterval`) to signal the job is still alive
+- **Wait and retry:** If a lock is held by another job, the caller retries with exponential backoff up to `spark.ariadne.lockMaxWait` seconds
+- **Auto-healing:** If a lock's `lastRefreshedAt` timestamp is older than `spark.ariadne.lockTimeout`, it is considered stale (e.g., the holding job crashed) and is automatically broken so the new job can proceed
+
+**Lock file format:** JSON files stored at `{indexStoragePath}/.filelist.lock` and `{indexStoragePath}/.update.lock`, containing a correlation ID, timestamps, and the Spark application ID of the lock holder for diagnostics.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,10 +26,10 @@ The Ariadne Index system provides a modular architecture for managing file-based
                                 │
                                 │ uses
                                 ▼
-┌─────────────────────┐    ┌─────────────────────┐
-│   IndexPathUtils    │    │     FileList        │
-│ (Utility Object)    │    │  (File Tracking)    │
-└─────────────────────┘    └─────────────────────┘
+┌─────────────────────┐    ┌─────────────────────┐    ┌─────────────────────┐
+│   IndexPathUtils    │    │     FileList        │    │     IndexLock       │
+│ (Utility Object)    │    │  (File Tracking)    │    │  (Concurrency)      │
+└─────────────────────┘    └─────────────────────┘    └─────────────────────┘
 ```
 
 ## Core Components
@@ -198,7 +198,40 @@ The Ariadne Index system provides a modular architecture for managing file-based
 - `loadLargeIndex(colName: String): Option[DataFrame]` - Loads a large index Delta table in row form
 - `maybeRepartition(df: DataFrame): DataFrame` - Conditionally repartitions a DataFrame based on `indexRepartitionCount` configuration
 
-### 8. Index Class (Main API)
+### 8. IndexLock (Concurrency Control)
+
+**Purpose**: Prevents concurrent index modifications by providing per-index file-based locking with auto-healing support.
+
+**Key Responsibilities**:
+
+- Atomic lock acquisition using Hadoop FileSystem `create(overwrite=false)`
+- Lock refresh during long-running batch operations
+- Stale lock detection and auto-healing for crashed jobs
+- Wait-and-retry with exponential backoff for lock contention
+
+**Methods**:
+
+- `acquire(correlationId: String): Unit` - Acquires the lock; retries with backoff if held; auto-heals stale locks
+- `release(correlationId: String): Unit` - Releases the lock if the correlation ID matches
+- `refresh(correlationId: String): Unit` - Updates the lock's `lastRefreshedAt` timestamp
+
+**Lock File Format** (JSON):
+
+```json
+{
+  "correlationId": "uuid",
+  "acquiredAt": "ISO-8601",
+  "lastRefreshedAt": "ISO-8601",
+  "owner": "spark-app-id"
+}
+```
+
+**Usage in Index**:
+
+- `addFile()` acquires/releases `.filelist.lock`
+- `update()` acquires/releases `.update.lock` with periodic refresh every `lockRefreshInterval` batches
+
+### 9. Index Class (Main API)
 
 **Purpose**: Main public interface that combines all functionality through trait composition.
 
@@ -229,7 +262,7 @@ case class Index private (
 - `Index(name: String, schema: StructType, format: String, allowSchemaMismatch: Boolean): Index`
 - `Index(name: String, schema: StructType, format: String, readOptions: Map[String, String]): Index`
 
-### 9. IndexPathUtils (Object)
+### 10. IndexPathUtils (Object)
 
 **Purpose**: Provides utility functions for path manipulation and index management.
 
@@ -248,7 +281,7 @@ case class Index private (
 - `remove(name: String): Boolean` - Removes an index
 - `storagePath: Path` - Overrides base storage path for indexes
 
-### 10. Supporting Classes
+### 11. Supporting Classes
 
 #### IndexMetadata
 
@@ -454,6 +487,7 @@ Each trait can be tested independently with focused test suites:
 - `IndexQueryOperationsTests` - Tests querying and statistics
 - `IndexPathUtilsTests` - Tests utility functions
 - `BloomFilterOperationsTests` - Tests bloom filter functionality
+- `IndexLockTests` - Tests locking, auto-healing, and contention
 
 ### 3. **Performance Optimization**
 
@@ -508,6 +542,7 @@ Each module handles specific error conditions:
 - `FormatMismatchException` - Format validation failures
 - `IndexNotFoundException` - Missing index references
 - `IndexNotFoundInNewSchemaException` - Schema evolution issues
+- `IndexLockException` - Lock acquisition timeout or contention
 
 ## Implementation Details
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>dev.cjfravel</groupId>
     <artifactId>ariadne-spark${spark.suffix}_2.12</artifactId>
-    <version>0.0.1-alpha-41</version>
+    <version>0.0.1-alpha-42</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/scala/dev/cjfravel/ariadne/AriadneContext.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/AriadneContext.scala
@@ -120,4 +120,40 @@ trait AriadneContextUser {
       None
     }
   }
+
+  /** Time in seconds after lastRefreshedAt before a lock is considered stale and eligible for auto-heal.
+    * Reads from spark.ariadne.lockTimeout configuration (default: 1800).
+    */
+  lazy val lockTimeout: Long = {
+    val value = spark.conf.get("spark.ariadne.lockTimeout", "1800").toLong
+    logger.warn(s"lockTimeout initialized: $value")
+    value
+  }
+
+  /** Base interval in seconds between lock acquisition retries (exponential backoff applied).
+    * Reads from spark.ariadne.lockRetryInterval configuration (default: 60).
+    */
+  lazy val lockRetryInterval: Long = {
+    val value = spark.conf.get("spark.ariadne.lockRetryInterval", "60").toLong
+    logger.warn(s"lockRetryInterval initialized: $value")
+    value
+  }
+
+  /** Maximum total time in seconds to wait for lock acquisition before failing.
+    * Reads from spark.ariadne.lockMaxWait configuration (default: 3600).
+    */
+  lazy val lockMaxWait: Long = {
+    val value = spark.conf.get("spark.ariadne.lockMaxWait", "3600").toLong
+    logger.warn(s"lockMaxWait initialized: $value")
+    value
+  }
+
+  /** Refresh the update lock every N batches during updateBatched.
+    * Reads from spark.ariadne.lockRefreshInterval configuration (default: 1).
+    */
+  lazy val lockRefreshInterval: Int = {
+    val value = spark.conf.get("spark.ariadne.lockRefreshInterval", "1").toInt
+    logger.warn(s"lockRefreshInterval initialized: $value")
+    value
+  }
 }

--- a/src/main/scala/dev/cjfravel/ariadne/Index.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/Index.scala
@@ -10,7 +10,7 @@ import dev.cjfravel.ariadne.Index.DataFrameOps
 import com.google.gson.Gson
 import scala.collection.JavaConverters._
 import java.util
-import java.util.Collections
+import java.util.{Collections, UUID}
 
 /** Represents an Index for managing metadata and file-based indexes in Apache
   * Spark.
@@ -41,6 +41,12 @@ case class Index private (
   /** Path to the storage location of the index. */
   override lazy val storagePath: Path = new Path(IndexPathUtils.storagePath, name)
 
+  /** Lock path for file list operations. */
+  private def fileListLockPath: Path = new Path(storagePath, ".filelist.lock")
+
+  /** Lock path for index update operations. */
+  private def updateLockPath: Path = new Path(storagePath, ".update.lock")
+
   /** Selects specific columns for optimized reading.
     *
     *
@@ -67,7 +73,16 @@ case class Index private (
 
   def hasFile(fileName: String): Boolean = fileList.hasFile(fileName)
 
-  def addFile(fileNames: String*): Unit = fileList.addFile(fileNames: _*)
+  def addFile(fileNames: String*): Unit = {
+    val lock = IndexLock(fileListLockPath, name)
+    val correlationId = UUID.randomUUID().toString
+    lock.acquire(correlationId)
+    try {
+      fileList.addFile(fileNames: _*)
+    } finally {
+      lock.release(correlationId)
+    }
+  }
 
   /** Helper function to get a list of files that haven't yet been indexed
     *
@@ -263,18 +278,27 @@ case class Index private (
 
   /** Updates the index with new files. */
   def update: Unit = {
-    val unindexed = unindexedFiles
-    if (unindexed.nonEmpty) {
-      logger.warn(s"Updating index for ${unindexed.size} files")
-      updateBatched(unindexed)
+    val lock = IndexLock(updateLockPath, name)
+    val correlationId = UUID.randomUUID().toString
+    lock.acquire(correlationId)
+    try {
+      val unindexed = unindexedFiles
+      if (unindexed.nonEmpty) {
+        logger.warn(s"Updating index for ${unindexed.size} files")
+        updateBatched(unindexed, lock, correlationId)
+      }
+    } finally {
+      lock.release(correlationId)
     }
   }
 
   /** Updates the index using intelligent batching based on pre-flight analysis.
     *
     * @param files Set of files to process
+    * @param lock The update lock to refresh during processing
+    * @param correlationId The correlation ID for lock refresh
     */
-  private def updateBatched(files: Set[String]): Unit = {
+  private def updateBatched(files: Set[String], lock: IndexLock, correlationId: String): Unit = {
     logger.warn(s"Using intelligent batched update for ${files.size} files")
 
     // Perform pre-flight analysis to determine optimal batching
@@ -284,11 +308,19 @@ case class Index private (
     logger.warn(s"Processing ${batches.size} batches with consolidation threshold of $stagingConsolidationThreshold")
 
     var batchesSinceConsolidation = 0
+    var batchesSinceRefresh = 0
 
     batches.zipWithIndex.foreach { case (batch, idx) =>
       logger.warn(s"Processing batch ${idx + 1}/${batches.size} with ${batch.size} files")
       updateSingleBatch(batch)
       batchesSinceConsolidation += 1
+      batchesSinceRefresh += 1
+
+      // Periodic lock refresh to prevent stale lock detection
+      if (batchesSinceRefresh >= lockRefreshInterval) {
+        lock.refresh(correlationId)
+        batchesSinceRefresh = 0
+      }
 
       // Periodic consolidation for fault tolerance
       if (batchesSinceConsolidation >= stagingConsolidationThreshold) {

--- a/src/main/scala/dev/cjfravel/ariadne/IndexLock.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexLock.scala
@@ -1,0 +1,213 @@
+package dev.cjfravel.ariadne
+
+import com.google.gson.Gson
+import dev.cjfravel.ariadne.exceptions.IndexLockException
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.SparkSession
+
+import java.net.InetAddress
+import java.nio.charset.StandardCharsets
+import java.time.{Duration, Instant}
+import scala.io.Source
+
+case class LockInfo(
+    correlationId: String,
+    acquiredAt: String,
+    lastRefreshedAt: String,
+    owner: String
+)
+
+case class IndexLock(lockPath: Path, indexName: String)(implicit val spark: SparkSession)
+    extends AriadneContextUser {
+
+  private val gson = new Gson()
+
+  private def getOwner: String = {
+    try {
+      spark.sparkContext.applicationId
+    } catch {
+      case _: Exception => InetAddress.getLocalHost.getHostName
+    }
+  }
+
+  /** Acquires the lock for the given correlation ID.
+    * @param correlationId
+    *   The correlation ID to associate with the lock.
+    */
+  def acquire(correlationId: String): Unit = {
+    val startTime = System.currentTimeMillis()
+    var attempt = 0
+
+    def tryAcquire(): Unit = {
+      try {
+        val now = Instant.now().toString
+        val lockInfo = LockInfo(correlationId, now, now, getOwner)
+        val outputStream = fs.create(lockPath, false)
+        try {
+          outputStream.write(gson.toJson(lockInfo).getBytes(StandardCharsets.UTF_8))
+          outputStream.flush()
+        } finally {
+          outputStream.close()
+        }
+      } catch {
+        case _: org.apache.hadoop.fs.FileAlreadyExistsException | _: java.io.IOException =>
+          handleExistingLock(correlationId, startTime, attempt)
+      }
+    }
+
+    tryAcquire()
+  }
+
+  private def handleExistingLock(correlationId: String, startTime: Long, attempt: Int): Unit = {
+    readLock() match {
+      case Some(existingLock) if isStale(existingLock) =>
+        logger.warn(
+          s"Auto-healing stale lock for index '$indexName' " +
+            s"(held by correlationId='${existingLock.correlationId}', owner='${existingLock.owner}')"
+        )
+        delete(lockPath)
+        acquire(correlationId)
+      case Some(existingLock) =>
+        retryLoop(correlationId, startTime, attempt, existingLock)
+      case None =>
+        acquire(correlationId)
+    }
+  }
+
+  private def retryLoop(
+      correlationId: String,
+      startTime: Long,
+      attempt: Int,
+      lastLock: LockInfo
+  ): Unit = {
+    var currentAttempt = attempt
+    var currentLock = lastLock
+
+    while (true) {
+      val elapsed = (System.currentTimeMillis() - startTime) / 1000
+      if (elapsed >= lockMaxWait) {
+        throw new IndexLockException(indexName, currentLock.correlationId, currentLock.owner)
+      }
+
+      val sleepSeconds = Math.min(lockRetryInterval * Math.pow(2, currentAttempt).toLong, 60)
+      Thread.sleep(sleepSeconds * 1000)
+      currentAttempt += 1
+
+      readLock() match {
+        case Some(lock) if isStale(lock) =>
+          logger.warn(
+            s"Auto-healing stale lock for index '$indexName' " +
+              s"(held by correlationId='${lock.correlationId}', owner='${lock.owner}')"
+          )
+          delete(lockPath)
+          try {
+            val now = Instant.now().toString
+            val lockInfo = LockInfo(correlationId, now, now, getOwner)
+            val outputStream = fs.create(lockPath, false)
+            try {
+              outputStream.write(gson.toJson(lockInfo).getBytes(StandardCharsets.UTF_8))
+              outputStream.flush()
+            } finally {
+              outputStream.close()
+            }
+            return
+          } catch {
+            case _: org.apache.hadoop.fs.FileAlreadyExistsException | _: java.io.IOException =>
+              currentLock = readLock().getOrElse(currentLock)
+          }
+        case Some(lock) =>
+          currentLock = lock
+        case None =>
+          try {
+            val now = Instant.now().toString
+            val lockInfo = LockInfo(correlationId, now, now, getOwner)
+            val outputStream = fs.create(lockPath, false)
+            try {
+              outputStream.write(gson.toJson(lockInfo).getBytes(StandardCharsets.UTF_8))
+              outputStream.flush()
+            } finally {
+              outputStream.close()
+            }
+            return
+          } catch {
+            case _: org.apache.hadoop.fs.FileAlreadyExistsException | _: java.io.IOException =>
+              currentLock = readLock().getOrElse(currentLock)
+          }
+      }
+    }
+  }
+
+  /** Releases the lock for the given correlation ID.
+    * @param correlationId
+    *   The correlation ID that holds the lock.
+    */
+  def release(correlationId: String): Unit = {
+    readLock() match {
+      case Some(lockInfo) if lockInfo.correlationId == correlationId =>
+        delete(lockPath)
+      case Some(lockInfo) =>
+        logger.warn(
+          s"Cannot release lock for index '$indexName': " +
+            s"correlationId mismatch (expected='$correlationId', actual='${lockInfo.correlationId}')"
+        )
+      case None =>
+        logger.warn(s"Cannot release lock for index '$indexName': lock file does not exist")
+    }
+  }
+
+  /** Refreshes the lock timestamp for the given correlation ID.
+    * @param correlationId
+    *   The correlation ID that holds the lock.
+    */
+  def refresh(correlationId: String): Unit = {
+    readLock() match {
+      case Some(lockInfo) if lockInfo.correlationId == correlationId =>
+        val updated = lockInfo.copy(lastRefreshedAt = Instant.now().toString)
+        writeLock(updated)
+      case Some(lockInfo) =>
+        logger.warn(
+          s"Cannot refresh lock for index '$indexName': " +
+            s"correlationId mismatch (expected='$correlationId', actual='${lockInfo.correlationId}')"
+        )
+      case None =>
+        logger.warn(s"Cannot refresh lock for index '$indexName': lock file does not exist")
+    }
+  }
+
+  private def isStale(lockInfo: LockInfo): Boolean = {
+    try {
+      val lastRefreshed = Instant.parse(lockInfo.lastRefreshedAt)
+      Duration.between(lastRefreshed, Instant.now()).getSeconds > lockTimeout
+    } catch {
+      case _: Exception => true
+    }
+  }
+
+  private def readLock(): Option[LockInfo] = {
+    try {
+      if (exists(lockPath)) {
+        val inputStream = open(lockPath)
+        try {
+          val jsonString = Source.fromInputStream(inputStream)(StandardCharsets.UTF_8).mkString
+          Some(gson.fromJson(jsonString, classOf[LockInfo]))
+        } finally {
+          inputStream.close()
+        }
+      } else {
+        None
+      }
+    } catch {
+      case _: Exception => None
+    }
+  }
+
+  private def writeLock(lockInfo: LockInfo): Unit = {
+    val outputStream = fs.create(lockPath, true)
+    try {
+      outputStream.write(gson.toJson(lockInfo).getBytes(StandardCharsets.UTF_8))
+      outputStream.flush()
+    } finally {
+      outputStream.close()
+    }
+  }
+}

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexLockException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexLockException.scala
@@ -1,0 +1,13 @@
+package dev.cjfravel.ariadne.exceptions
+
+class IndexLockException(message: String) extends Exception(message) {
+  def this(indexName: String, holderCorrelationId: String, holderOwner: String) =
+    this(
+      s"Could not acquire lock for index '$indexName'. Currently held by correlationId='$holderCorrelationId', owner='$holderOwner'"
+    )
+}
+
+object IndexLockException {
+  def apply(indexName: String): IndexLockException =
+    new IndexLockException(s"Could not acquire lock for index '$indexName' within the configured timeout")
+}

--- a/src/test/scala/dev/cjfravel/ariadne/IndexLockTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexLockTests.scala
@@ -1,0 +1,188 @@
+package dev.cjfravel.ariadne
+
+import com.google.gson.Gson
+import dev.cjfravel.ariadne.exceptions.IndexLockException
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+import scala.io.Source
+
+class IndexLockTests extends SparkTests {
+
+  private val gson = new Gson()
+
+  private def fileSystem: FileSystem =
+    FileSystem.get(tempDir.toUri, spark.sparkContext.hadoopConfiguration)
+
+  private def lockPath(testName: String): Path =
+    new Path(new Path(tempDir.toUri), s"index-lock-$testName.json")
+
+  private def cleanup(path: Path): Unit = {
+    if (fileSystem.exists(path)) {
+      fileSystem.delete(path, true)
+    }
+  }
+
+  private def readLock(path: Path): LockInfo = {
+    val in = fileSystem.open(path)
+    try {
+      val json = Source.fromInputStream(in)(StandardCharsets.UTF_8).mkString
+      gson.fromJson(json, classOf[LockInfo])
+    } finally {
+      in.close()
+    }
+  }
+
+  private def writeLock(path: Path, info: LockInfo): Unit = {
+    val out = fileSystem.create(path, true)
+    try {
+      out.write(gson.toJson(info).getBytes(StandardCharsets.UTF_8))
+      out.flush()
+    } finally {
+      out.close()
+    }
+  }
+
+  private def withConfigOverrides[T](overrides: (String, String)*)(block: => T): T = {
+    val originals = overrides.map { case (key, _) => key -> spark.conf.getOption(key) }
+    overrides.foreach { case (key, value) => spark.conf.set(key, value) }
+    try block
+    finally {
+      originals.foreach {
+        case (key, Some(value)) => spark.conf.set(key, value)
+        case (key, None)        => spark.conf.unset(key)
+      }
+    }
+  }
+
+  test("acquire and release lock") {
+    val path = lockPath("acquire-release")
+    cleanup(path)
+    val lock = IndexLock(path, "test-index")
+    val correlationId = "corr-1"
+
+    try {
+      lock.acquire(correlationId)
+      assert(fileSystem.exists(path))
+      lock.release(correlationId)
+      assert(!fileSystem.exists(path))
+    } finally {
+      cleanup(path)
+    }
+  }
+
+  test("acquire lock is idempotent for same correlation ID after release") {
+    val path = lockPath("idempotent")
+    cleanup(path)
+    val lock = IndexLock(path, "test-index")
+    val correlationId = "same-id"
+
+    try {
+      lock.acquire(correlationId)
+      lock.release(correlationId)
+      lock.acquire(correlationId)
+      assert(fileSystem.exists(path))
+      lock.release(correlationId)
+    } finally {
+      cleanup(path)
+    }
+  }
+
+  test("release with wrong correlation ID does not remove lock") {
+    val path = lockPath("wrong-release")
+    cleanup(path)
+    val lock = IndexLock(path, "test-index")
+
+    try {
+      lock.acquire("a")
+      lock.release("b")
+      assert(fileSystem.exists(path))
+      lock.release("a")
+      assert(!fileSystem.exists(path))
+    } finally {
+      cleanup(path)
+    }
+  }
+
+  test("refresh updates lastRefreshedAt timestamp") {
+    val path = lockPath("refresh-updates")
+    cleanup(path)
+    val lock = IndexLock(path, "test-index")
+    val correlationId = "refresh-id"
+
+    try {
+      lock.acquire(correlationId)
+      val before = readLock(path)
+      Thread.sleep(100)
+      lock.refresh(correlationId)
+      val after = readLock(path)
+      assert(after.lastRefreshedAt != before.lastRefreshedAt)
+      assert(after.acquiredAt == before.acquiredAt)
+      lock.release(correlationId)
+    } finally {
+      cleanup(path)
+    }
+  }
+
+  test("refresh with wrong correlation ID does not update lock") {
+    val path = lockPath("refresh-wrong-id")
+    cleanup(path)
+    val lock = IndexLock(path, "test-index")
+
+    try {
+      lock.acquire("a")
+      val before = readLock(path)
+      lock.refresh("b")
+      val after = readLock(path)
+      assert(after.lastRefreshedAt == before.lastRefreshedAt)
+      lock.release("a")
+    } finally {
+      cleanup(path)
+    }
+  }
+
+  test("stale lock is auto-healed") {
+    val path = lockPath("stale-auto-heal")
+    cleanup(path)
+    val staleTime = Instant.now().minusSeconds(3600).toString
+    writeLock(path, LockInfo("a", staleTime, staleTime, "stale-owner"))
+    val lock = IndexLock(path, "test-index")
+    val newCorrelationId = "b"
+
+    try {
+      lock.acquire(newCorrelationId)
+      val info = readLock(path)
+      assert(info.correlationId == newCorrelationId)
+      lock.release(newCorrelationId)
+    } finally {
+      cleanup(path)
+    }
+  }
+
+  test("lock contention throws IndexLockException after max wait") {
+    val path = lockPath("lock-contention")
+    cleanup(path)
+
+    try {
+      withConfigOverrides(
+        "spark.ariadne.lockMaxWait" -> "1",
+        "spark.ariadne.lockRetryInterval" -> "1"
+      ) {
+        val lockA = IndexLock(path, "test-index")
+        val lockB = IndexLock(path, "test-index")
+
+        lockA.acquire("a")
+        try {
+          intercept[IndexLockException] {
+            lockB.acquire("b")
+          }
+        } finally {
+          lockA.release("a")
+        }
+      }
+    } finally {
+      cleanup(path)
+    }
+  }
+}


### PR DESCRIPTION
Add file-based locking mechanism to prevent concurrent index updates from corrupting data. Each index gets two locks (.filelist.lock for addFile, .update.lock for update) implemented as JSON files on Hadoop FS.

Features:
- Atomic lock acquisition via fs.create(overwrite=false)
- Automatic lock refresh during batch processing
- Stale lock auto-healing for crashed/stuck jobs
- Wait-and-retry with exponential backoff for contention
- Configurable timeout, retry interval, and max wait

New configuration properties:
- spark.ariadne.lockTimeout (default: 1800s)
- spark.ariadne.lockRetryInterval (default: 60s)
- spark.ariadne.lockMaxWait (default: 3600s)
- spark.ariadne.lockRefreshInterval (default: 1 batch)

Bump version to 0.0.1-alpha-42.