### PR TITLE
feat: backfill new index columns on existing files during update

### DIFF
--- a/src/main/scala/dev/cjfravel/ariadne/Index.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/Index.scala
@@ -108,6 +108,30 @@ case class Index private (
     }
   }
 
+  /** Identifies files already in the index that are missing data for newly added columns.
+    *
+    * Compares the columns declared in metadata against the columns present in the
+    * Delta index table schema. If any metadata columns are missing from the table,
+    * all indexed files need to be re-processed for the new columns.
+    *
+    * @return
+    *   Set of filenames needing column backfill
+    */
+  private[ariadne] def filesNeedingColumnUpdate: Set[String] = {
+    import spark.implicits._
+    index match {
+      case Some(df) =>
+        val expectedCols = storageColumns ++ bloomStorageColumns ++
+          metadata.temporal_indexes.asScala.map(_.column).toSet
+        val existingCols = df.columns.toSet - "filename"
+        val missingCols = expectedCols -- existingCols
+        if (missingCols.isEmpty) return Set.empty
+        logger.warn(s"Detected new index columns not yet in index table: ${missingCols.mkString(", ")}")
+        df.select("filename").as[String].collect().toSet
+      case None => Set.empty
+    }
+  }
+
   /** Adds an index entry.
     * @param index
     *   The index entry to add.
@@ -276,12 +300,19 @@ case class Index private (
     writeMetadata(metadata)
   }
 
-  /** Updates the index with new files. */
+  /** Updates the index with new files and backfills newly added columns. */
   def update: Unit = {
     val lock = IndexLock(updateLockPath, name)
     val correlationId = UUID.randomUUID().toString
     lock.acquire(correlationId)
     try {
+      // Backfill existing files for new columns first, so the index schema
+      // is complete before processing new files
+      val needsColumnUpdate = filesNeedingColumnUpdate
+      if (needsColumnUpdate.nonEmpty) {
+        logger.warn(s"Backfilling ${needsColumnUpdate.size} files for new index columns")
+        updateBatched(needsColumnUpdate, lock, correlationId)
+      }
       val unindexed = unindexedFiles
       if (unindexed.nonEmpty) {
         logger.warn(s"Updating index for ${unindexed.size} files")

--- a/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
@@ -252,11 +252,14 @@ trait IndexBuildOperations extends BloomFilterOperations {
 
     smallGroupedDf.write
       .format("delta")
+      .option("mergeSchema", "true")
       .mode("append")
       .save(stagingFilePath.toString)
   }
 
   /** Appends large index data directly to large_indexes/{column} Delta tables.
+    * When files already exist in the large index (e.g., during column backfill),
+    * existing rows for those files are removed before appending to prevent duplicates.
     *
     * @param df The DataFrame with large index data to append
     */
@@ -273,6 +276,9 @@ trait IndexBuildOperations extends BloomFilterOperations {
         )
     }
     
+    // Collect filenames being processed for dedup
+    val processedFiles = df.select("filename").distinct()
+    
     allStorageColumns.foreach { colName =>
       val columnData = largeGroupedDf
         .select("filename", colName)
@@ -284,8 +290,20 @@ trait IndexBuildOperations extends BloomFilterOperations {
       if (!columnData.isEmpty) {
         val columnPath = new Path(largeIndexesFilePath, colName)
         logger.warn(s"Appending large index data for column $colName to ${columnPath}")
+        
+        // Remove existing rows for these files to prevent duplicates during re-indexing
+        delta(columnPath) match {
+          case Some(deltaTable) =>
+            deltaTable.as("target")
+              .merge(processedFiles.as("source"), "target.filename = source.filename")
+              .whenMatched().delete()
+              .execute()
+          case None => // No existing table, nothing to dedup
+        }
+        
         columnData.write
           .format("delta")
+          .option("mergeSchema", "true")
           .mode("append")
           .save(columnPath.toString)
       }
@@ -307,26 +325,34 @@ trait IndexBuildOperations extends BloomFilterOperations {
       return
     }
     
-    val allStorageColumns = storageColumns
+    val allStorageColumns = storageColumns ++ bloomStorageColumns
     val stagingDf = spark.read.format("delta").load(stagingFilePath.toString)
     
     if (allStorageColumns.nonEmpty) {
       delta(indexFilePath) match {
         case Some(deltaTable) =>
           logger.warn(s"Merging staging data into main index at ${indexFilePath}")
-          deltaTable
-            .as("target")
-            .merge(
-              stagingDf.as("source"),
-              "target.filename = source.filename"
-            )
-            .whenMatched()
-            .updateExpr(
-              allStorageColumns.map(colName => colName -> s"source.$colName").toMap
-            )
-            .whenNotMatched()
-            .insertAll()
-            .execute()
+          // Enable schema auto-merge so new index columns evolve the target table
+          val previousAutoMerge = spark.conf.getOption("spark.databricks.delta.schema.autoMerge.enabled")
+          spark.conf.set("spark.databricks.delta.schema.autoMerge.enabled", "true")
+          try {
+            deltaTable
+              .as("target")
+              .merge(
+                stagingDf.as("source"),
+                "target.filename = source.filename"
+              )
+              .whenMatched()
+              .updateAll()
+              .whenNotMatched()
+              .insertAll()
+              .execute()
+          } finally {
+            previousAutoMerge match {
+              case Some(v) => spark.conf.set("spark.databricks.delta.schema.autoMerge.enabled", v)
+              case None => spark.conf.unset("spark.databricks.delta.schema.autoMerge.enabled")
+            }
+          }
         case None =>
           logger.warn(s"Creating new main index from staging at ${indexFilePath}")
           stagingDf.write

--- a/src/test/scala/dev/cjfravel/ariadne/ColumnBackfillTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/ColumnBackfillTests.scala
@@ -1,0 +1,199 @@
+package dev.cjfravel.ariadne
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.Row
+
+class ColumnBackfillTests extends SparkTests with Matchers {
+
+  val testSchema = StructType(
+    Seq(
+      StructField("Id", IntegerType, nullable = false),
+      StructField("Version", IntegerType, nullable = false),
+      StructField("Value", DoubleType, nullable = false)
+    )
+  )
+
+  test("should backfill new regular index column on existing files") {
+    val csvOptions = Map("header" -> "true")
+    val index = Index("backfill_regular", testSchema, "csv", csvOptions)
+    val paths = Array(
+      resourcePath("/data/table1_part0.csv"),
+      resourcePath("/data/table1_part1.csv")
+    )
+    index.addFile(paths: _*)
+    index.addIndex("Id")
+    index.update
+
+    // Verify initial state: Id is indexed, Version is not
+    index.unindexedFiles should be(empty)
+    val idFiles = index.locateFiles(Map("Id" -> Array(1)))
+    idFiles should not be empty
+
+    // Now add a new index column and update
+    index.addIndex("Version")
+    index.update
+
+    // Verify Version is now queryable
+    val versionFiles = index.locateFiles(Map("Version" -> Array(1)))
+    versionFiles should not be empty
+    versionFiles.size should be(2) // Both files contain Version=1
+
+    // Verify Id still works
+    val idFilesAfter = index.locateFiles(Map("Id" -> Array(1)))
+    idFilesAfter should not be empty
+    idFilesAfter should be(idFiles)
+  }
+
+  test("should backfill new computed index column on existing files") {
+    val csvOptions = Map("header" -> "true")
+    val index = Index("backfill_computed", testSchema, "csv", csvOptions)
+    val paths = Array(
+      resourcePath("/data/table1_part0.csv"),
+      resourcePath("/data/table1_part1.csv")
+    )
+    index.addFile(paths: _*)
+    index.addIndex("Id")
+    index.update
+
+    // Add computed index after initial build
+    index.addComputedIndex("id_doubled", "Id * 2")
+    index.update
+
+    // Verify computed index is populated
+    val doubledFiles = index.locateFiles(Map("id_doubled" -> Array(2, 4)))
+    doubledFiles should not be empty
+
+    // Verify original index still works
+    val idFiles = index.locateFiles(Map("Id" -> Array(1)))
+    idFiles should not be empty
+  }
+
+  test("should backfill new bloom index column on existing files") {
+    val csvOptions = Map("header" -> "true")
+    val index = Index("backfill_bloom", testSchema, "csv", csvOptions)
+    val paths = Array(
+      resourcePath("/data/table1_part0.csv"),
+      resourcePath("/data/table1_part1.csv")
+    )
+    index.addFile(paths: _*)
+    index.addIndex("Id")
+    index.update
+
+    // Add bloom index after initial build
+    index.addBloomIndex("Version", fpr = 0.01)
+    index.update
+
+    // Verify bloom index is populated and queryable
+    val bloomFiles = index.locateFiles(Map("Version" -> Array(1)))
+    bloomFiles should not be empty
+
+    // Verify original index still works
+    val idFiles = index.locateFiles(Map("Id" -> Array(1)))
+    idFiles should not be empty
+  }
+
+  test("should backfill new temporal index column on existing files") {
+    val temporalSchema = StructType(Seq(
+      StructField("Id", IntegerType, nullable = false),
+      StructField("Value", DoubleType, nullable = false),
+      StructField("UpdatedAt", TimestampType, nullable = true)
+    ))
+
+    val csvOptions = Map("header" -> "true")
+    val index = Index("backfill_temporal", temporalSchema, "csv", csvOptions)
+    val paths = Array(
+      resourcePath("/data/temporal_part0.csv"),
+      resourcePath("/data/temporal_part1.csv")
+    )
+    index.addFile(paths: _*)
+    index.addIndex("Value")
+    index.update
+
+    // Add temporal index after initial build
+    index.addTemporalIndex("Id", "UpdatedAt")
+    index.update
+
+    // Verify temporal index is populated
+    val temporalFiles = index.locateFiles(Map("Id" -> Array(1)))
+    temporalFiles should not be empty
+
+    // Verify original index still works
+    val valueFiles = index.locateFiles(Map("Value" -> Array(100.0)))
+    valueFiles should not be empty
+  }
+
+  test("should handle multiple new columns added at once") {
+    val csvOptions = Map("header" -> "true")
+    val index = Index("backfill_multiple", testSchema, "csv", csvOptions)
+    val paths = Array(
+      resourcePath("/data/table1_part0.csv"),
+      resourcePath("/data/table1_part1.csv")
+    )
+    index.addFile(paths: _*)
+    index.addIndex("Id")
+    index.update
+
+    // Add two new columns at once
+    index.addIndex("Version")
+    index.addComputedIndex("id_tripled", "Id * 3")
+    index.update
+
+    // Verify both new columns are populated
+    val versionFiles = index.locateFiles(Map("Version" -> Array(1)))
+    versionFiles should not be empty
+
+    val tripledFiles = index.locateFiles(Map("id_tripled" -> Array(3, 6)))
+    tripledFiles should not be empty
+
+    // Verify original index still works
+    val idFiles = index.locateFiles(Map("Id" -> Array(1)))
+    idFiles should not be empty
+  }
+
+  test("should be idempotent - second update after backfill is a no-op") {
+    val csvOptions = Map("header" -> "true")
+    val index = Index("backfill_idempotent", testSchema, "csv", csvOptions)
+    val paths = Array(
+      resourcePath("/data/table1_part0.csv"),
+      resourcePath("/data/table1_part1.csv")
+    )
+    index.addFile(paths: _*)
+    index.addIndex("Id")
+    index.update
+
+    index.addIndex("Version")
+    index.update
+
+    // Second update should be a no-op
+    index.filesNeedingColumnUpdate should be(empty)
+    index.unindexedFiles should be(empty)
+    index.update // Should not throw
+  }
+
+  test("should handle backfill with new files added simultaneously") {
+    val csvOptions = Map("header" -> "true")
+    val index = Index("backfill_with_new_files", testSchema, "csv", csvOptions)
+
+    // First: index one file with col1
+    val path0 = resourcePath("/data/table1_part0.csv")
+    index.addFile(path0)
+    index.addIndex("Id")
+    index.update
+
+    // Add new column AND new file at the same time
+    val path1 = resourcePath("/data/table1_part1.csv")
+    index.addFile(path1)
+    index.addIndex("Version")
+    index.update
+
+    // Both files should have both columns indexed
+    val idFiles = index.locateFiles(Map("Id" -> Array(1)))
+    idFiles should not be empty
+
+    val versionFiles = index.locateFiles(Map("Version" -> Array(1)))
+    versionFiles.size should be(2) // Both files contain Version=1
+  }
+}


### PR DESCRIPTION
When a new index column is added to an already-populated index, update now detects the missing column via schema-diff and re-indexes existing files to populate it. Column backfill runs before processing new files so both scenarios (new column only, new column + new files) work.

Changes:
- Add filesNeedingColumnUpdate detection to Index.scala
- Make update two-phase: backfill first, then new files
- Enable Delta schema evolution (mergeSchema + autoMerge)
- Switch consolidation merge to updateAll() for schema compat
- Add large-index dedup protection on re-index
- Add ColumnBackfillTests (7 tests)