### PR TITLE
feat: v0.0.1-alpha-45 — New index features, production hardening, and metrics

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -100,7 +100,7 @@ A column can have exactly one index type: regular, bloom, computed, temporal, ex
 
 ### Shading
 
-Guava and Gson are shaded under `dev.cjfravel.ariadne.shaded.*` to avoid version conflicts with the host Spark environment. Always use the shaded imports inside the library; do not add unshaded `com.google.*` runtime dependencies.
+Guava and Gson are shaded under `dev.cjfravel.ariadne.shaded.*` to avoid version conflicts with the host Spark environment. Source code uses standard `com.google.common.*` (Guava) and `com.google.gson.*` (Gson) imports — the Maven Shade Plugin automatically relocates these to `dev.cjfravel.ariadne.shaded.*` in the packaged JAR. Do not add additional unshaded `com.google.*` runtime dependencies to `pom.xml` as they would conflict with the shading configuration.
 
 ### Spark Profiles
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,102 @@
+# Ariadne – Copilot Instructions
+
+## Overview
+
+Ariadne is a Scala 2.12 / Apache Spark library that builds file-level indexes for data lake joins. Index metadata and data are stored as Delta Lake tables on a Hadoop-accessible filesystem. The library is published for two Spark versions (3.4 and 3.5) via Maven profiles.
+
+## Build & Test
+
+```bash
+# Build and test (default: Spark 3.4 profile)
+mvn test
+
+# Build and test with Spark 3.5
+mvn test -P spark35
+
+# Run a single test suite
+mvn test -Dsuites="dev.cjfravel.ariadne.IndexTests"
+
+# Run a specific test within a suite
+mvn test -Dsuites="dev.cjfravel.ariadne.IndexTests#my test name"
+
+# Package (produces shaded jar)
+mvn package
+```
+
+The `test` phase also runs `dev/scripts/readme-has-version.sh`, which fails if the version in `pom.xml` is not present in `README.md`. Always update `README.md` when bumping the version.
+
+Formatting: scalafmt (`runner.dialect = scala213`). Run with `scalafmt` or via your editor.
+
+## Architecture
+
+### Trait Hierarchy
+
+`Index` (case class, public API) extends a stack of traits, each adding a layer:
+
+```
+Index
+  └── IndexQueryOperations   # locateFiles, stats, printIndex
+        └── IndexJoinOperations  # join, joinDf, temporal dedup
+              └── IndexBuildOperations  # update, batching, staging, large indexes
+                    └── BloomFilterOperations  # bloom filter build & query
+                          └── IndexMetadataOperations  # read/write metadata.json
+                                └── AriadneContextUser  # SparkSession, HDFS, config
+```
+
+All traits use `self: Index =>` to access `Index` members.
+
+### Storage Layout (under `spark.ariadne.storagePath/{indexName}/`)
+
+| Path | Purpose |
+|------|---------|
+| `metadata.json` | JSON config: schema, format, index types, read options |
+| `index/` | Main Delta table — arrays of indexed values keyed by filename |
+| `staging/` | Transient Delta table during batched `update`; merged then deleted |
+| `large_indexes/{column}/` | Separate Delta table for columns exceeding `largeIndexLimit` (exploded rows instead of arrays) |
+| `.filelist.lock` / `.update.lock` | JSON lock files for concurrency control |
+
+The file list (`{indexName}.json`) is tracked separately via `FileList`.
+
+### Data Flow for `update`
+
+1. `analyzeFiles` — pre-flight distinct-count scan to decide batching
+2. `createOptimalBatches` — groups files so no batch exceeds `largeIndexLimit`
+3. Per batch: read files → apply computed indexes → build regular/exploded/bloom/temporal index DataFrames → join them → `appendToStaging` + `appendToLargeIndex`
+4. After every `stagingConsolidationThreshold` batches: `consolidateStaging` (Delta merge staging → main index)
+5. Final consolidation at end of all batches
+
+### Data Flow for `join`
+
+`Index.join(df, cols)` → `joinDf` → `locateFilesFromDataFrame` (returns a `Set[String]` of matching file paths) → `readFiles(files)` → `applyTemporalDeduplication` → `.join(df, cols, joinType)`
+
+`df.join(index, cols, joinType)` (via the `DataFrameOps` implicit) is the reverse direction.
+
+## Key Conventions
+
+### Index Type Mutual Exclusivity
+
+A column can have exactly one index type: regular, bloom, computed, temporal, or exploded. Attempting to add a second type throws `IllegalArgumentException`. All add methods are idempotent (calling twice is a no-op).
+
+### Metadata Versioning
+
+`IndexMetadata.apply(jsonString)` performs sequential null-checks to migrate old metadata files forward (v1→v2→…→v6). When adding a new field to `IndexMetadata`, add a corresponding null-check migration block in `IndexMetadata.apply`.
+
+### Logging Convention
+
+`logger.warn(...)` is used for all normal operational messages (progress, counts, paths). This is intentional — it matches how Spark surfaces log output in cluster environments. Reserve `logger.debug` for verbose/low-value entries.
+
+### Java/Scala Collections
+
+`IndexMetadata` uses Java collections (`util.List`, `util.Map`) for Gson compatibility. Use `import scala.collection.JavaConverters._` and `.asScala` / `.asJava` when bridging. Never change `IndexMetadata` fields to Scala collections without updating Gson serialization.
+
+### Shading
+
+Guava and Gson are shaded under `dev.cjfravel.ariadne.shaded.*` to avoid version conflicts with the host Spark environment. Always use the shaded imports inside the library; do not add unshaded `com.google.*` runtime dependencies.
+
+### Spark Profiles
+
+Default Maven profile is `spark34`. Use `-P spark35` for Spark 3.5 / Delta 3.2. The artifact ID encodes the Spark version: `ariadne-spark34_2.12` or `ariadne-spark35_2.12`.
+
+### Tests
+
+All Spark tests mix in `SparkTests`, which creates a local `SparkSession` with a temp directory as `spark.ariadne.storagePath` and the Delta extensions configured. Test data files live in `src/test/resources/` and are accessed via `resourcePath(fileName)`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -109,3 +109,56 @@ Default Maven profile is `spark34`. Use `-P spark35` for Spark 3.5 / Delta 3.2. 
 ### Tests
 
 All Spark tests mix in `SparkTests`, which creates a local `SparkSession` with a temp directory as `spark.ariadne.storagePath` and the Delta extensions configured. Test data files live in `src/test/resources/` and are accessed via `resourcePath(fileName)`.
+
+### Java Version
+
+Java 11 is required (`JAVA_HOME=/usr/lib/jvm/java-11-openjdk`). Do not use Java features beyond Java 11. The Scala version (2.12.17) and Spark versions (3.4/3.5) are tied to Azure Synapse dependencies and must not be changed.
+
+### Scaladoc Requirements
+
+All classes, traits, objects, and public/protected methods must have scaladoc documentation:
+- Class/trait/object level: purpose, thread-safety notes, relationship to other components
+- Method level: `@param`, `@return`, `@throws` annotations
+- Include usage examples for public API methods
+- Document edge cases and limitations (e.g., driver OOM risks for `collect()`)
+- Exception classes: document when thrown, by which methods, and recovery steps
+
+### Logging Standards
+
+- Use Log4j2 API (`org.apache.logging.log4j`)
+- `logger.warn(...)` for all operational messages (progress, counts, paths, durations). This is intentional — Spark clusters surface warn-level output.
+- `logger.debug(...)` for verbose/diagnostic entries only
+- All public mutating methods (`update`, `compact`, `vacuum`, `deleteFiles`) must:
+  - Log entry with index name and key parameters
+  - Log completion with duration
+  - Use catch-log-rethrow pattern so failures are logged before lock release
+- All `add*Index` methods must log confirmation of the addition
+- Silent catch blocks are prohibited — always log the exception before swallowing or rethrowing
+- Include enough context in log messages for debugging (index name, file counts, column names, durations)
+
+### Edge Case & Production Readiness Standards
+
+- Guard `.head`, `.last`, `.get` calls with `nonEmpty`/`isDefined` checks
+- Use try-finally for resource cleanup (broadcast variables, cached DataFrames, streams)
+- Close all streams (ByteArrayOutputStream, ByteArrayInputStream, scala.io.Source) in finally blocks
+- Guard against null in finally blocks (e.g., `if (stream != null) stream.close()`)
+- Document thread-safety: `Index` instances are NOT safe for concurrent `select()` + `join()` from multiple threads
+- Add comments documenting TOCTOU race conditions and driver OOM risks where applicable
+- Validate inputs: throw `IllegalArgumentException` for null/empty required parameters
+
+### Scala Coding Standards
+
+- Expression-oriented style: use `if/else` expressions instead of `return` statements
+- Use `import scala.collection.JavaConverters._` (NOT `CollectionConverters` which is Scala 2.13+)
+- Prefer immutable collections; use `var` only when required (e.g., Gson compatibility in `IndexMetadata`)
+- Use `Set.empty`, `Seq.empty` instead of `Set()`, `Seq()`
+- String interpolation (`s"..."`) over concatenation
+- Follow standard Scala naming: camelCase for methods/vals, PascalCase for types, UPPER_SNAKE for constants
+
+### Spark Coding Standards
+
+- Minimize driver-side `collect()` — document OOM risks where unavoidable
+- Use try-finally for `broadcast.destroy()` and `df.unpersist()` cleanup
+- Prefer built-in Spark functions over UDFs where possible
+- Use `@transient` for non-serializable fields in closures
+- Document any operations that break Catalyst optimization

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -88,7 +88,7 @@ A column can have exactly one index type: regular, bloom, computed, temporal, ex
 
 ### Metadata Versioning
 
-`IndexMetadata.apply(jsonString)` performs sequential null-checks to migrate old metadata files forward (v1→v2→…→v8). When adding a new field to `IndexMetadata`, add a corresponding null-check migration block in `IndexMetadata.apply`.
+`IndexMetadata.apply(jsonString)` performs sequential null-checks to migrate old metadata files forward (v1→v2→…→v9). When adding a new field to `IndexMetadata`, add a corresponding null-check migration block in `IndexMetadata.apply`.
 
 ### Logging Convention
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,7 +35,7 @@ Formatting: scalafmt (`runner.dialect = scala213`). Run with `scalafmt` or via y
 
 ```
 Index
-  └── IndexQueryOperations   # locateFiles, stats, printIndex
+  └── IndexQueryOperations   # locateFiles (with range/auto-bloom pre-filtering), stats, printIndex
         └── IndexJoinOperations  # join, joinDf, temporal dedup
               └── IndexBuildOperations  # update, batching, staging, large indexes
                     └── BloomFilterOperations  # bloom filter build & query
@@ -50,7 +50,7 @@ All traits use `self: Index =>` to access `Index` members.
 | Path | Purpose |
 |------|---------|
 | `metadata.json` | JSON config: schema, format, index types, read options |
-| `index/` | Main Delta table — arrays of indexed values keyed by filename |
+| `index/` | Main Delta table — arrays of indexed values keyed by filename, plus range structs and auto-bloom binary columns |
 | `staging/` | Transient Delta table during batched `update`; merged then deleted |
 | `large_indexes/{column}/` | Separate Delta table for columns exceeding `largeIndexLimit` (exploded rows instead of arrays) |
 | `.filelist.lock` / `.update.lock` | JSON lock files for concurrency control |
@@ -61,25 +61,34 @@ The file list (`{indexName}.json`) is tracked separately via `FileList`.
 
 1. `analyzeFiles` — pre-flight distinct-count scan to decide batching
 2. `createOptimalBatches` — groups files so no batch exceeds `largeIndexLimit`
-3. Per batch: read files → apply computed indexes → build regular/exploded/bloom/temporal index DataFrames → join them → `appendToStaging` + `appendToLargeIndex`
-4. After every `stagingConsolidationThreshold` batches: `consolidateStaging` (Delta merge staging → main index)
+3. Per batch: read files → apply computed indexes → build regular/exploded/bloom/temporal/range index DataFrames → build auto-bloom filters for large columns → join them → `appendToStaging` + `appendToLargeIndex`
+4. After every `stagingConsolidationThreshold` batches: `consolidateStaging` (Delta merge staging → main index); optionally auto-compact if `autoCompactThreshold` is set
 5. Final consolidation at end of all batches
 
 ### Data Flow for `join`
 
-`Index.join(df, cols)` → `joinDf` → `locateFilesFromDataFrame` (returns a `Set[String]` of matching file paths) → `readFiles(files)` → `applyTemporalDeduplication` → `.join(df, cols, joinType)`
+`Index.join(df, cols)` → `joinDf` → `locateFilesFromDataFrame` (returns a `Set[String]` of matching file paths via intersection across all index types: regular, bloom, temporal, range, and auto-bloom pre-filtering) → `readFiles(files)` → `applyTemporalDeduplication` → `.join(df, cols, joinType)`
 
 `df.join(index, cols, joinType)` (via the `DataFrameOps` implicit) is the reverse direction.
+
+### Data Flow for `deleteFiles`
+
+`deleteFiles(filenames)` → acquire update lock → merge-delete from main index → merge-delete from each large index table → merge-delete from staging (if exists) → remove from FileList → release lock
+
+### Data Flow for `compact` / `vacuum`
+
+`compact()` → acquire update lock → Delta OPTIMIZE on main index + all large index tables → release lock
+`vacuum(hours)` → acquire update lock → Delta VACUUM on main index + all large index tables → release lock
 
 ## Key Conventions
 
 ### Index Type Mutual Exclusivity
 
-A column can have exactly one index type: regular, bloom, computed, temporal, or exploded. Attempting to add a second type throws `IllegalArgumentException`. All add methods are idempotent (calling twice is a no-op).
+A column can have exactly one index type: regular, bloom, computed, temporal, exploded, or range. Attempting to add a second type throws `IllegalArgumentException`. All add methods are idempotent (calling twice is a no-op).
 
 ### Metadata Versioning
 
-`IndexMetadata.apply(jsonString)` performs sequential null-checks to migrate old metadata files forward (v1→v2→…→v6). When adding a new field to `IndexMetadata`, add a corresponding null-check migration block in `IndexMetadata.apply`.
+`IndexMetadata.apply(jsonString)` performs sequential null-checks to migrate old metadata files forward (v1→v2→…→v8). When adding a new field to `IndexMetadata`, add a corresponding null-check migration block in `IndexMetadata.apply`.
 
 ### Logging Convention
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Additional format-specific options can be provided via `readOptions` when creati
    - **Bloom filter indexes** – Space-efficient probabilistic indexes for high-cardinality columns (`addBloomIndex("column_name", fpr)`)
    - **Temporal indexes** – Version-aware indexes that deduplicate by recency (`addTemporalIndex("column_name", "timestamp_column")`)
    - **Computed indexes** – Index derived values using SQL expressions (`addComputedIndex("alias", "expression")`)
+   - **Range indexes** – Min/max pruning for ordered columns (`addRangeIndex("column_name")`)
    - **Exploded field indexes** – Index elements within array columns (`addExplodedFieldIndex("array_column", "field_path", "alias")`)
 3. **Add files** – Register files with the index.
 4. **Update the index** – Run updates whenever you add new files or indexed columns.
@@ -65,8 +66,8 @@ val joinedWithoutIndex = otherDf.join(table, Seq("version", "id"), "left_semi")
 // ensure spark.sparkContext.hadoopConfiguration has access to this location
 spark.conf.set("spark.ariadne.storagePath", s"abfss://${container}@${storageAccount}.dfs.core.windows.net/ariadne")
 
-import dev.cjfravel.ariadne
-
+import dev.cjfravel.ariadne.Index
+import dev.cjfravel.ariadne.Index._  // for df.join(index, ...) implicit
 // Create and configure the index
 val index = Index("table", tableSchema, "parquet")
 index.addIndex("version")
@@ -298,3 +299,169 @@ Ariadne uses per-index file-based locks to prevent concurrent updates from corru
 - **Auto-healing:** If a lock's `lastRefreshedAt` timestamp is older than `spark.ariadne.lockTimeout`, it is considered stale (e.g., the holding job crashed) and is automatically broken so the new job can proceed
 
 **Lock file format:** JSON files stored at `{indexStoragePath}/.filelist.lock` and `{indexStoragePath}/.update.lock`, containing a correlation ID, timestamps, and the Spark application ID of the lock holder for diagnostics.
+
+## API Reference
+
+### Index Lifecycle
+
+```scala
+// Check if an index exists
+val exists: Boolean = Index.exists("myIndex")
+
+// Remove an index and all its data (index, large indexes, staging, file list, metadata)
+// Throws IndexNotFoundException if the index does not exist
+val removed: Boolean = Index.remove("myIndex")
+```
+
+### Factory Methods
+
+```scala
+// Basic: name, schema, format
+val index = Index("myIndex", schema, "parquet")
+
+// With schema mismatch tolerance (allows updating schema while preserving indexes)
+val index = Index("myIndex", newSchema, "parquet", allowSchemaMismatch = true)
+
+// With format-specific read options
+val index = Index("myIndex", schema, "json", readOptions = Map("multiLine" -> "true"))
+
+// Reconnect to an existing index (no schema/format needed if metadata exists)
+val index = Index("myIndex")
+```
+
+### Querying & Inspection
+
+```scala
+// Get the set of all indexed column names (across all index types)
+val cols: Set[String] = index.indexes
+
+// Check if a specific file is tracked by this index
+val tracked: Boolean = index.hasFile("data/file1.parquet")
+
+// Get index statistics (file count, per-column min/max/avg/median/stddev of array sizes)
+val statsDF: DataFrame = index.stats()
+statsDF.show()
+
+// Locate files matching specific values without performing a full join
+val files: Set[String] = index.locateFiles(Map(
+  "user_id" -> Array("u1", "u2", "u3")
+))
+
+// Refresh cached metadata from disk (useful if another job updated the index)
+index.refreshMetadata()
+
+// Access index properties
+val fmt: String = index.format         // e.g., "parquet"
+val sch: StructType = index.storedSchema  // the stored schema
+```
+
+## Error Handling
+
+All Ariadne exceptions extend `AriadneException` (a `RuntimeException`), so you can catch them with a single handler:
+
+```scala
+import dev.cjfravel.ariadne.exceptions._
+
+try {
+  val index = Index("myIndex", schema, "parquet")
+  index.update
+} catch {
+  case e: AriadneException => // handle any Ariadne error
+}
+```
+
+### Exception Reference
+
+| Exception | When Thrown |
+|-----------|------------|
+| `SchemaNotProvidedException` | Creating a new index without providing a schema |
+| `SchemaMismatchException` | Schema differs from stored metadata and `allowSchemaMismatch` is `false` |
+| `FormatMismatchException` | Format differs from stored metadata |
+| `IndexNotFoundException` | Calling `Index.remove()` on a non-existent index |
+| `IndexNotFoundInNewSchemaException` | Using `allowSchemaMismatch = true` but the new schema is missing a previously indexed column |
+| `ColumnNotFoundException` | Calling `select()` or `addBloomIndex()` with a column that doesn't exist in the schema |
+| `IndexLockException` | Lock acquisition timed out after `lockMaxWait` seconds |
+| `MetadataMissingOrCorruptException` | Index metadata file is unreadable or corrupt — delete and re-create the index |
+| `IllegalArgumentException` | Adding a column that already has a different index type (mutual exclusivity violation) |
+
+## Troubleshooting
+
+### `FetchFailedException` During Joins
+
+**Symptom:** `org.apache.spark.shuffle.FetchFailedException` when joining against indexes with very large arrays of values.
+
+**Cause:** Default Spark partitioning can concentrate large index arrays on too few executors, causing OOM during the shuffle phase.
+
+**Fix:** Set `indexRepartitionCount` to spread the work across more partitions:
+
+```scala
+spark.conf.set("spark.ariadne.indexRepartitionCount", "500")
+```
+
+If data files are also large, enable data file repartitioning:
+
+```scala
+spark.conf.set("spark.ariadne.repartitionDataFiles", "true")
+```
+
+### Lock Contention / `IndexLockException`
+
+**Symptom:** `IndexLockException: Could not acquire lock for index '...'`
+
+**Cause:** Another job holds the lock and hasn't released it within `lockMaxWait` seconds, or a crashed job left a stale lock.
+
+**Fix:**
+1. **Stale locks auto-heal:** If the lock holder crashed, the lock will be automatically broken after `lockTimeout` seconds (default: 30 minutes). Wait and retry.
+2. **Increase wait time** if contention is expected:
+   ```scala
+   spark.conf.set("spark.ariadne.lockMaxWait", "7200")  // wait up to 2 hours
+   ```
+3. **Manual recovery:** Delete the lock file from storage if you're certain no other job is running:
+   ```
+   {storagePath}/{indexName}/.update.lock
+   {storagePath}/{indexName}/.filelist.lock
+   ```
+
+### Out of Memory on Large Indexes
+
+**Symptom:** OOM errors during `update` when indexing files with very high cardinality columns.
+
+**Cause:** A single file has more distinct values than `largeIndexLimit`, causing large in-memory arrays.
+
+**Fix:**
+1. **Lower `largeIndexLimit`** so high-cardinality columns are stored as exploded rows in separate Delta tables:
+   ```scala
+   spark.conf.set("spark.ariadne.largeIndexLimit", "100000")
+   ```
+2. **Use bloom indexes** instead of regular indexes for high-cardinality columns:
+   ```scala
+   index.addBloomIndex("high_cardinality_col", fpr = 0.01)
+   ```
+3. **Reduce batch size** by lowering `stagingConsolidationThreshold` for more frequent staging checkpoints:
+   ```scala
+   spark.conf.set("spark.ariadne.stagingConsolidationThreshold", "10")
+   ```
+
+### `MetadataMissingOrCorruptException`
+
+**Symptom:** `Index metadata is missing or corrupt. Delete and re-create the index.`
+
+**Cause:** The `metadata.json` file in the index storage path is unreadable, typically due to a partial write or manual tampering.
+
+**Fix:** Remove the index and re-create it:
+
+```scala
+Index.remove("myIndex")
+val index = Index("myIndex", schema, "parquet")
+// re-add indexes and files, then update
+```
+
+### `SchemaMismatchException` After Schema Evolution
+
+**Symptom:** `Schema provided does not match stored schema` when the data schema has changed.
+
+**Fix:** Use `allowSchemaMismatch = true` to update the schema while preserving existing indexes. All indexed columns must still exist in the new schema:
+
+```scala
+val index = Index("myIndex", newSchema, "parquet", allowSchemaMismatch = true)
+```

--- a/README.md
+++ b/README.md
@@ -182,6 +182,17 @@ val result = index.join(queryDf, Seq("event_date", "user_id"), "inner")
 - **Supported types**: Works with any comparable Spark type (DateType, TimestampType, IntegerType, LongType, DoubleType, StringType, etc.)
 - **Mutually exclusive**: A column can have only one index type
 
+### Column Selection
+
+You can optimize reads by selecting only the columns you need:
+
+```scala
+// Only read specific columns from indexed files
+val result = index.select("user_id", "name", "email").join(queryDf, Seq("user_id"), "inner")
+```
+
+When columns are selected, only those columns are read from the data files during joins, reducing I/O and memory usage. Join columns must always be included in the selection.
+
 ## Index Maintenance
 
 ### Deleting Files

--- a/README.md
+++ b/README.md
@@ -215,6 +215,16 @@ spark.conf.set("spark.ariadne.autoCompactThreshold", "10")  // Compact every 10 
 index.update  // Automatically compacts during update
 ```
 
+### Pruning Metrics
+
+Ariadne tracks the file size of every indexed file and logs how much data each join pruned:
+
+```
+Index pruning: loaded 42 of 10000 files (1.23 GB of 45.67 GB) — 97% data pruned
+```
+
+File sizes are stored in the index table and totals are cached in metadata, so this metric adds no overhead. Existing indexes automatically backfill file sizes on the next `update()`.
+
 ## Configuration
 
 All configuration is done via Spark configuration properties. Set them before creating or using indexes.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Additional format-specific options can be provided via `readOptions` when creati
 4. **Update the index** – Run updates whenever you add new files or indexed columns.
 5. **Use the index in joins** – Leverage the index to load only the relevant files based on your DataFrame's join conditions.
 
+> **Multi-column joins**: When joining on multiple columns, Ariadne uses AND semantics — a file must match on *all* queried index types to be included. This applies across regular, bloom, temporal, and range indexes.
+
 > **Note:** When using an index in a join, it is no longer a "narrow" transformation. The index must first retrieve matching values from its records, load the appropriate data, and then perform the narrow transformation on the resulting DataFrame.
 
 ### Example Usage
@@ -126,6 +128,8 @@ val result = index.join(userQueryDf, Seq("user_id"), "inner")
 - **Mutually exclusive**: A column can have either a regular index OR a bloom index, not both
 - **Best for**: High-cardinality columns across large datasets where exact value storage would be prohibitive
 
+**Automatic bloom filters for large indexes**: When a column exceeds `largeIndexLimit` distinct values, Ariadne automatically creates a bloom filter for that column in addition to the large index table. This pre-filters candidate files before querying the expensive large index, significantly reducing I/O. The false positive rate is controlled by `spark.ariadne.autoBloomFpr` (default: 1%). This feature is backward-compatible — existing indexes are automatically migrated on the next `update`.
+
 ### Temporal Index Example
 
 Temporal indexes are ideal when the same entity appears in multiple files at different timestamps, and you only want the most recent version:
@@ -151,6 +155,66 @@ val result = index.join(queryDf, Seq("user_id"), "inner")
 - **Mutually exclusive**: A column can have either a regular, bloom, computed, OR temporal index — not multiple
 - **Best for**: Slowly changing dimensions, entity snapshots, event-sourced data where you need the current state
 
+### Range Index Example
+
+Range indexes store per-file min/max values for a column, enabling efficient file pruning at query time. Files are only loaded when the query values fall within their min/max range.
+
+```scala
+// Create an index with range-based pruning for date or numeric columns
+val index = Index("events", eventSchema, "parquet")
+index.addRangeIndex("event_date")   // Store min/max event_date per file
+index.addRangeIndex("amount")       // Store min/max amount per file
+index.addIndex("user_id")           // Regular index alongside range indexes
+index.addFile(eventFiles: _*)
+index.update
+
+// During joins, range indexes automatically prune files that can't contain matching values
+val queryDf = // DataFrame with event_date and user_id columns
+val result = index.join(queryDf, Seq("event_date", "user_id"), "inner")
+// Only files where event_date range overlaps with query values are loaded
+```
+
+**Key points about range indexes:**
+
+- **Min/max pruning**: Each file stores the minimum and maximum value for the indexed column. At query time, files are skipped if no query value falls within their range
+- **Best for ordered data**: Most effective when data has natural ordering (dates, timestamps, sequential IDs, amounts)
+- **Complementary**: Range indexes work alongside regular, bloom, and temporal indexes — results are intersected across all index types
+- **Supported types**: Works with any comparable Spark type (DateType, TimestampType, IntegerType, LongType, DoubleType, StringType, etc.)
+- **Mutually exclusive**: A column can have only one index type
+
+## Index Maintenance
+
+### Deleting Files
+
+Remove files from the index when they are no longer needed (e.g., after data archival or deletion):
+
+```scala
+// Remove specific files from the index
+index.deleteFiles("old_data_2023.parquet", "archived_events.parquet")
+
+// Removes entries from: main index, large index tables, staging, and file list
+```
+
+### Compaction
+
+Delta Lake tables accumulate small files over time from repeated updates. Compaction consolidates these into larger files for better read performance:
+
+```scala
+// Manually compact all index Delta tables
+index.compact()
+
+// Vacuum old Delta log files (default: 168 hours / 7 days retention)
+index.vacuum()
+index.vacuum(retentionHours = 72)  // Custom retention period
+```
+
+**Auto-compaction**: Set `spark.ariadne.autoCompactThreshold` to automatically compact after a specified number of update batches:
+
+```scala
+spark.conf.set("spark.ariadne.autoCompactThreshold", "10")  // Compact every 10 batches
+index.update  // Automatically compacts during update
+```
+
 ## Configuration
 
 All configuration is done via Spark configuration properties. Set them before creating or using indexes.
@@ -167,6 +231,8 @@ All configuration is done via Spark configuration properties. Set them before cr
 | `spark.ariadne.lockRetryInterval`             | Long    | `60`         | Base interval in seconds between lock acquisition retries. Exponential backoff is applied up to a 60-second cap per retry. |
 | `spark.ariadne.lockMaxWait`                   | Long    | `3600`       | Maximum total seconds to wait for lock acquisition before throwing `IndexLockException`. Default is 1 hour. |
 | `spark.ariadne.lockRefreshInterval`           | Int     | `1`          | Refresh the update lock every N batches during `update`. Keeps the lock from appearing stale during long-running updates. |
+| `spark.ariadne.autoCompactThreshold`          | Int     | _(not set)_  | Number of update batches before triggering automatic Delta table compaction. When not set, auto-compaction is disabled. |
+| `spark.ariadne.autoBloomFpr`                  | Double  | `0.01`       | False positive rate for automatic bloom filters on large index columns. Only applies to columns that exceed `largeIndexLimit`. |
 
 ### Example
 
@@ -186,6 +252,12 @@ spark.conf.set("spark.ariadne.repartitionDataFiles", "true")
 
 // Optional: enable debug logging
 spark.conf.set("spark.ariadne.debug", "true")
+
+// Optional: auto-compact index after every 10 update batches
+spark.conf.set("spark.ariadne.autoCompactThreshold", "10")
+
+// Optional: tune auto-bloom false positive rate for large indexes (default: 1%)
+spark.conf.set("spark.ariadne.autoBloomFpr", "0.005")
 
 // Optional: tune lock behavior for concurrent jobs
 spark.conf.set("spark.ariadne.lockTimeout", "1800")        // 30 min stale threshold

--- a/README.md
+++ b/README.md
@@ -393,6 +393,13 @@ IndexCatalog.toDF().show()
 
 // Remove an index by name
 IndexCatalog.remove("myIndex")
+
+// Find all indexes that track a specific file
+val affected: Seq[String] = IndexCatalog.findIndexes("s3a://bucket/data/file1.parquet")
+// Clean up references after a file is deleted
+affected.foreach { name =>
+  IndexCatalog.get(name).deleteFiles("s3a://bucket/data/file1.parquet")
+}
 ```
 
 ## Error Handling

--- a/README.md
+++ b/README.md
@@ -357,6 +357,44 @@ val fmt: String = index.format         // e.g., "parquet"
 val sch: StructType = index.storedSchema  // the stored schema
 ```
 
+### Index Catalog
+
+`IndexCatalog` provides a global view of all indexes under the configured storage path. Use it to discover, inspect, and manage indexes without knowing their names upfront.
+
+```scala
+import dev.cjfravel.ariadne.IndexCatalog
+
+// List all index names
+val names: Seq[String] = IndexCatalog.list()
+
+// Check if a specific index exists
+val exists: Boolean = IndexCatalog.exists("myIndex")
+
+// Get a summary of a single index (index types, file count, format)
+val summary: IndexSummary = IndexCatalog.describe("myIndex")
+println(s"Format: ${summary.format}")
+println(s"Regular indexes: ${summary.regularIndexes}")
+println(s"Bloom indexes: ${summary.bloomIndexes}")
+println(s"File count: ${summary.fileCount}")
+
+// Get summaries for all indexes at once
+val allSummaries: Seq[IndexSummary] = IndexCatalog.describeAll()
+
+// Fetch an Index instance by name (reconnects to existing index)
+val index: Index = IndexCatalog.get("myIndex")
+
+// View all indexes as a DataFrame (one row per index)
+IndexCatalog.toDF().show()
+// +--------+-------+---------------+-------------+---------+----------+
+// |    name| format|regular_indexes|bloom_indexes|file_count|        ...|
+// +--------+-------+---------------+-------------+---------+----------+
+// |myIndex |parquet|     Id, Version|             |       42|        ...|
+// +--------+-------+---------------+-------------+---------+----------+
+
+// Remove an index by name
+IndexCatalog.remove("myIndex")
+```
+
 ## Error Handling
 
 All Ariadne exceptions extend `AriadneException` (a `RuntimeException`), so you can catch them with a single handler:

--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ Additional format-specific options can be provided via `readOptions` when creati
 <dependency>
     <groupId>dev.cjfravel</groupId>
     <artifactId>ariadne-spark34_2.12</artifactId>
-    <version>0.0.1-alpha-44</version>
+    <version>0.0.1-alpha-45</version>
 </dependency>
 
 <!-- Spark 3.5 / Delta 3.2 -->
 <dependency>
     <groupId>dev.cjfravel</groupId>
     <artifactId>ariadne-spark35_2.12</artifactId>
-    <version>0.0.1-alpha-44</version>
+    <version>0.0.1-alpha-45</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -220,12 +220,14 @@ index.vacuum()
 index.vacuum(retentionHours = 72)  // Custom retention period
 ```
 
-**Auto-compaction**: Set `spark.ariadne.autoCompactThreshold` to automatically compact after a specified number of update batches:
+**Auto-compaction**: Set `spark.ariadne.autoCompactThreshold` to automatically compact after a specified number of update batches. The batch counter is persisted in index metadata, so it accumulates correctly across separate Spark jobs:
 
 ```scala
 spark.conf.set("spark.ariadne.autoCompactThreshold", "10")  // Compact every 10 batches
 index.update  // Automatically compacts during update
 ```
+
+> **Note:** If auto-compaction is not configured and the batch counter reaches 50, Ariadne logs a warning suggesting you run `index.compact()` or enable `autoCompactThreshold`.
 
 ### Pruning Metrics
 

--- a/README.md
+++ b/README.md
@@ -291,11 +291,11 @@ spark.conf.set("spark.ariadne.lockMaxWait", "3600")         // 1 hr max wait
 
 ### Concurrency & Locking
 
-Ariadne uses per-index file-based locks to prevent concurrent updates from corrupting index data. Locks are automatically acquired and released during `addFile()` and `update()` operations.
+Ariadne uses per-index file-based locks to prevent concurrent modifications from corrupting index data. Locks are automatically acquired and released during mutating operations.
 
 **How it works:**
 
-- **Two separate locks per index:** `.filelist.lock` (for `addFile`) and `.update.lock` (for `update`)
+- **Two separate locks per index:** `.filelist.lock` (for `addFile`) and `.update.lock` (for `update`, `deleteFiles`, `compact`, and `vacuum`)
 - **Automatic refresh:** During `update`, the lock is refreshed every N batches (configurable via `spark.ariadne.lockRefreshInterval`) to signal the job is still alive
 - **Wait and retry:** If a lock is held by another job, the caller retries with exponential backoff up to `spark.ariadne.lockMaxWait` seconds
 - **Auto-healing:** If a lock's `lastRefreshedAt` timestamp is older than `spark.ariadne.lockTimeout`, it is considered stale (e.g., the holding job crashed) and is automatically broken so the new job can proceed
@@ -426,9 +426,13 @@ try {
 | `FormatMismatchException` | Format differs from stored metadata |
 | `IndexNotFoundException` | Calling `Index.remove()` on a non-existent index |
 | `IndexNotFoundInNewSchemaException` | Using `allowSchemaMismatch = true` but the new schema is missing a previously indexed column |
-| `ColumnNotFoundException` | Calling `select()` or `addBloomIndex()` with a column that doesn't exist in the schema |
+| `ColumnNotFoundException` | Calling `select()` or `addBloomIndex()` with a column that doesn't exist in the schema, or joining on columns not present in the schema or indexes |
 | `IndexLockException` | Lock acquisition timed out after `lockMaxWait` seconds |
 | `MetadataMissingOrCorruptException` | Index metadata file is unreadable or corrupt — delete and re-create the index |
+| `MissingFormatException` | Creating a new index without providing a format |
+| `MissingSchemaException` | Accessing `storedSchema` when the schema field is null in metadata |
+| `SchemaParseException` | The schema string in metadata cannot be parsed as a valid StructType |
+| `FileListNotFoundException` | Attempting to remove a file list that does not exist |
 | `IllegalArgumentException` | Adding a column that already has a different index type (mutual exclusivity violation) |
 
 ## Troubleshooting

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -525,6 +525,7 @@ The system supports automatic migration between metadata versions:
 - v5 → v6: Adds temporal_indexes support
 - v6 → v7: Adds range_indexes support (RangeIndexConfig with column name and data type)
 - v7 → v8: Adds auto_bloom_indexes support (automatic bloom filters for large index columns)
+- v8 → v9: Adds total_indexed_file_size field (per-file size tracking and pruning metrics)
 
 ### Caching Strategy
 
@@ -580,6 +581,7 @@ Each trait can be tested independently with focused test suites:
 - `RangeIndexTests` - Tests range index build and query
 - `AutoBloomLargeIndexTests` - Tests automatic bloom filter generation
 - `MixedIndexIntersectionTests` - Tests cross-type intersection edge cases
+- `FileSizeTrackingTests` - Tests file size tracking, pruning metrics, and backfill
 
 ### 3. **Performance Optimization**
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -566,6 +566,38 @@ spark.conf.set("spark.ariadne.indexRepartitionCount", "200")
 val result = queryDf.join(index, Seq("user_id"), "inner")
 ```
 
+## Thread Safety & Concurrency
+
+### Index Instance Thread Safety
+
+**`Index` instances are NOT thread-safe for concurrent mutation.** Specifically:
+
+- `select()` mutates internal `selectedColumns` state and returns `this` (not a copy)
+- `_metadata` is a mutable `var` read/written from multiple call sites without synchronization
+- `IndexMetadata` uses mutable Java collections that are not thread-safe
+
+**Safe patterns:**
+- One thread per `Index` instance
+- Create separate `Index` instances per thread (they will coordinate via file-based locks)
+- Read-only operations (`locateFiles`, `stats`, `printIndex`) are safe from multiple threads if no mutations occur concurrently
+
+### Lock File Concurrency
+
+File-based locks (`.filelist.lock`, `.update.lock`) coordinate between separate Spark jobs/applications:
+- Uses Hadoop `create(overwrite=false)` for atomic acquisition
+- Stale lock auto-healing has a known TOCTOU window (mitigated by retry depth guard)
+- Lock refresh during long `update` operations prevents false stale detection
+
+### Driver Memory Considerations
+
+Several operations collect data to the driver and may cause OOM on large indexes:
+- `FileList.addFile()` collects all filenames for duplicate checking
+- `BloomFilterOperations.locateFilesWithBloom()` collects bloom filters
+- `IndexQueryOperations.getAutoBloomCandidates()` collects auto-bloom data
+- `locateFilesWithRangeFromDataFrame()` truncates to 10,000 distinct values
+
+These are documented in scaladoc with `@note` or inline comments.
+
 ## Design Benefits
 
 ### 1. **Trait-Based Modularity**

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -96,10 +96,12 @@ The Ariadne Index system provides a modular architecture for managing file-based
 
 **Protected Methods**:
 
-- `readFiles(files: Set[String]): DataFrame` - Reads files into DataFrame
+- `readFiles(files: Set[String]): DataFrame` - Reads files into DataFrame (full pipeline: base read → computed indexes → exploded fields → column selection)
 - `createBaseDataFrame(files: Set[String]): DataFrame` - Creates base DataFrame
 - `applyComputedIndexes(df: DataFrame): DataFrame` - Adds computed columns
 - `applyExplodedFields(df: DataFrame): DataFrame` - Adds exploded field columns
+- `applyColumnSelection(df: DataFrame): DataFrame` - Prunes to user-selected columns if specified via `select()`
+- `addFilenameColumn(df: DataFrame, files: Set[String]): DataFrame` - Adds stable filename column using `input_file_name()`
 
 ### 4. BloomFilterOperations
 
@@ -144,10 +146,19 @@ The Ariadne Index system provides a modular architecture for managing file-based
 
 - `buildRegularIndexes(df: DataFrame): DataFrame` - Builds regular indexes
 - `buildExplodedFieldIndexes(baseData: DataFrame, resultDf: DataFrame): DataFrame` - Builds exploded indexes
+- `buildTemporalIndexes(df: DataFrame): DataFrame` - Builds temporal indexes (struct arrays with value + max_ts per file)
+- `buildRangeIndexes(df: DataFrame): DataFrame` - Builds range indexes (struct with min/max per file)
+- `buildAutoBloomIndexes(df: DataFrame): DataFrame` - Builds auto-bloom filters for columns exceeding `largeIndexLimit`
 - `handleLargeIndexes(df: DataFrame): Unit` - Handles large index storage
 - `appendToStaging(df: DataFrame): Unit` - Appends data to staging Delta table
 - `appendToLargeIndex(df: DataFrame): Unit` - Appends data to large index Delta tables
+- `consolidateStaging(): Unit` - Merges staging Delta table into main index via Delta MERGE
+- `maybeAutoCompact(): Unit` - Runs compaction if `autoCompactThreshold` is set and batch count has been reached
+- `analyzeFiles(files: Set[String]): Seq[FileAnalysis]` - Pre-flight scan for batching decisions
+- `createOptimalBatches(fileAnalyses: Seq[FileAnalysis]): Seq[Set[String]]` - Groups files into optimal batches
+- `getFileSizes(files: Set[String]): Map[String, Long]` - Computes file sizes in bytes from Hadoop FileSystem
 - `storageColumns: Set[String]` - Returns all storage column names
+- `rangeStorageColumns: Set[String]` - Returns range storage column names (prefixed with `range_`)
 - `indexFilePath: Path` - Path to main index Delta table
 - `largeIndexesFilePath: Path` - Path to large indexes storage
 
@@ -170,8 +181,8 @@ The Ariadne Index system provides a modular architecture for managing file-based
 **Protected Methods**:
 
 - `joinDf(df: DataFrame, usingColumns: Seq[String]): DataFrame` - Creates optimized join DataFrame
-- `mapJoinColumnsToStorage(joinColumns: Seq[String]): Map[String, String]` - Maps join to storage columns (including bloom columns with `bloom_` prefix)
-- `applyJoinFilters(...)` - Creates filter conditions (skips bloom columns since filtering is done at file level)
+- `mapJoinColumnsToStorage(joinColumns: Seq[String]): Map[String, String]` - Maps join to storage columns (including bloom columns with `bloom_` prefix, range columns with `range_` prefix, and exploded field columns to their backing array column)
+- `applyTemporalDeduplication(df: DataFrame, joinColumns: Seq[String]): DataFrame` - Keeps only the latest version of each value for temporal index columns used in the current join
 
 ### 7. IndexQueryOperations
 
@@ -188,7 +199,11 @@ The Ariadne Index system provides a modular architecture for managing file-based
 **Key Methods**:
 
 - `locateFiles(indexes: Map[String, Array[Any]]): Set[String]` - Find files matching criteria
+- `locateFilesFromDataFrame(valuesDf: DataFrame, columnMappings: Map[String, String], joinColumns: Seq[String]): Set[String]` - Find files matching DataFrame values
 - `stats(): DataFrame` - Get comprehensive statistics
+
+**Internal/Diagnostic Methods** (`private[ariadne]`):
+
 - `printIndex(truncate: Boolean = false): Unit` - Print index contents
 - `printMetadata: Unit` - Print metadata information
 
@@ -197,7 +212,11 @@ The Ariadne Index system provides a modular architecture for managing file-based
 - `index: Option[DataFrame]` - Access to main index DataFrame
 - `largeIndexColumns: Set[String]` - Returns column names with large index Delta tables
 - `loadLargeIndex(colName: String): Option[DataFrame]` - Loads a large index Delta table in row form
+- `loadColumnIndex(indexDf: DataFrame, colName: String, bloomCandidateFiles: Option[Set[String]]): DataFrame` - Returns unified (filename, value) DataFrame for a regular index column
+- `loadTemporalColumnIndex(indexDf: DataFrame, colName: String): DataFrame` - Returns unified (filename, _value, _max_ts) DataFrame for a temporal index column
 - `maybeRepartition(df: DataFrame): DataFrame` - Conditionally repartitions a DataFrame based on `indexRepartitionCount` configuration
+- `getAutoBloomCandidates(column: String, values: Array[Any], indexDf: DataFrame): Option[Set[String]]` - Pre-filters files using auto-bloom before querying large index tables
+- `collectFilenamesViaStaging(resultDF: DataFrame): Set[String]` - Collects filenames via temporary CSV storage to reduce executor memory pressure
 
 ### 8. IndexLock (Concurrency Control)
 
@@ -231,6 +250,9 @@ The Ariadne Index system provides a modular architecture for managing file-based
 
 - `addFile()` acquires/releases `.filelist.lock`
 - `update()` acquires/releases `.update.lock` with periodic refresh every `lockRefreshInterval` batches
+- `deleteFiles()` acquires/releases `.update.lock`
+- `compact()` acquires/releases `.update.lock`
+- `vacuum()` acquires/releases `.update.lock`
 
 ### 9. Index Class (Main API)
 
@@ -305,6 +327,11 @@ case class Index private (
 - `exploded_field_indexes: util.List[ExplodedFieldMapping]` - Exploded field configurations
 - `read_options: util.Map[String, String]` - Format-specific read options
 - `bloom_indexes: util.List[BloomIndexConfig]` - Bloom filter index configurations
+- `temporal_indexes: util.List[TemporalIndexConfig]` - Temporal index configurations
+- `range_indexes: util.List[RangeIndexConfig]` - Range index configurations
+- `auto_bloom_indexes: util.List[String]` - Columns with automatic bloom filters (for large indexes)
+- `total_indexed_file_size: java.lang.Long` - Cumulative size in bytes of all indexed files, or -1 if unknown
+- `batches_since_compact: java.lang.Integer` - Number of update batches since last compaction (persisted across Spark jobs)
 
 #### BloomIndexConfig
 
@@ -329,6 +356,64 @@ case class Index private (
 
 **Purpose**: Tracks which files have been added to an index for processing.
 
+**Storage**: Persisted as a Delta Lake table with two columns: `filename` (StringType) and `addedAt` (TimestampType).
+
+**Key Methods**:
+
+- `files: DataFrame` - Returns the DataFrame of tracked files (lazily loaded and cached)
+- `addFile(fileNames: String*): Unit` - Registers new files (skips duplicates)
+- `removeFile(fileNames: String*): Unit` - Removes files via Delta merge-delete
+- `hasFile(fileName: String): Boolean` - Checks if a file is tracked
+
+**Factory Methods** (companion object):
+
+- `FileList(name: String): FileList` - Creates an instance backed by a Delta table
+- `FileList.exists(name: String): Boolean` - Checks if a file list exists on storage
+- `FileList.remove(name: String): Boolean` - Removes a file list Delta table
+
+#### TemporalIndexConfig
+
+**Purpose**: Configuration for temporal indexes that track entity versions across files.
+
+**Fields**:
+
+- `column: String` - The value column to index and deduplicate on (e.g., "user_id")
+- `timestamp_column: String` - The timestamp column used to determine recency (e.g., "updated_at")
+
+#### RangeIndexConfig
+
+**Purpose**: Configuration for range indexes that store min/max values per file for a column.
+
+**Fields**:
+
+- `column: String` - The column name to create a range index for
+
+### 12. IndexCatalog (Object)
+
+**Purpose**: Provides a global view of all Ariadne indexes under the configured storage path. Stateless — every call scans the filesystem.
+
+**Key Methods**:
+
+- `list(): Seq[String]` - Lists all index names (alphabetically sorted)
+- `exists(name: String): Boolean` - Checks if an index exists
+- `describe(name: String): IndexSummary` - Returns a summary of a single index
+- `describeAll(): Seq[IndexSummary]` - Returns summaries for all indexes
+- `get(name: String): Index` - Fetches an Index instance by name
+- `toDF(): DataFrame` - Returns all indexes as a DataFrame (one row per index)
+- `remove(name: String): Boolean` - Removes an index and its associated data
+- `findIndexes(fileName: String): Seq[String]` - Finds all indexes that track a given file
+
+**IndexSummary** case class fields: `name`, `format`, `columns`, `regularIndexes`, `bloomIndexes`, `computedIndexes`, `temporalIndexes`, `rangeIndexes`, `explodedFieldIndexes`, `fileCount`, `totalIndexedFileSize`
+
+### 13. SchemaHelper (Object)
+
+**Purpose**: Provides utility functions for schema validation and field lookup.
+
+**Key Methods**:
+
+- `fieldExists(schema: StructType, fieldName: String): Boolean` - Checks if a field exists in the schema (supports nested fields)
+- `fieldType(schema: StructType, fieldName: String): Option[DataType]` - Returns the data type of a field
+
 ## Supported File Formats
 
 Ariadne supports three data formats with Parquet as the default:
@@ -344,11 +429,13 @@ Additional format-specific options can be provided via `readOptions` when creati
 ### Data Flow for `deleteFiles`
 
 1. Acquire update lock
-2. Delete matching rows from main index Delta table (merge-delete on filename)
-3. Delete matching rows from each large index Delta table
-4. Delete matching rows from staging table (if it exists from an interrupted update)
-5. Remove files from the FileList
-6. Release update lock
+2. Read file sizes from the main index table (to update the total)
+3. Delete matching rows from main index Delta table (merge-delete on filename)
+4. Delete matching rows from each large index Delta table
+5. Delete matching rows from staging table (if it exists from an interrupted update)
+6. Update `total_indexed_file_size` in metadata (subtract deleted file sizes)
+7. Remove files from the FileList
+8. Release update lock
 
 ### Data Flow for `compact` and `vacuum`
 
@@ -532,7 +619,7 @@ The system supports automatic migration between metadata versions:
 - v3 → v4: Adds read_options support
 - v4 → v5: Adds bloom_indexes support
 - v5 → v6: Adds temporal_indexes support
-- v6 → v7: Adds range_indexes support (RangeIndexConfig with column name and data type)
+- v6 → v7: Adds range_indexes support (RangeIndexConfig with column name)
 - v7 → v8: Adds auto_bloom_indexes support (automatic bloom filters for large index columns)
 - v8 → v9: Adds total_indexed_file_size field (per-file size tracking and pruning metrics)
 - v9 → v10: Adds batches_since_compact field (cross-job auto-compaction counter)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -357,7 +357,7 @@ Additional format-specific options can be provided via `readOptions` when creati
 
 `vacuum(retentionHours)` runs Delta `VACUUM` on the same tables with configurable retention (default: 168 hours).
 
-**Auto-compaction**: When `spark.ariadne.autoCompactThreshold` is set, compaction runs automatically after every N staging consolidation cycles during `update`.
+**Auto-compaction**: When `spark.ariadne.autoCompactThreshold` is set, compaction runs automatically after every N update batches. The batch counter (`batches_since_compact`) is persisted in index metadata so it accumulates correctly across separate Spark jobs. Both `compact()` and auto-compact reset the counter to zero. If auto-compaction is not configured and the counter reaches 50, a warning is logged.
 
 ## Key Features
 
@@ -534,6 +534,7 @@ The system supports automatic migration between metadata versions:
 - v6 → v7: Adds range_indexes support (RangeIndexConfig with column name and data type)
 - v7 → v8: Adds auto_bloom_indexes support (automatic bloom filters for large index columns)
 - v8 → v9: Adds total_indexed_file_size field (per-file size tracking and pruning metrics)
+- v9 → v10: Adds batches_since_compact field (cross-job auto-compaction counter)
 
 ### Caching Strategy
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -145,7 +145,8 @@ The Ariadne Index system provides a modular architecture for managing file-based
 - `buildRegularIndexes(df: DataFrame): DataFrame` - Builds regular indexes
 - `buildExplodedFieldIndexes(baseData: DataFrame, resultDf: DataFrame): DataFrame` - Builds exploded indexes
 - `handleLargeIndexes(df: DataFrame): Unit` - Handles large index storage
-- `mergeToDelta(df: DataFrame): Unit` - Merges data to Delta table
+- `appendToStaging(df: DataFrame): Unit` - Appends data to staging Delta table
+- `appendToLargeIndex(df: DataFrame): Unit` - Appends data to large index Delta tables
 - `storageColumns: Set[String]` - Returns all storage column names
 - `indexFilePath: Path` - Path to main index Delta table
 - `largeIndexesFilePath: Path` - Path to large indexes storage

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -330,6 +330,27 @@ Ariadne supports three data formats with Parquet as the default:
 
 Additional format-specific options can be provided via `readOptions` when creating an index.
 
+## Data Flows
+
+### Data Flow for `deleteFiles`
+
+1. Acquire update lock
+2. Delete matching rows from main index Delta table (merge-delete on filename)
+3. Delete matching rows from each large index Delta table
+4. Delete matching rows from staging table (if it exists from an interrupted update)
+5. Remove files from the FileList
+6. Release update lock
+
+### Data Flow for `compact` and `vacuum`
+
+`compact()` runs Delta `OPTIMIZE` (executeCompaction) on:
+1. Main index table (`index/`)
+2. All large index tables (`large_indexes/{column}/`)
+
+`vacuum(retentionHours)` runs Delta `VACUUM` on the same tables with configurable retention (default: 168 hours).
+
+**Auto-compaction**: When `spark.ariadne.autoCompactThreshold` is set, compaction runs automatically after every N staging consolidation cycles during `update`.
+
 ## Key Features
 
 ### Large Index Handling
@@ -431,6 +452,68 @@ Bloom filters provide space-efficient probabilistic indexing for high-cardinalit
 - A column can have either a regular index OR a bloom index, not both
 - This is enforced at the API level with clear error messages
 
+### Range Indexes
+
+Range indexes store per-file min/max values for columns with natural ordering (dates, timestamps, numeric IDs). At query time, files are pruned when no query value falls within the file's [min, max] range.
+
+**Storage:**
+
+- Range values are stored as struct columns in the main index Delta table with `range_` prefix
+- Example: A range index on `event_date` creates a `range_event_date` column containing `struct(min: DateType, max: DateType)`
+- Range columns are NOT included in `storageColumns` (which tracks array-type columns) — they have their own `rangeStorageColumns` set
+
+**Query Behavior:**
+
+- For Map-based queries (`locateFiles`): Uses Spark `lit()` expressions for type-safe comparisons
+- For DataFrame-based queries (`locateFilesFromDataFrame`): Computes query min/max and uses range overlap check
+- Results are intersected with other index type results (AND semantics)
+
+**Configuration:**
+
+- Data type is inferred from the index schema
+- Range indexes work alongside regular, bloom, and temporal indexes on different columns
+
+**Mutual Exclusivity:**
+
+- A column can have a range index OR any other index type, not both
+
+### Automatic Bloom Filters for Large Indexes
+
+When a column exceeds `largeIndexLimit` distinct values per file during `update`, it gets stored in a separate large index table (`large_indexes/{column}/`). Querying these large tables is expensive as they contain exploded (filename, value) rows.
+
+Auto-bloom automatically creates a bloom filter for such columns, stored in the main index table. At query time, the bloom filter pre-filters candidate files before querying the large index table, reducing I/O significantly.
+
+**Storage:**
+
+- Auto-bloom filters are stored as binary columns in the main index Delta table with `auto_bloom_` prefix
+- Example: Column `user_id` exceeding the limit creates `auto_bloom_user_id` containing serialized bloom filter bytes
+- Auto-bloom columns are tracked in `autoBloomStorageColumns`, separate from `storageColumns`
+
+**Build Flow:**
+
+1. During `buildAutoBloomIndexes`, each eligible column's distinct count is checked against `largeIndexLimit`
+2. Columns exceeding the limit get a bloom filter built with the configured FPR (`spark.ariadne.autoBloomFpr`, default 0.01)
+3. The bloom filter is added as a binary column to the combined DataFrame before staging
+4. Metadata is updated after data is safely staged
+
+**Query Flow (getAutoBloomCandidates):**
+
+1. Load bloom filter bytes from the main index for the target column
+2. Test each query value against each file's bloom filter
+3. Return only files where the bloom filter reports a possible match
+4. These candidates are then verified against the actual large index table
+
+**Backward Compatibility:**
+
+- Metadata migration v7→v8 adds the `auto_bloom_indexes` field
+- `filesNeedingColumnUpdate` includes `autoBloomStorageColumns`, so existing files get auto-bloom on the next `update`
+- Query methods check for column existence before attempting bloom filter lookups
+
+**Configuration:**
+
+- `spark.ariadne.autoBloomFpr`: False positive rate for auto-bloom filters (default: 0.01 = 1%)
+- Higher FPR = smaller bloom filters but more false positives (more large index lookups)
+
 ### Metadata Versioning
 
 The system supports automatic migration between metadata versions:
@@ -439,6 +522,9 @@ The system supports automatic migration between metadata versions:
 - v2 → v3: Adds exploded_field_indexes support
 - v3 → v4: Adds read_options support
 - v4 → v5: Adds bloom_indexes support
+- v5 → v6: Adds temporal_indexes support
+- v6 → v7: Adds range_indexes support (RangeIndexConfig with column name and data type)
+- v7 → v8: Adds auto_bloom_indexes support (automatic bloom filters for large index columns)
 
 ### Caching Strategy
 
@@ -488,6 +574,12 @@ Each trait can be tested independently with focused test suites:
 - `IndexPathUtilsTests` - Tests utility functions
 - `BloomFilterOperationsTests` - Tests bloom filter functionality
 - `IndexLockTests` - Tests locking, auto-healing, and contention
+- `DeleteFilesTests` - Tests file deletion from index
+- `CompactionTests` - Tests compact, vacuum, and auto-compaction
+- `MultiColumnIntersectTests` - Tests AND semantics across index types
+- `RangeIndexTests` - Tests range index build and query
+- `AutoBloomLargeIndexTests` - Tests automatic bloom filter generation
+- `MixedIndexIntersectionTests` - Tests cross-type intersection edge cases
 
 ### 3. **Performance Optimization**
 
@@ -497,6 +589,10 @@ Each trait can be tested independently with focused test suites:
 - Exploded field indexing enables efficient nested data joins
 - Bloom filter indexes provide space-efficient probabilistic matching for high-cardinality columns
 - Optional index repartitioning prevents FetchFailedExceptions on large index joins
+- Range indexes enable min/max file pruning for ordered columns
+- Automatic bloom filters reduce large index table I/O at query time
+- Multi-column queries use AND semantics (intersection) to minimize files loaded
+- Index compaction (OPTIMIZE) consolidates small Delta files for better read performance
 
 ### 4. **Extensibility**
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -252,8 +252,14 @@ case class Index private (
 - `addBloomIndex(column: String, fpr: Double = 0.01): Unit` - Add bloom filter index (mutually exclusive with regular index)
 - `addComputedIndex(name: String, sql_expression: String): Unit` - Add computed index
 - `addExplodedFieldIndex(arrayColumn: String, fieldPath: String, asColumn: String): Unit` - Add exploded field index
-- `indexes: Set[String]` - Get all available index column names (includes both regular and bloom indexes)
+- `addTemporalIndex(column: String, timestampColumn: String): Unit` - Add temporal index for version-aware deduplication
+- `addRangeIndex(column: String): Unit` - Add range index for min/max file pruning
+- `indexes: Set[String]` - Get all available index column names (includes regular, computed, exploded, bloom, temporal, and range indexes)
+- `select(columns: String*): Index` - Select specific columns for optimized reading (returns Index for chaining)
 - `update: Unit` - Update index with new files
+- `deleteFiles(filenames: String*): Unit` - Delete files from the index, large index tables, staging, and file list
+- `compact(): Unit` - Run Delta OPTIMIZE on all index Delta tables
+- `vacuum(retentionHours: Int = 168): Unit` - Run Delta VACUUM on all index Delta tables
 - `storagePath: Path` - Storage location for this index
 
 **Factory Methods** (in companion object):
@@ -261,6 +267,8 @@ case class Index private (
 - `Index(name: String, schema: StructType, format: String): Index`
 - `Index(name: String, schema: StructType, format: String, allowSchemaMismatch: Boolean): Index`
 - `Index(name: String, schema: StructType, format: String, readOptions: Map[String, String]): Index`
+- `Index(name: String, schema: StructType, format: String, allowSchemaMismatch: Boolean, readOptions: Map[String, String]): Index`
+- `Index(name: String): Index` - Reconnect to an existing index (metadata must exist)
 
 ### 10. IndexPathUtils (Object)
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,9 @@
 
     <properties>
         <scala.version>2.12.17</scala.version>
+        <scoverage.plugin.version>2.0.6</scoverage.plugin.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <profiles>
@@ -133,6 +136,18 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.scoverage</groupId>
+                <artifactId>scoverage-maven-plugin</artifactId>
+                <version>${scoverage.plugin.version}</version>
+                <configuration>
+                    <scalaVersion>${scala.version}</scalaVersion>
+                    <minimumCoverage>80</minimumCoverage>
+                    <failOnMinimumCoverage>true</failOnMinimumCoverage>
+                    <highlighting>true</highlighting>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>dev.cjfravel</groupId>
     <artifactId>ariadne-spark${spark.suffix}_2.12</artifactId>
-    <version>0.0.1-alpha-44</version>
+    <version>0.0.1-alpha-45</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/scala/dev/cjfravel/ariadne/AriadneContext.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/AriadneContext.scala
@@ -33,7 +33,13 @@ trait AriadneContextUser {
     * from spark.ariadne.largeIndexLimit configuration (default: 500000).
     */
   lazy val largeIndexLimit: Long = {
-    val limit = spark.conf.get("spark.ariadne.largeIndexLimit", "500000").toLong
+    val limit = try {
+      spark.conf.get("spark.ariadne.largeIndexLimit", "500000").toLong
+    } catch {
+      case _: NumberFormatException =>
+        logger.warn("Invalid spark.ariadne.largeIndexLimit value, using default 500000")
+        500000L
+    }
     logger.warn(s"largeIndexLimit initialized: $limit")
     limit
   }
@@ -45,8 +51,13 @@ trait AriadneContextUser {
     * 50).
     */
   lazy val stagingConsolidationThreshold: Int = {
-    val threshold =
+    val threshold = try {
       spark.conf.get("spark.ariadne.stagingConsolidationThreshold", "50").toInt
+    } catch {
+      case _: NumberFormatException =>
+        logger.warn("Invalid spark.ariadne.stagingConsolidationThreshold value, using default 50")
+        50
+    }
     logger.warn(s"stagingConsolidationThreshold initialized: $threshold")
     threshold
   }
@@ -58,8 +69,15 @@ trait AriadneContextUser {
     * spark.ariadne.indexRepartitionCount configuration (default: not set).
     */
   lazy val indexRepartitionCount: Option[Int] = {
-    val count =
-      spark.conf.getOption("spark.ariadne.indexRepartitionCount").map(_.toInt)
+    val count = spark.conf.getOption("spark.ariadne.indexRepartitionCount").flatMap { v =>
+      try {
+        Some(v.toInt)
+      } catch {
+        case _: NumberFormatException =>
+          logger.warn("Invalid spark.ariadne.indexRepartitionCount value, ignoring")
+          None
+      }
+    }
     count.foreach(c => logger.warn(s"indexRepartitionCount initialized: $c"))
     count
   }
@@ -69,21 +87,31 @@ trait AriadneContextUser {
     * spark.ariadne.debug configuration (default: false).
     */
   lazy val debugEnabled: Boolean = {
-    val enabled =
+    val enabled = try {
       spark.conf.get("spark.ariadne.debug", "false").toBoolean
+    } catch {
+      case _: IllegalArgumentException =>
+        logger.warn("Invalid spark.ariadne.debug value, using default false")
+        false
+    }
     if (enabled) logger.warn("Debug mode enabled")
     enabled
   }
 
-  /** When true (default), applies indexRepartitionCount repartitioning to the
+  /** When true, applies indexRepartitionCount repartitioning to the
     * data files read during joinDf. When false, data files keep their natural
     * parquet partitioning. Disable when column selection significantly reduces
     * data volume, making the repartition shuffle more expensive than useful.
-    * Reads from spark.ariadne.repartitionDataFiles configuration (default: true).
+    * Reads from spark.ariadne.repartitionDataFiles configuration (default: false).
     */
   lazy val repartitionDataFiles: Boolean = {
-    val enabled =
+    val enabled = try {
       spark.conf.get("spark.ariadne.repartitionDataFiles", "false").toBoolean
+    } catch {
+      case _: IllegalArgumentException =>
+        logger.warn("Invalid spark.ariadne.repartitionDataFiles value, using default false")
+        false
+    }
     if (enabled) logger.warn("repartitionDataFiles enabled — data files will be repartitioned")
     enabled
   }
@@ -99,18 +127,34 @@ trait AriadneContextUser {
     filesystem
   }
 
-  /** Checks if a path exists on the filesystem */
+  /** Checks if a path exists on the filesystem.
+    *
+    * @param path The Hadoop Path to check
+    * @return true if the path exists
+    */
   def exists(path: Path): Boolean = fs.exists(path)
 
-  /** Deletes a path recursively from the filesystem */
+  /** Deletes a path recursively from the filesystem.
+    *
+    * @param path The Hadoop Path to delete
+    * @return true if the path was successfully deleted
+    */
   def delete(path: Path): Boolean = fs.delete(path, true)
 
-  /** Opens an input stream to read from a path */
+  /** Opens an input stream to read from a path on the filesystem.
+    *
+    * @param path The Hadoop Path to open for reading
+    * @return An FSDataInputStream for reading the file contents
+    */
   def open(path: Path): FSDataInputStream = fs.open(path)
 
-  /** Returns a DeltaTable if the path exists and is a valid Delta table. If the
-    * path exists but is not a valid Delta table, it will be deleted and None
-    * returned. If the path doesn't exist, None is returned.
+  /** Returns a DeltaTable if the path exists and is a valid Delta table.
+    *
+    * If the path exists but is not a valid Delta table, it will be deleted
+    * and None returned. If the path doesn't exist, None is returned.
+    *
+    * @param path The Hadoop Path to check for a Delta table
+    * @return Some(DeltaTable) if a valid Delta table exists, None otherwise
     */
   def delta(path: Path): Option[DeltaTable] = {
     if (exists(path)) {
@@ -130,7 +174,13 @@ trait AriadneContextUser {
     * Reads from spark.ariadne.lockTimeout configuration (default: 1800).
     */
   lazy val lockTimeout: Long = {
-    val value = spark.conf.get("spark.ariadne.lockTimeout", "1800").toLong
+    val value = try {
+      spark.conf.get("spark.ariadne.lockTimeout", "1800").toLong
+    } catch {
+      case _: NumberFormatException =>
+        logger.warn("Invalid spark.ariadne.lockTimeout value, using default 1800")
+        1800L
+    }
     logger.warn(s"lockTimeout initialized: $value")
     value
   }
@@ -139,7 +189,13 @@ trait AriadneContextUser {
     * Reads from spark.ariadne.lockRetryInterval configuration (default: 60).
     */
   lazy val lockRetryInterval: Long = {
-    val value = spark.conf.get("spark.ariadne.lockRetryInterval", "60").toLong
+    val value = try {
+      spark.conf.get("spark.ariadne.lockRetryInterval", "60").toLong
+    } catch {
+      case _: NumberFormatException =>
+        logger.warn("Invalid spark.ariadne.lockRetryInterval value, using default 60")
+        60L
+    }
     logger.warn(s"lockRetryInterval initialized: $value")
     value
   }
@@ -148,7 +204,13 @@ trait AriadneContextUser {
     * Reads from spark.ariadne.lockMaxWait configuration (default: 3600).
     */
   lazy val lockMaxWait: Long = {
-    val value = spark.conf.get("spark.ariadne.lockMaxWait", "3600").toLong
+    val value = try {
+      spark.conf.get("spark.ariadne.lockMaxWait", "3600").toLong
+    } catch {
+      case _: NumberFormatException =>
+        logger.warn("Invalid spark.ariadne.lockMaxWait value, using default 3600")
+        3600L
+    }
     logger.warn(s"lockMaxWait initialized: $value")
     value
   }
@@ -157,7 +219,13 @@ trait AriadneContextUser {
     * Reads from spark.ariadne.lockRefreshInterval configuration (default: 1).
     */
   lazy val lockRefreshInterval: Int = {
-    val value = spark.conf.get("spark.ariadne.lockRefreshInterval", "1").toInt
+    val value = try {
+      spark.conf.get("spark.ariadne.lockRefreshInterval", "1").toInt
+    } catch {
+      case _: NumberFormatException =>
+        logger.warn("Invalid spark.ariadne.lockRefreshInterval value, using default 1")
+        1
+    }
     logger.warn(s"lockRefreshInterval initialized: $value")
     value
   }
@@ -168,7 +236,15 @@ trait AriadneContextUser {
     * (default: not set).
     */
   lazy val autoCompactThreshold: Option[Int] = {
-    val value = spark.conf.getOption("spark.ariadne.autoCompactThreshold").map(_.toInt)
+    val value = spark.conf.getOption("spark.ariadne.autoCompactThreshold").flatMap { v =>
+      try {
+        Some(v.toInt)
+      } catch {
+        case _: NumberFormatException =>
+          logger.warn("Invalid spark.ariadne.autoCompactThreshold value, ignoring")
+          None
+      }
+    }
     value.foreach(v => logger.warn(s"autoCompactThreshold initialized: $v"))
     value
   }
@@ -179,7 +255,13 @@ trait AriadneContextUser {
     * Reads from spark.ariadne.autoBloomFpr configuration (default: 0.01).
     */
   lazy val autoBloomFpr: Double = {
-    val value = spark.conf.get("spark.ariadne.autoBloomFpr", "0.01").toDouble
+    val value = try {
+      spark.conf.get("spark.ariadne.autoBloomFpr", "0.01").toDouble
+    } catch {
+      case _: NumberFormatException =>
+        logger.warn("Invalid spark.ariadne.autoBloomFpr value, using default 0.01")
+        0.01
+    }
     logger.warn(s"autoBloomFpr initialized: $value")
     value
   }

--- a/src/main/scala/dev/cjfravel/ariadne/AriadneContext.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/AriadneContext.scala
@@ -20,9 +20,12 @@ trait AriadneContextUser {
     * spark.ariadne.storagePath configuration.
     */
   lazy val storagePath: Path = {
-    val path = new Path(spark.conf.get("spark.ariadne.storagePath"))
+    val pathStr = spark.conf.getOption("spark.ariadne.storagePath")
+      .getOrElse(throw new IllegalArgumentException(
+        "Spark configuration 'spark.ariadne.storagePath' must be set. " +
+        "Set it via spark.conf.set(\"spark.ariadne.storagePath\", \"/path/to/storage\")"))
+    val path = new Path(pathStr)
     logger.warn(s"storagePath initialized: $path")
-    println(s"Ariadne storage path: $path")
     path
   }
 
@@ -87,11 +90,12 @@ trait AriadneContextUser {
 
   /** Hadoop FileSystem instance associated with the storage path. */
   lazy val fs: FileSystem = {
+    val fsUri = Option(storagePath.getParent).getOrElse(storagePath).toUri
     val filesystem = FileSystem.get(
-      storagePath.getParent.toUri,
+      fsUri,
       spark.sparkContext.hadoopConfiguration
     )
-    logger.warn(s"FileSystem initialized for: ${storagePath.getParent}")
+    logger.warn(s"FileSystem initialized for: $storagePath")
     filesystem
   }
 
@@ -113,6 +117,7 @@ trait AriadneContextUser {
       if (DeltaTable.isDeltaTable(spark, path.toString)) {
         Some(DeltaTable.forPath(spark, path.toString))
       } else {
+        logger.warn(s"Path $path exists but is not a Delta table — deleting to allow re-creation")
         delete(path)
         None
       }

--- a/src/main/scala/dev/cjfravel/ariadne/AriadneContext.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/AriadneContext.scala
@@ -6,18 +6,46 @@ import org.apache.logging.log4j.{Logger, LogManager}
 import io.delta.tables.DeltaTable
 import org.apache.hadoop.fs.FSDataInputStream
 
-/** Provides context and helper methods for Ariadne operations using an implicit
-  * SparkSession. This trait should be mixed in by classes that need access to
-  * Ariadne resources.
+/** Provides Spark session context, HDFS access, and configuration for Ariadne operations.
+  *
+  * Mix this trait into any class that needs access to Ariadne infrastructure.
+  * All configuration is read lazily from `SparkConf` properties prefixed with
+  * `spark.ariadne.*` and logged at `warn` level on first access.
+  *
+  * '''Spark configuration keys:'''
+  * {{{
+  * spark.ariadne.storagePath                 (required) Base HDFS/filesystem path for index storage
+  * spark.ariadne.largeIndexLimit             (default: 500000) Max values before a column is "large"
+  * spark.ariadne.stagingConsolidationThreshold (default: 50) Batches between staging merges
+  * spark.ariadne.indexRepartitionCount       (optional) Repartition count for index DataFrames
+  * spark.ariadne.debug                       (default: false) Enable verbose join diagnostics
+  * spark.ariadne.repartitionDataFiles        (default: false) Repartition data files during joins
+  * spark.ariadne.lockTimeout                 (default: 1800) Seconds before a lock is considered stale
+  * spark.ariadne.lockRetryInterval           (default: 60) Base seconds between lock retries
+  * spark.ariadne.lockMaxWait                 (default: 3600) Max seconds to wait for a lock
+  * spark.ariadne.lockRefreshInterval         (default: 1) Batches between lock refreshes
+  * spark.ariadne.autoCompactThreshold        (optional) Delta log file count triggering auto-compact
+  * spark.ariadne.autoBloomFpr                (default: 0.01) FPR for auto-bloom filters on large columns
+  * }}}
+  *
+  * '''Thread safety:''' Lazy vals are initialized at most once per instance and
+  * are safe for concurrent reads after initialization. However, the underlying
+  * `SparkSession` and `FileSystem` are shared resources governed by Spark's own
+  * concurrency model.
   */
 trait AriadneContextUser {
+  /** Log4j logger shared by all Ariadne components. Uses the "ariadne" logger name. */
   val logger: Logger = LogManager.getLogger("ariadne")
 
-  /** Implicit SparkSession that must be provided by the mixing class */
+  /** Implicit SparkSession that must be provided by the mixing class. */
   implicit def spark: SparkSession
 
-  /** Path on FileSystem where Ariadne should create files. Reads from
-    * spark.ariadne.storagePath configuration.
+  /** Base path on the Hadoop-compatible filesystem where all Ariadne index data
+    * is stored. Each index creates a subdirectory under this path.
+    *
+    * Reads from `spark.ariadne.storagePath` (required — no default).
+    *
+    * @throws IllegalArgumentException if the configuration key is not set
     */
   lazy val storagePath: Path = {
     val pathStr = spark.conf.getOption("spark.ariadne.storagePath")
@@ -29,8 +57,12 @@ trait AriadneContextUser {
     path
   }
 
-  /** Maximum number of records before an index is considered "large". Reads
-    * from spark.ariadne.largeIndexLimit configuration (default: 500000).
+  /** Maximum number of distinct values per file before an index column is promoted
+    * to a "large index" (stored in a separate exploded Delta table). Reads
+    * from `spark.ariadne.largeIndexLimit` (default: 500000).
+    *
+    * If the configured value is not a valid positive number, a warning is logged
+    * and the default of 500,000 is used.
     */
   lazy val largeIndexLimit: Long = {
     val limit = try {
@@ -40,8 +72,14 @@ trait AriadneContextUser {
         logger.warn("Invalid spark.ariadne.largeIndexLimit value, using default 500000")
         500000L
     }
-    logger.warn(s"largeIndexLimit initialized: $limit")
-    limit
+    val validated = if (limit <= 0) {
+      logger.warn(s"spark.ariadne.largeIndexLimit must be positive (got $limit), using default 500000")
+      500000L
+    } else {
+      limit
+    }
+    logger.warn(s"largeIndexLimit initialized: $validated")
+    validated
   }
 
   /** Number of batches to process before consolidating staged data into the
@@ -116,7 +154,10 @@ trait AriadneContextUser {
     enabled
   }
 
-  /** Hadoop FileSystem instance associated with the storage path. */
+  /** Hadoop `FileSystem` instance resolved from the [[storagePath]] URI and
+    * the Spark Hadoop configuration. Used for all filesystem operations
+    * (existence checks, reads, deletes, lock files).
+    */
   lazy val fs: FileSystem = {
     val fsUri = Option(storagePath.getParent).getOrElse(storagePath).toUri
     val filesystem = FileSystem.get(
@@ -148,13 +189,14 @@ trait AriadneContextUser {
     */
   def open(path: Path): FSDataInputStream = fs.open(path)
 
-  /** Returns a DeltaTable if the path exists and is a valid Delta table.
+  /** Returns a [[io.delta.tables.DeltaTable]] if the path exists and contains valid Delta metadata.
     *
-    * If the path exists but is not a valid Delta table, it will be deleted
-    * and None returned. If the path doesn't exist, None is returned.
+    * If the path exists but is ''not'' a valid Delta table (e.g., leftover partial
+    * write), the directory is deleted and `None` is returned so it can be
+    * recreated cleanly on the next write.
     *
     * @param path The Hadoop Path to check for a Delta table
-    * @return Some(DeltaTable) if a valid Delta table exists, None otherwise
+    * @return `Some(DeltaTable)` if a valid Delta table exists, `None` otherwise
     */
   def delta(path: Path): Option[DeltaTable] = {
     if (exists(path)) {
@@ -170,8 +212,9 @@ trait AriadneContextUser {
     }
   }
 
-  /** Time in seconds after lastRefreshedAt before a lock is considered stale and eligible for auto-heal.
-    * Reads from spark.ariadne.lockTimeout configuration (default: 1800).
+  /** Seconds since `lastRefreshedAt` before a lock is considered stale and
+    * eligible for auto-heal (forcible acquisition by another process).
+    * Reads from `spark.ariadne.lockTimeout` (default: 1800).
     */
   lazy val lockTimeout: Long = {
     val value = try {

--- a/src/main/scala/dev/cjfravel/ariadne/AriadneContext.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/AriadneContext.scala
@@ -156,4 +156,26 @@ trait AriadneContextUser {
     logger.warn(s"lockRefreshInterval initialized: $value")
     value
   }
+
+  /** Optional threshold for auto-compaction. When set, the main index Delta table
+    * is compacted after an update if the number of Delta log JSON files meets or
+    * exceeds this value. Reads from spark.ariadne.autoCompactThreshold configuration
+    * (default: not set).
+    */
+  lazy val autoCompactThreshold: Option[Int] = {
+    val value = spark.conf.getOption("spark.ariadne.autoCompactThreshold").map(_.toInt)
+    value.foreach(v => logger.warn(s"autoCompactThreshold initialized: $v"))
+    value
+  }
+
+  /** False positive rate for auto-bloom filters on large index columns.
+    * When a column exceeds largeIndexLimit, an auto-bloom filter is built
+    * with this FPR to enable file pruning at query time.
+    * Reads from spark.ariadne.autoBloomFpr configuration (default: 0.01).
+    */
+  lazy val autoBloomFpr: Double = {
+    val value = spark.conf.get("spark.ariadne.autoBloomFpr", "0.01").toDouble
+    logger.warn(s"autoBloomFpr initialized: $value")
+    value
+  }
 }

--- a/src/main/scala/dev/cjfravel/ariadne/AriadneContext.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/AriadneContext.scala
@@ -68,8 +68,8 @@ trait AriadneContextUser {
     val limit = try {
       spark.conf.get("spark.ariadne.largeIndexLimit", "500000").toLong
     } catch {
-      case _: NumberFormatException =>
-        logger.warn("Invalid spark.ariadne.largeIndexLimit value, using default 500000")
+      case e: NumberFormatException =>
+        logger.warn(s"Invalid spark.ariadne.largeIndexLimit value, using default 500000: ${e.getMessage}")
         500000L
     }
     val validated = if (limit <= 0) {
@@ -92,8 +92,8 @@ trait AriadneContextUser {
     val threshold = try {
       spark.conf.get("spark.ariadne.stagingConsolidationThreshold", "50").toInt
     } catch {
-      case _: NumberFormatException =>
-        logger.warn("Invalid spark.ariadne.stagingConsolidationThreshold value, using default 50")
+      case e: NumberFormatException =>
+        logger.warn(s"Invalid spark.ariadne.stagingConsolidationThreshold value, using default 50: ${e.getMessage}")
         50
     }
     logger.warn(s"stagingConsolidationThreshold initialized: $threshold")
@@ -111,8 +111,8 @@ trait AriadneContextUser {
       try {
         Some(v.toInt)
       } catch {
-        case _: NumberFormatException =>
-          logger.warn("Invalid spark.ariadne.indexRepartitionCount value, ignoring")
+        case e: NumberFormatException =>
+          logger.warn(s"Invalid spark.ariadne.indexRepartitionCount value, ignoring: ${e.getMessage}")
           None
       }
     }
@@ -128,8 +128,8 @@ trait AriadneContextUser {
     val enabled = try {
       spark.conf.get("spark.ariadne.debug", "false").toBoolean
     } catch {
-      case _: IllegalArgumentException =>
-        logger.warn("Invalid spark.ariadne.debug value, using default false")
+      case e: IllegalArgumentException =>
+        logger.warn(s"Invalid spark.ariadne.debug value, using default false: ${e.getMessage}")
         false
     }
     if (enabled) logger.warn("Debug mode enabled")
@@ -146,8 +146,8 @@ trait AriadneContextUser {
     val enabled = try {
       spark.conf.get("spark.ariadne.repartitionDataFiles", "false").toBoolean
     } catch {
-      case _: IllegalArgumentException =>
-        logger.warn("Invalid spark.ariadne.repartitionDataFiles value, using default false")
+      case e: IllegalArgumentException =>
+        logger.warn(s"Invalid spark.ariadne.repartitionDataFiles value, using default false: ${e.getMessage}")
         false
     }
     if (enabled) logger.warn("repartitionDataFiles enabled — data files will be repartitioned")
@@ -173,21 +173,30 @@ trait AriadneContextUser {
     * @param path The Hadoop Path to check
     * @return true if the path exists
     */
-  def exists(path: Path): Boolean = fs.exists(path)
+  def exists(path: Path): Boolean = {
+    require(path != null, "path must not be null")
+    fs.exists(path)
+  }
 
   /** Deletes a path recursively from the filesystem.
     *
     * @param path The Hadoop Path to delete
     * @return true if the path was successfully deleted
     */
-  def delete(path: Path): Boolean = fs.delete(path, true)
+  def delete(path: Path): Boolean = {
+    require(path != null, "path must not be null")
+    fs.delete(path, true)
+  }
 
   /** Opens an input stream to read from a path on the filesystem.
     *
     * @param path The Hadoop Path to open for reading
     * @return An FSDataInputStream for reading the file contents
     */
-  def open(path: Path): FSDataInputStream = fs.open(path)
+  def open(path: Path): FSDataInputStream = {
+    require(path != null, "path must not be null")
+    fs.open(path)
+  }
 
   /** Returns a [[io.delta.tables.DeltaTable]] if the path exists and contains valid Delta metadata.
     *
@@ -220,8 +229,8 @@ trait AriadneContextUser {
     val value = try {
       spark.conf.get("spark.ariadne.lockTimeout", "1800").toLong
     } catch {
-      case _: NumberFormatException =>
-        logger.warn("Invalid spark.ariadne.lockTimeout value, using default 1800")
+      case e: NumberFormatException =>
+        logger.warn(s"Invalid spark.ariadne.lockTimeout value, using default 1800: ${e.getMessage}")
         1800L
     }
     logger.warn(s"lockTimeout initialized: $value")
@@ -235,8 +244,8 @@ trait AriadneContextUser {
     val value = try {
       spark.conf.get("spark.ariadne.lockRetryInterval", "60").toLong
     } catch {
-      case _: NumberFormatException =>
-        logger.warn("Invalid spark.ariadne.lockRetryInterval value, using default 60")
+      case e: NumberFormatException =>
+        logger.warn(s"Invalid spark.ariadne.lockRetryInterval value, using default 60: ${e.getMessage}")
         60L
     }
     logger.warn(s"lockRetryInterval initialized: $value")
@@ -250,8 +259,8 @@ trait AriadneContextUser {
     val value = try {
       spark.conf.get("spark.ariadne.lockMaxWait", "3600").toLong
     } catch {
-      case _: NumberFormatException =>
-        logger.warn("Invalid spark.ariadne.lockMaxWait value, using default 3600")
+      case e: NumberFormatException =>
+        logger.warn(s"Invalid spark.ariadne.lockMaxWait value, using default 3600: ${e.getMessage}")
         3600L
     }
     logger.warn(s"lockMaxWait initialized: $value")
@@ -265,8 +274,8 @@ trait AriadneContextUser {
     val value = try {
       spark.conf.get("spark.ariadne.lockRefreshInterval", "1").toInt
     } catch {
-      case _: NumberFormatException =>
-        logger.warn("Invalid spark.ariadne.lockRefreshInterval value, using default 1")
+      case e: NumberFormatException =>
+        logger.warn(s"Invalid spark.ariadne.lockRefreshInterval value, using default 1: ${e.getMessage}")
         1
     }
     logger.warn(s"lockRefreshInterval initialized: $value")
@@ -283,8 +292,8 @@ trait AriadneContextUser {
       try {
         Some(v.toInt)
       } catch {
-        case _: NumberFormatException =>
-          logger.warn("Invalid spark.ariadne.autoCompactThreshold value, ignoring")
+        case e: NumberFormatException =>
+          logger.warn(s"Invalid spark.ariadne.autoCompactThreshold value, ignoring: ${e.getMessage}")
           None
       }
     }
@@ -301,11 +310,17 @@ trait AriadneContextUser {
     val value = try {
       spark.conf.get("spark.ariadne.autoBloomFpr", "0.01").toDouble
     } catch {
-      case _: NumberFormatException =>
-        logger.warn("Invalid spark.ariadne.autoBloomFpr value, using default 0.01")
+      case e: NumberFormatException =>
+        logger.warn(s"Invalid spark.ariadne.autoBloomFpr value, using default 0.01: ${e.getMessage}")
         0.01
     }
-    logger.warn(s"autoBloomFpr initialized: $value")
-    value
+    val validated = if (value <= 0.0 || value >= 1.0) {
+      logger.warn(s"autoBloomFpr value $value is out of valid range (0, 1), using default 0.01")
+      0.01
+    } else {
+      value
+    }
+    logger.warn(s"autoBloomFpr initialized: $validated")
+    validated
   }
 }

--- a/src/main/scala/dev/cjfravel/ariadne/AriadneContext.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/AriadneContext.scala
@@ -34,8 +34,11 @@ import org.apache.hadoop.fs.FSDataInputStream
   * concurrency model.
   */
 trait AriadneContextUser {
-  /** Log4j logger shared by all Ariadne components. Uses the "ariadne" logger name. */
-  val logger: Logger = LogManager.getLogger("ariadne")
+  /** Log4j logger shared by all Ariadne components. Uses the "ariadne" logger name.
+    * Marked `@transient lazy` so that `Index` (a case class) remains serializable
+    * across Spark stages — Log4j loggers are not `Serializable`.
+    */
+  @transient lazy val logger: Logger = LogManager.getLogger("ariadne")
 
   /** Implicit SparkSession that must be provided by the mixing class. */
   implicit def spark: SparkSession
@@ -96,8 +99,12 @@ trait AriadneContextUser {
         logger.warn(s"Invalid spark.ariadne.stagingConsolidationThreshold value, using default 50: ${e.getMessage}")
         50
     }
-    logger.warn(s"stagingConsolidationThreshold initialized: $threshold")
-    threshold
+    val validated = if (threshold <= 0) {
+      logger.warn(s"spark.ariadne.stagingConsolidationThreshold must be positive (got $threshold), using default 50")
+      50
+    } else threshold
+    logger.warn(s"stagingConsolidationThreshold initialized: $validated")
+    validated
   }
 
   /** Optional number of partitions to use when repartitioning the index

--- a/src/main/scala/dev/cjfravel/ariadne/BloomFilterOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/BloomFilterOperations.scala
@@ -76,7 +76,7 @@ trait BloomFilterOperations extends IndexFileOperations {
     * @return
     *   UDF that takes Array[Any] and returns Array[Byte]
     */
-  private def createBloomFilterUdf(fprValue: Double): UserDefinedFunction = {
+  protected def createBloomFilterUdf(fprValue: Double): UserDefinedFunction = {
     // Capture the FPR as a local constant to ensure it's serializable
     val fpr: Double = fprValue
     

--- a/src/main/scala/dev/cjfravel/ariadne/BloomFilterOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/BloomFilterOperations.scala
@@ -239,6 +239,9 @@ trait BloomFilterOperations extends IndexFileOperations {
       values: Array[Any],
       indexDf: DataFrame
   ): Set[String] = {
+    require(column != null && column.trim.nonEmpty, "column must not be null or blank")
+    require(values != null, "values must not be null")
+    require(indexDf != null, "indexDf must not be null")
     val bloomColumn = bloomColumnPrefix + column
     logger.warn(s"Querying bloom filter for column '$column' with ${values.length} values")
 
@@ -289,6 +292,9 @@ trait BloomFilterOperations extends IndexFileOperations {
       valuesDf: DataFrame,
       indexDf: DataFrame
   ): Set[String] = {
+    require(column != null && column.trim.nonEmpty, "column must not be null or blank")
+    require(valuesDf != null, "valuesDf must not be null")
+    require(indexDf != null, "indexDf must not be null")
     val bloomColumn = bloomColumnPrefix + column
 
     if (!indexDf.columns.contains(bloomColumn)) {

--- a/src/main/scala/dev/cjfravel/ariadne/BloomFilterOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/BloomFilterOperations.scala
@@ -83,23 +83,27 @@ trait BloomFilterOperations extends IndexFileOperations {
     */
   protected def buildBloomFilterIndexes(df: DataFrame): DataFrame = {
     val configs = bloomIndexConfigs
-    if (configs.isEmpty) return df.select("filename").distinct()
+    if (configs.isEmpty) {
+      df.select("filename").distinct()
+    } else {
+      logger.debug(s"Building bloom filter indexes for ${configs.size} columns: ${configs.map(_.column).mkString(", ")}")
 
-    // For each bloom column, create aggregation that produces binary bloom filter
-    configs.foldLeft(df.select("filename").distinct) { (accumDf, config) =>
-      val bloomColumn = bloomColumnPrefix + config.column
-      val fprValue = config.fpr  // Capture FPR as a local val
+      // For each bloom column, create aggregation that produces binary bloom filter
+      configs.foldLeft(df.select("filename").distinct) { (accumDf, config) =>
+        val bloomColumn = bloomColumnPrefix + config.column
+        val fprValue = config.fpr  // Capture FPR as a local val
 
-      // Get distinct values per file and create bloom filter
-      val bloomUdf = createBloomFilterUdf(fprValue)
-      val bloomData = df
-        .select("filename", config.column)
-        .groupBy("filename")
-        .agg(
-          bloomUdf(collect_set(col(config.column))).alias(bloomColumn)
-        )
+        // Get distinct values per file and create bloom filter
+        val bloomUdf = createBloomFilterUdf(fprValue)
+        val bloomData = df
+          .select("filename", config.column)
+          .groupBy("filename")
+          .agg(
+            bloomUdf(collect_set(col(config.column))).alias(bloomColumn)
+          )
 
-      accumDf.join(bloomData, Seq("filename"), "left")
+        accumDf.join(bloomData, Seq("filename"), "left")
+      }
     }
   }
 
@@ -114,11 +118,15 @@ trait BloomFilterOperations extends IndexFileOperations {
     * The `fprValue` parameter is captured as a local `val` to ensure it is
     * serializable when the UDF closure is shipped to Spark executors.
     *
-    * @param fprValue the desired false positive rate (e.g., 0.01 for 1%)
+    * @param fprValue the desired false positive rate (e.g., 0.01 for 1%);
+    *                 must be strictly between 0 and 1 (exclusive)
     * @return a UDF that accepts `Seq[Any]` (from `collect_set`) and returns `Array[Byte]`,
     *         or `null` if the input is null or contains only nulls
+    * @throws IllegalArgumentException if `fprValue` is not in the range (0, 1)
     */
   protected def createBloomFilterUdf(fprValue: Double): UserDefinedFunction = {
+    require(fprValue > 0.0 && fprValue < 1.0,
+      s"False positive rate must be between 0 and 1 (exclusive), got: $fprValue")
     // Capture the FPR as a local constant to ensure it's serializable
     val fpr: Double = fprValue
     
@@ -143,8 +151,12 @@ trait BloomFilterOperations extends IndexFileOperations {
 
           // Serialize to bytes
           val baos = new ByteArrayOutputStream()
-          bf.writeTo(baos)
-          baos.toByteArray
+          try {
+            bf.writeTo(baos)
+            baos.toByteArray
+          } finally {
+            baos.close()
+          }
         }
       }
     }
@@ -163,7 +175,11 @@ trait BloomFilterOperations extends IndexFileOperations {
       bytes: Array[Byte]
   ): BloomFilter[CharSequence] = {
     val bais = new ByteArrayInputStream(bytes)
-    BloomFilter.readFrom(bais, Funnels.stringFunnel(StandardCharsets.UTF_8))
+    try {
+      BloomFilter.readFrom(bais, Funnels.stringFunnel(StandardCharsets.UTF_8))
+    } finally {
+      bais.close()
+    }
   }
 
   /** Checks if a value might be contained in a serialized bloom filter.
@@ -176,9 +192,11 @@ trait BloomFilterOperations extends IndexFileOperations {
     * @return `true` if the value might be present (probabilistic), `false` if definitely absent
     */
   protected def bloomMightContain(bloomBytes: Array[Byte], value: Any): Boolean = {
-    if (bloomBytes == null || value == null) return false
-    val bf = deserializeBloomFilter(bloomBytes)
-    bf.mightContain(value.toString)
+    if (bloomBytes == null || value == null) false
+    else {
+      val bf = deserializeBloomFilter(bloomBytes)
+      bf.mightContain(value.toString)
+    }
   }
 
   /** Creates a Spark UDF for checking bloom filter membership at query time.
@@ -205,6 +223,11 @@ trait BloomFilterOperations extends IndexFileOperations {
     * specified column, and tests every candidate value. A file is included in the
     * result if any value passes the `mightContain` check.
     *
+    * @note This method calls `.collect()` to load all bloom filter binary data to the
+    *       driver. For indexes with millions of files, each row carries a serialized
+    *       bloom filter (potentially KBs each), which can cause driver OOM. Consider
+    *       increasing driver memory for very large indexes.
+    *
     * @param column the source column name (without `bloom_` prefix)
     * @param values array of candidate values to search for
     * @param indexDf the index DataFrame containing bloom filter binary columns
@@ -221,32 +244,39 @@ trait BloomFilterOperations extends IndexFileOperations {
 
     if (!indexDf.columns.contains(bloomColumn)) {
       logger.warn(s"Bloom column $bloomColumn not found in index")
-      return Set.empty
-    }
-
-    // Check each file's bloom filter against all values
-    val matchingFiles = indexDf
-      .select("filename", bloomColumn)
-      .collect()
-      .filter { row =>
-        val bloomBytes = row.getAs[Array[Byte]](bloomColumn)
-        if (bloomBytes == null) false
-        else {
-          // File matches if ANY value might be contained
-          values.exists(v => bloomMightContain(bloomBytes, v))
+      Set.empty
+    } else {
+      // NOTE: collect() loads all bloom filter byte arrays to the driver. For very large
+      // indexes with millions of files, this could cause driver OOM as each row includes
+      // a serialized bloom filter (potentially KBs each).
+      val matchingFiles = indexDf
+        .select("filename", bloomColumn)
+        .collect()
+        .filter { row =>
+          val bloomBytes = row.getAs[Array[Byte]](bloomColumn)
+          if (bloomBytes == null) false
+          else {
+            // File matches if ANY value might be contained
+            values.exists(v => bloomMightContain(bloomBytes, v))
+          }
         }
-      }
-      .map(_.getString(0))
-      .toSet
+        .map(_.getString(0))
+        .toSet
 
-    logger.warn(s"Bloom filter for '$column': ${matchingFiles.size} files matched out of total index rows")
-    matchingFiles
+      logger.warn(s"Bloom filter for '$column': ${matchingFiles.size} files matched out of total index rows")
+      matchingFiles
+    }
   }
 
   /** Locates files that might contain values from a DataFrame using bloom filters.
     *
     * Collects distinct non-null values from the specified column of `valuesDf`,
     * then delegates to [[locateFilesWithBloom]] for the actual bloom filter check.
+    *
+    * @note This method calls `.collect()` twice: first to gather distinct candidate
+    *       values from `valuesDf`, then indirectly via [[locateFilesWithBloom]] to
+    *       load all bloom filter binary data to the driver. Both operations can cause
+    *       driver OOM for very large DataFrames or indexes with millions of files.
     *
     * @param column the source column name (without `bloom_` prefix)
     * @param valuesDf DataFrame containing the candidate values to search for
@@ -263,21 +293,22 @@ trait BloomFilterOperations extends IndexFileOperations {
 
     if (!indexDf.columns.contains(bloomColumn)) {
       logger.warn(s"Bloom column $bloomColumn not found in index")
-      return Set.empty
+      Set.empty
+    } else {
+      // Collect distinct values from the query DataFrame
+      val values = valuesDf
+        .select(column)
+        .distinct()
+        .collect()
+        .map(_.get(0))
+        .filter(_ != null)
+
+      if (values.isEmpty) Set.empty
+      else {
+        logger.warn(s"Bloom filter query for '$column': ${values.length} distinct values from DataFrame")
+        // Use the existing method with collected values
+        locateFilesWithBloom(column, values, indexDf)
+      }
     }
-
-    // Collect distinct values from the query DataFrame
-    val values = valuesDf
-      .select(column)
-      .distinct()
-      .collect()
-      .map(_.get(0))
-      .filter(_ != null)
-
-    if (values.isEmpty) return Set.empty
-
-    logger.warn(s"Bloom filter query for '$column': ${values.length} distinct values from DataFrame")
-    // Use the existing method with collected values
-    locateFilesWithBloom(column, values, indexDf)
   }
 }

--- a/src/main/scala/dev/cjfravel/ariadne/BloomFilterOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/BloomFilterOperations.scala
@@ -1,50 +1,85 @@
 package dev.cjfravel.ariadne
 
 import com.google.common.hash.{BloomFilter, Funnels}
-import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types._
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 import java.nio.charset.StandardCharsets
 import scala.collection.JavaConverters._
 
-/** Trait providing bloom filter operations for Index instances.
+/** Trait providing bloom filter operations for [[Index]] instances.
   *
-  * This trait handles:
-  * - Building bloom filters during index updates
-  * - Serializing/deserializing bloom filters for Delta storage
-  * - Querying bloom filters for file location
+  * Bloom filters are probabilistic data structures used to test set membership.
+  * This trait handles the full lifecycle of bloom filter indexes:
   *
-  * Bloom filters are probabilistic data structures that provide:
-  * - Guaranteed NO false negatives (if filter says "no", value definitely absent)
-  * - Configurable false positive rate (if filter says "yes", value MIGHT be present)
-  * - Space-efficient storage (approximately 10 bits per element at 1% FPR)
+  * '''Building''': During index updates, bloom filters are created per file per
+  * configured column via [[buildBloomFilterIndexes]]. Values are hashed into a
+  * Guava `BloomFilter[CharSequence]` and serialized to `Array[Byte]` for storage
+  * in the Delta index table.
+  *
+  * '''Querying''': At query time, [[locateFilesWithBloom]] and
+  * [[locateFilesWithBloomFromDataFrame]] deserialize stored bloom filters and
+  * test candidate values, returning the set of files that might contain matches.
+  *
+  * '''Serialization''': Bloom filters are serialized/deserialized via Guava's
+  * `writeTo`/`readFrom` methods using a `StringFunnel` with UTF-8 encoding.
+  * All indexed values are converted to strings before hashing.
+  *
+  * Bloom filters provide:
+  *  - Guaranteed no false negatives (if filter says "no", value is definitely absent)
+  *  - Configurable false positive rate (if filter says "yes", value might be present)
+  *  - Space-efficient storage (approximately 10 bits per element at 1% FPR)
+  *
+  * UDF mechanics: Bloom filter creation and querying are performed inside Spark UDFs
+  * ([[createBloomFilterUdf]] and [[bloomContainsUdf]]) so they can execute on worker
+  * nodes. The false positive rate is captured as a local `Double` to ensure
+  * serializability across the Spark closure boundary.
+  *
+  * @see [[BloomIndexConfig]] for per-column configuration
+  * @see [[IndexBuildOperations]] for the build pipeline that invokes these operations
   */
 trait BloomFilterOperations extends IndexFileOperations {
   self: Index =>
 
-  /** Column name prefix for bloom filter storage */
+  /** Column name prefix used when storing bloom filter binary data in the index Delta table. */
   protected val bloomColumnPrefix = "bloom_"
 
-  /** Get bloom index configurations from metadata */
+  /** Returns the bloom index configurations from the current index metadata.
+    *
+    * @return sequence of [[BloomIndexConfig]] objects, one per bloom-indexed column
+    */
   protected def bloomIndexConfigs: Seq[BloomIndexConfig] =
     metadata.bloom_indexes.asScala.toSeq
 
-  /** Get the set of bloom index column names */
+  /** Returns the set of source column names that have bloom indexes configured.
+    *
+    * @return set of column names (without the `bloom_` prefix)
+    */
   protected def bloomColumns: Set[String] =
     metadata.bloom_indexes.asScala.map(_.column).toSet
 
-  /** Get the set of bloom storage column names (with prefix) */
+  /** Returns the set of storage column names used for bloom filter binary data.
+    *
+    * Each name is the source column name prefixed with [[bloomColumnPrefix]].
+    *
+    * @return set of prefixed column names (e.g., `bloom_user_id`)
+    */
   protected def bloomStorageColumns: Set[String] =
     metadata.bloom_indexes.asScala.map(c => bloomColumnPrefix + c.column).toSet
 
   /** Builds bloom filter indexes for all configured bloom columns.
     *
-    * @param df
-    *   DataFrame with filename column and source data
-    * @return
-    *   DataFrame with bloom filter binary columns added
+    * For each [[BloomIndexConfig]], this method:
+    *  1. Groups the input data by filename
+    *  2. Collects distinct values per file into a set
+    *  3. Creates a bloom filter from the collected values using [[createBloomFilterUdf]]
+    *  4. Joins the resulting bloom column back onto the accumulating DataFrame
+    *
+    * If no bloom indexes are configured, returns a distinct filename-only DataFrame.
+    *
+    * @param df DataFrame containing a `filename` column and all bloom-indexed source columns
+    * @return DataFrame with `filename` plus one `bloom_{column}` binary column per configured bloom index
     */
   protected def buildBloomFilterIndexes(df: DataFrame): DataFrame = {
     val configs = bloomIndexConfigs
@@ -68,13 +103,20 @@ trait BloomFilterOperations extends IndexFileOperations {
     }
   }
 
-  /** Creates a UDF that converts an array of values to a serialized bloom
-    * filter.
+  /** Creates a Spark UDF that converts a collected set of values into a serialized bloom filter.
     *
-    * @param fprValue
-    *   False positive rate (captured as a serializable value)
-    * @return
-    *   UDF that takes Array[Any] and returns Array[Byte]
+    * The UDF is designed for use inside `agg(bloomUdf(collect_set(...)))`. It:
+    *  1. Filters out null values from the input sequence
+    *  2. Creates a Guava `BloomFilter` sized for the actual number of non-null elements
+    *  3. Inserts each value (converted to `String`) into the filter
+    *  4. Serializes the filter to `Array[Byte]` via `ByteArrayOutputStream`
+    *
+    * The `fprValue` parameter is captured as a local `val` to ensure it is
+    * serializable when the UDF closure is shipped to Spark executors.
+    *
+    * @param fprValue the desired false positive rate (e.g., 0.01 for 1%)
+    * @return a UDF that accepts `Seq[Any]` (from `collect_set`) and returns `Array[Byte]`,
+    *         or `null` if the input is null or contains only nulls
     */
   protected def createBloomFilterUdf(fprValue: Double): UserDefinedFunction = {
     // Capture the FPR as a local constant to ensure it's serializable
@@ -108,12 +150,14 @@ trait BloomFilterOperations extends IndexFileOperations {
     }
   }
 
-  /** Deserializes a bloom filter from bytes.
+  /** Deserializes a Guava bloom filter from its byte representation.
     *
-    * @param bytes
-    *   Serialized bloom filter
-    * @return
-    *   BloomFilter instance
+    * Uses `BloomFilter.readFrom` with a UTF-8 `StringFunnel`, which must match
+    * the funnel used during creation in [[createBloomFilterUdf]].
+    *
+    * @param bytes serialized bloom filter bytes (produced by `BloomFilter.writeTo`)
+    * @return a `BloomFilter[CharSequence]` instance ready for membership queries
+    * @throws java.io.IOException if the byte array is malformed or corrupted
     */
   protected def deserializeBloomFilter(
       bytes: Array[Byte]
@@ -124,12 +168,12 @@ trait BloomFilterOperations extends IndexFileOperations {
 
   /** Checks if a value might be contained in a serialized bloom filter.
     *
-    * @param bloomBytes
-    *   Serialized bloom filter
-    * @param value
-    *   Value to check
-    * @return
-    *   true if value MIGHT be present, false if DEFINITELY not present
+    * Deserializes the bloom filter and performs a `mightContain` check. Returns
+    * `false` if either argument is `null`.
+    *
+    * @param bloomBytes serialized bloom filter bytes
+    * @param value the value to test for membership (converted to `String` internally)
+    * @return `true` if the value might be present (probabilistic), `false` if definitely absent
     */
   protected def bloomMightContain(bloomBytes: Array[Byte], value: Any): Boolean = {
     if (bloomBytes == null || value == null) return false
@@ -137,10 +181,13 @@ trait BloomFilterOperations extends IndexFileOperations {
     bf.mightContain(value.toString)
   }
 
-  /** Creates a UDF for checking bloom filter membership.
+  /** Creates a Spark UDF for checking bloom filter membership at query time.
     *
-    * @return
-    *   UDF that takes (bloom_bytes, value) and returns Boolean
+    * The returned UDF accepts a serialized bloom filter (`Array[Byte]`) and a
+    * candidate value (`String`), and returns `true` if the bloom filter indicates
+    * the value might be present.
+    *
+    * @return UDF with signature `(Array[Byte], String) => Boolean`
     */
   protected def bloomContainsUdf: UserDefinedFunction = {
     udf { (bloomBytes: Array[Byte], value: String) =>
@@ -152,16 +199,17 @@ trait BloomFilterOperations extends IndexFileOperations {
     }
   }
 
-  /** Locates files that might contain the given values using bloom filters.
+  /** Locates files that might contain any of the given values using bloom filters.
     *
-    * @param column
-    *   The bloom index column name
-    * @param values
-    *   Values to search for
-    * @param indexDf
-    *   The index DataFrame to search
-    * @return
-    *   Set of filenames that might contain any of the values
+    * Collects all rows from the index, deserializes each file's bloom filter for the
+    * specified column, and tests every candidate value. A file is included in the
+    * result if any value passes the `mightContain` check.
+    *
+    * @param column the source column name (without `bloom_` prefix)
+    * @param values array of candidate values to search for
+    * @param indexDf the index DataFrame containing bloom filter binary columns
+    * @return set of filenames whose bloom filters indicate a possible match;
+    *         empty set if the bloom column does not exist in the index
     */
   protected def locateFilesWithBloom(
       column: String,
@@ -195,17 +243,16 @@ trait BloomFilterOperations extends IndexFileOperations {
     matchingFiles
   }
 
-  /** Locates files that might contain values from a DataFrame using bloom
-    * filters.
+  /** Locates files that might contain values from a DataFrame using bloom filters.
     *
-    * @param column
-    *   The bloom index column name
-    * @param valuesDf
-    *   DataFrame containing values to search for
-    * @param indexDf
-    *   The index DataFrame to search
-    * @return
-    *   Set of filenames that might contain any of the values
+    * Collects distinct non-null values from the specified column of `valuesDf`,
+    * then delegates to [[locateFilesWithBloom]] for the actual bloom filter check.
+    *
+    * @param column the source column name (without `bloom_` prefix)
+    * @param valuesDf DataFrame containing the candidate values to search for
+    * @param indexDf the index DataFrame containing bloom filter binary columns
+    * @return set of filenames whose bloom filters indicate a possible match;
+    *         empty set if no non-null values exist or the bloom column is missing
     */
   protected def locateFilesWithBloomFromDataFrame(
       column: String,

--- a/src/main/scala/dev/cjfravel/ariadne/BloomFilterOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/BloomFilterOperations.scala
@@ -48,7 +48,7 @@ trait BloomFilterOperations extends IndexFileOperations {
     */
   protected def buildBloomFilterIndexes(df: DataFrame): DataFrame = {
     val configs = bloomIndexConfigs
-    if (configs.isEmpty) return spark.emptyDataFrame
+    if (configs.isEmpty) return df.select("filename").distinct()
 
     // For each bloom column, create aggregation that produces binary bloom filter
     configs.foldLeft(df.select("filename").distinct) { (accumDf, config) =>
@@ -169,6 +169,7 @@ trait BloomFilterOperations extends IndexFileOperations {
       indexDf: DataFrame
   ): Set[String] = {
     val bloomColumn = bloomColumnPrefix + column
+    logger.warn(s"Querying bloom filter for column '$column' with ${values.length} values")
 
     if (!indexDf.columns.contains(bloomColumn)) {
       logger.warn(s"Bloom column $bloomColumn not found in index")
@@ -190,6 +191,7 @@ trait BloomFilterOperations extends IndexFileOperations {
       .map(_.getString(0))
       .toSet
 
+    logger.warn(s"Bloom filter for '$column': ${matchingFiles.size} files matched out of total index rows")
     matchingFiles
   }
 
@@ -227,6 +229,7 @@ trait BloomFilterOperations extends IndexFileOperations {
 
     if (values.isEmpty) return Set.empty
 
+    logger.warn(s"Bloom filter query for '$column': ${values.length} distinct values from DataFrame")
     // Use the existing method with collected values
     locateFilesWithBloom(column, values, indexDf)
   }

--- a/src/main/scala/dev/cjfravel/ariadne/FileList.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/FileList.scala
@@ -29,7 +29,7 @@ case class FileList private (
     name: String
 )(implicit val spark: SparkSession)
     extends AriadneContextUser {
-  override val logger: Logger = LogManager.getLogger("ariadne")
+  override lazy val logger: Logger = LogManager.getLogger("ariadne")
 
   override lazy val storagePath: Path = new Path(FileList.storagePath, name)
 

--- a/src/main/scala/dev/cjfravel/ariadne/FileList.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/FileList.scala
@@ -74,6 +74,23 @@ case class FileList private (
 
   def addFile(fileNames: String*): Unit = addFile(spark, fileNames: _*)
 
+  def removeFile(fileNames: String*): Unit = {
+    delta(storagePath) match {
+      case Some(dt) =>
+        import spark.implicits._
+        val toRemove = fileNames.toDF("filename")
+        dt.as("target")
+          .merge(toRemove.as("source"), "target.filename = source.filename")
+          .whenMatched()
+          .delete()
+          .execute()
+        _files = null
+        logger.warn(s"Removed ${fileNames.size} files from FileList $name")
+      case None =>
+        logger.warn(s"FileList $name does not exist, nothing to remove")
+    }
+  }
+
   def hasFile(fileName: String): Boolean =
     !files.filter(col("filename") === fileName).isEmpty
 

--- a/src/main/scala/dev/cjfravel/ariadne/FileList.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/FileList.scala
@@ -144,6 +144,8 @@ case class FileList private (
     *   one or more file paths to add
     * @throws IllegalArgumentException
     *   if fileNames is null or any individual file name is null or blank
+    * @note Collects all existing filenames to the driver for duplicate detection.
+    *   May cause driver OOM for indexes tracking millions of files.
     */
   def addFile(fileNames: String*): Unit = addFile(spark, fileNames: _*)
 
@@ -154,8 +156,12 @@ case class FileList private (
     *
     * @param fileNames
     *   one or more file paths to remove
+    * @throws IllegalArgumentException
+    *   if fileNames is null or empty, or any individual file name is null or blank
     */
   def removeFile(fileNames: String*): Unit = {
+    require(fileNames != null && fileNames.nonEmpty, "fileNames must not be null or empty")
+    require(fileNames.forall(f => f != null && f.trim.nonEmpty), "fileNames must not contain null or blank entries")
     logger.warn(
       s"removeFile called on FileList '$name' with ${fileNames.size} file(s)"
     )
@@ -181,9 +187,13 @@ case class FileList private (
     *   the file path to check
     * @return
     *   true if the file exists in the list
+    * @throws IllegalArgumentException
+    *   if fileName is null or blank
     */
-  def hasFile(fileName: String): Boolean =
+  def hasFile(fileName: String): Boolean = {
+    require(fileName != null && fileName.trim.nonEmpty, "fileName must not be null or blank")
     !files.filter(col("filename") === fileName).isEmpty
+  }
 
   /** Persists the current in-memory file list to the Delta table.
     *
@@ -244,6 +254,7 @@ object FileList {
     *   true if the Delta table directory exists
     */
   def exists(name: String)(implicit sparkSession: SparkSession): Boolean = {
+    require(name != null && name.trim.nonEmpty, "name must not be null or blank")
     val contextUser = new AriadneContextUser {
       implicit def spark: SparkSession = sparkSession
     }
@@ -262,6 +273,7 @@ object FileList {
     *   if the file list does not exist
     */
   def remove(name: String)(implicit sparkSession: SparkSession): Boolean = {
+    require(name != null && name.trim.nonEmpty, "name must not be null or blank")
     if (!exists(name)(sparkSession)) {
       throw new FileListNotFoundException(name)
     }
@@ -281,6 +293,7 @@ object FileList {
     *   a new FileList backed by a Delta table at `storagePath/name`
     */
   def apply(name: String)(implicit spark: SparkSession): FileList = {
+    require(name != null && name.trim.nonEmpty, "name must not be null or blank")
     new FileList(name)(spark)
   }
 }

--- a/src/main/scala/dev/cjfravel/ariadne/FileList.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/FileList.scala
@@ -13,12 +13,10 @@ import org.apache.hadoop.fs.{Path, FileSystem}
 import org.apache.hadoop.conf.Configuration
 import java.nio.charset.StandardCharsets
 import scala.collection.mutable
-import collection.JavaConverters._
+import scala.collection.JavaConverters._
 import java.util
 import java.util.Collections
 import org.apache.logging.log4j.{Logger, LogManager}
-import org.apache.spark.sql.Dataset
-
 import java.time.Instant
 import java.sql.Timestamp
 
@@ -67,9 +65,16 @@ case class FileList private (
       ))
     )
 
+    val originalFiles = _files
     _files = _files.union(newFiles)
-    write
-    logger.warn(s"Added ${toAdd.size} files")
+    try {
+      write
+    } catch {
+      case e: Exception =>
+        _files = originalFiles
+        throw e
+    }
+    logger.warn(s"Added ${toAdd.size} files to FileList $name")
   }
 
   def addFile(fileNames: String*): Unit = addFile(spark, fileNames: _*)

--- a/src/main/scala/dev/cjfravel/ariadne/FileList.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/FileList.scala
@@ -20,6 +20,15 @@ import org.apache.logging.log4j.{Logger, LogManager}
 import java.time.Instant
 import java.sql.Timestamp
 
+/** Manages a tracked list of files associated with an Ariadne index.
+  *
+  * Files are stored as a Delta Lake table with filename and addedAt columns.
+  * The file list is used to track which files have been registered with an index
+  * and need to be processed during updates.
+  *
+  * @param name The name of this file list (typically "[ariadne_index] {indexName}")
+  * @param spark Implicit SparkSession for Delta Lake operations
+  */
 case class FileList private (
     name: String
 )(implicit val spark: SparkSession) extends AriadneContextUser {
@@ -44,6 +53,10 @@ case class FileList private (
     _files
   }
 
+  /** Returns the DataFrame of tracked files with filename and addedAt columns.
+    * Lazily loaded from the Delta table on first access.
+    * @return DataFrame with columns (filename: String, addedAt: Timestamp)
+    */
   def files: DataFrame = files(spark)
 
   private def addFile(spark: SparkSession, fileNames: String*): Unit = {
@@ -77,8 +90,14 @@ case class FileList private (
     logger.warn(s"Added ${toAdd.size} files to FileList $name")
   }
 
+  /** Registers new files in the file list. Files already present are silently skipped.
+    * @param fileNames One or more file paths to add
+    */
   def addFile(fileNames: String*): Unit = addFile(spark, fileNames: _*)
 
+  /** Removes files from the file list using a Delta merge-delete.
+    * @param fileNames One or more file paths to remove
+    */
   def removeFile(fileNames: String*): Unit = {
     delta(storagePath) match {
       case Some(dt) =>
@@ -96,6 +115,10 @@ case class FileList private (
     }
   }
 
+  /** Checks if a specific file is tracked in this file list.
+    * @param fileName The file path to check
+    * @return true if the file exists in the list
+    */
   def hasFile(fileName: String): Boolean =
     !files.filter(col("filename") === fileName).isEmpty
 
@@ -122,7 +145,15 @@ case class FileList private (
 
 }
 
+/** Factory and utility methods for FileList instances.
+  *
+  * Provides path resolution, existence checks, and removal operations
+  * for file lists stored as Delta tables.
+  */
 object FileList {
+  /** Returns the base storage path for all file lists.
+    * @return Hadoop Path to the filelists directory
+    */
   def storagePath(implicit sparkSession: SparkSession): Path = {
     val contextUser = new AriadneContextUser {
       implicit def spark: SparkSession = sparkSession
@@ -130,6 +161,10 @@ object FileList {
     new Path(contextUser.storagePath, "filelists")
   }
 
+  /** Checks if a file list exists.
+    * @param name The file list name
+    * @return true if the Delta table exists
+    */
   def exists(name: String)(implicit sparkSession: SparkSession): Boolean = {
     val contextUser = new AriadneContextUser {
       implicit def spark: SparkSession = sparkSession
@@ -137,6 +172,11 @@ object FileList {
     contextUser.exists(new Path(storagePath(sparkSession), name))
   }
 
+  /** Removes a file list's Delta table from storage.
+    * @param name The file list name
+    * @return true if deletion was successful
+    * @throws FileListNotFoundException if the file list does not exist
+    */
   def remove(name: String)(implicit sparkSession: SparkSession): Boolean = {
     if (!exists(name)(sparkSession)) {
       throw new FileListNotFoundException(name)
@@ -147,6 +187,10 @@ object FileList {
     contextUser.delete(new Path(storagePath(sparkSession), name))
   }
 
+  /** Creates a new FileList instance.
+    * @param name The file list name
+    * @return A new FileList instance
+    */
   def apply(name: String)(implicit spark: SparkSession): FileList = {
     new FileList(name)(spark)
   }

--- a/src/main/scala/dev/cjfravel/ariadne/FileList.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/FileList.scala
@@ -1,61 +1,91 @@
 package dev.cjfravel.ariadne
 
 import dev.cjfravel.ariadne.exceptions._
-import org.apache.spark.sql.{SparkSession, DataFrame}
+import org.apache.spark.sql.{SparkSession, DataFrame, Row}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.functions._
-import scala.io.Source
-import com.google.gson._
-import com.google.gson.reflect.TypeToken
 import io.delta.tables.DeltaTable
-import org.apache.spark.sql.Row
-import org.apache.hadoop.fs.{Path, FileSystem}
-import org.apache.hadoop.conf.Configuration
-import java.nio.charset.StandardCharsets
-import scala.collection.mutable
-import scala.collection.JavaConverters._
-import java.util
-import java.util.Collections
+import org.apache.hadoop.fs.Path
 import org.apache.logging.log4j.{Logger, LogManager}
 import java.time.Instant
 import java.sql.Timestamp
 
 /** Manages a tracked list of files associated with an Ariadne index.
   *
-  * Files are stored as a Delta Lake table with filename and addedAt columns.
-  * The file list is used to track which files have been registered with an index
-  * and need to be processed during updates.
+  * Each file list is persisted as a Delta Lake table with two columns:
+  *   - `filename` (`StringType`, not nullable) — the file path
+  *   - `addedAt` (`TimestampType`, not nullable) — when the file was registered
   *
-  * @param name The name of this file list (typically "[ariadne_index] {indexName}")
-  * @param spark Implicit SparkSession for Delta Lake operations
+  * The DataFrame is lazily loaded and cached in memory after the first access.
+  * Mutations (add, remove) invalidate the cache so the next read re-loads from
+  * the Delta table.
+  *
+  * @param name
+  *   the name of this file list, typically `"[ariadne_index] {indexName}"`
+  * @param spark
+  *   implicit SparkSession for Delta Lake operations
   */
 case class FileList private (
     name: String
-)(implicit val spark: SparkSession) extends AriadneContextUser {
+)(implicit val spark: SparkSession)
+    extends AriadneContextUser {
   override val logger: Logger = LogManager.getLogger("ariadne")
 
   override lazy val storagePath: Path = new Path(FileList.storagePath, name)
 
+  /** Cached DataFrame of tracked files. Set to `null` to force reload. */
   private var _files: DataFrame = _
 
+  /** Loads or returns the cached file list DataFrame.
+    *
+    * On first access (or after cache invalidation), reads the Delta table at
+    * `storagePath`. If the table does not yet exist, returns an empty DataFrame
+    * with the expected schema. The loaded result is cached for subsequent
+    * calls.
+    *
+    * @param spark
+    *   the SparkSession to use for reading
+    * @return
+    *   DataFrame with columns (filename: String, addedAt: Timestamp)
+    */
   private def files(spark: SparkSession): DataFrame = {
     if (_files == null) {
       _files = delta(storagePath) match {
-        case Some(delta) => delta.toDF
-        case None        => spark.createDataFrame(spark.sparkContext.emptyRDD[Row],
-                              StructType(Seq(
-                                StructField("filename", StringType, nullable = false),
-                                StructField("addedAt", TimestampType, nullable = false)
-                              )))
+        case Some(delta) =>
+          val df = delta.toDF
+          val count = df.count()
+          logger.warn(
+            s"Loaded file list '$name' from Delta table ($count files)"
+          )
+          df
+        case None =>
+          logger.warn(
+            s"File list '$name' not yet persisted, using empty DataFrame"
+          )
+          spark.createDataFrame(
+            spark.sparkContext.emptyRDD[Row],
+            StructType(
+              Seq(
+                StructField("filename", StringType, nullable = false),
+                StructField("addedAt", TimestampType, nullable = false)
+              )
+            )
+          )
       }
+    } else {
+      logger.debug(s"Returning cached file list '$name'")
     }
 
     _files
   }
 
   /** Returns the DataFrame of tracked files with filename and addedAt columns.
-    * Lazily loaded from the Delta table on first access.
-    * @return DataFrame with columns (filename: String, addedAt: Timestamp)
+    *
+    * Lazily loaded from the Delta table on first access; subsequent calls
+    * return the cached DataFrame until the cache is invalidated by a mutation.
+    *
+    * @return
+    *   DataFrame with columns (filename: String, addedAt: Timestamp)
     */
   def files: DataFrame = files(spark)
 
@@ -72,10 +102,12 @@ case class FileList private (
     val newFilesData = toAdd.toList.map(filename => Row(filename, ts))
     val newFiles = spark.createDataFrame(
       spark.sparkContext.parallelize(newFilesData),
-      StructType(Seq(
-        StructField("filename", StringType, nullable = false),
-        StructField("addedAt", TimestampType, nullable = false)
-      ))
+      StructType(
+        Seq(
+          StructField("filename", StringType, nullable = false),
+          StructField("addedAt", TimestampType, nullable = false)
+        )
+      )
     )
 
     val originalFiles = _files
@@ -90,13 +122,24 @@ case class FileList private (
     logger.warn(s"Added ${toAdd.size} files to FileList $name")
   }
 
-  /** Registers new files in the file list. Files already present are silently skipped.
-    * @param fileNames One or more file paths to add
+  /** Registers new files in the file list.
+    *
+    * Files already present are silently skipped. The additions are written to
+    * the Delta table immediately; if the write fails, the in-memory cache is
+    * rolled back to its previous state.
+    *
+    * @param fileNames
+    *   one or more file paths to add
     */
   def addFile(fileNames: String*): Unit = addFile(spark, fileNames: _*)
 
   /** Removes files from the file list using a Delta merge-delete.
-    * @param fileNames One or more file paths to remove
+    *
+    * After deletion, the in-memory cache is invalidated so the next read
+    * reflects the updated state.
+    *
+    * @param fileNames
+    *   one or more file paths to remove
     */
   def removeFile(fileNames: String*): Unit = {
     delta(storagePath) match {
@@ -116,12 +159,20 @@ case class FileList private (
   }
 
   /** Checks if a specific file is tracked in this file list.
-    * @param fileName The file path to check
-    * @return true if the file exists in the list
+    *
+    * @param fileName
+    *   the file path to check
+    * @return
+    *   true if the file exists in the list
     */
   def hasFile(fileName: String): Boolean =
     !files.filter(col("filename") === fileName).isEmpty
 
+  /** Persists the current in-memory file list to the Delta table.
+    *
+    * Uses a merge (upsert) if the table already exists, or a full overwrite for
+    * first-time creation. Invalidates the in-memory cache after writing.
+    */
   private def write: Unit = {
     delta(storagePath) match {
       case Some(delta) =>
@@ -147,12 +198,17 @@ case class FileList private (
 
 /** Factory and utility methods for FileList instances.
   *
-  * Provides path resolution, existence checks, and removal operations
-  * for file lists stored as Delta tables.
+  * Provides path resolution, existence checks, and removal operations for file
+  * lists stored as Delta tables.
   */
 object FileList {
+
   /** Returns the base storage path for all file lists.
-    * @return Hadoop Path to the filelists directory
+    *
+    * @param sparkSession
+    *   the implicit SparkSession
+    * @return
+    *   Hadoop Path to the filelists directory
     */
   def storagePath(implicit sparkSession: SparkSession): Path = {
     val contextUser = new AriadneContextUser {
@@ -161,9 +217,14 @@ object FileList {
     new Path(contextUser.storagePath, "filelists")
   }
 
-  /** Checks if a file list exists.
-    * @param name The file list name
-    * @return true if the Delta table exists
+  /** Checks if a file list with the given name exists on storage.
+    *
+    * @param name
+    *   the file list name
+    * @param sparkSession
+    *   the implicit SparkSession
+    * @return
+    *   true if the Delta table directory exists
     */
   def exists(name: String)(implicit sparkSession: SparkSession): Boolean = {
     val contextUser = new AriadneContextUser {
@@ -173,9 +234,15 @@ object FileList {
   }
 
   /** Removes a file list's Delta table from storage.
-    * @param name The file list name
-    * @return true if deletion was successful
-    * @throws FileListNotFoundException if the file list does not exist
+    *
+    * @param name
+    *   the file list name
+    * @param sparkSession
+    *   the implicit SparkSession
+    * @return
+    *   true if deletion was successful
+    * @throws FileListNotFoundException
+    *   if the file list does not exist
     */
   def remove(name: String)(implicit sparkSession: SparkSession): Boolean = {
     if (!exists(name)(sparkSession)) {
@@ -187,9 +254,14 @@ object FileList {
     contextUser.delete(new Path(storagePath(sparkSession), name))
   }
 
-  /** Creates a new FileList instance.
-    * @param name The file list name
-    * @return A new FileList instance
+  /** Creates a new [[FileList]] instance for the given name.
+    *
+    * @param name
+    *   the file list name
+    * @param spark
+    *   the implicit SparkSession
+    * @return
+    *   a new FileList backed by a Delta table at `storagePath/name`
     */
   def apply(name: String)(implicit spark: SparkSession): FileList = {
     new FileList(name)(spark)

--- a/src/main/scala/dev/cjfravel/ariadne/FileList.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/FileList.scala
@@ -90,36 +90,48 @@ case class FileList private (
   def files: DataFrame = files(spark)
 
   private def addFile(spark: SparkSession, fileNames: String*): Unit = {
+    require(fileNames != null, "fileNames must not be null")
+    fileNames.foreach { fn =>
+      require(
+        fn != null && fn.trim.nonEmpty,
+        "Each fileName must be non-null and non-blank"
+      )
+    }
+    logger.warn(
+      s"addFile called on FileList '$name' with ${fileNames.size} file(s)"
+    )
     import spark.implicits._
     val existing = files.select("filename").as[String].collect().toSet
     val toAdd = fileNames.toSet.diff(existing)
     if (toAdd.isEmpty) {
       logger.warn("All files were already added")
-      return
-    }
-
-    val ts = Timestamp.from(Instant.now())
-    val newFilesData = toAdd.toList.map(filename => Row(filename, ts))
-    val newFiles = spark.createDataFrame(
-      spark.sparkContext.parallelize(newFilesData),
-      StructType(
-        Seq(
-          StructField("filename", StringType, nullable = false),
-          StructField("addedAt", TimestampType, nullable = false)
+    } else {
+      val ts = Timestamp.from(Instant.now())
+      val newFilesData = toAdd.toList.map(filename => Row(filename, ts))
+      val newFiles = spark.createDataFrame(
+        spark.sparkContext.parallelize(newFilesData),
+        StructType(
+          Seq(
+            StructField("filename", StringType, nullable = false),
+            StructField("addedAt", TimestampType, nullable = false)
+          )
         )
       )
-    )
 
-    val originalFiles = _files
-    _files = _files.union(newFiles)
-    try {
-      write
-    } catch {
-      case e: Exception =>
-        _files = originalFiles
-        throw e
+      val originalFiles = _files
+      _files = _files.union(newFiles)
+      try {
+        write
+      } catch {
+        case e: Exception =>
+          logger.warn(
+            s"Failed to write FileList '$name', rolling back in-memory state: ${e.getMessage}"
+          )
+          _files = originalFiles
+          throw e
+      }
+      logger.warn(s"Added ${toAdd.size} files to FileList $name")
     }
-    logger.warn(s"Added ${toAdd.size} files to FileList $name")
   }
 
   /** Registers new files in the file list.
@@ -130,6 +142,8 @@ case class FileList private (
     *
     * @param fileNames
     *   one or more file paths to add
+    * @throws IllegalArgumentException
+    *   if fileNames is null or any individual file name is null or blank
     */
   def addFile(fileNames: String*): Unit = addFile(spark, fileNames: _*)
 
@@ -142,6 +156,9 @@ case class FileList private (
     *   one or more file paths to remove
     */
   def removeFile(fileNames: String*): Unit = {
+    logger.warn(
+      s"removeFile called on FileList '$name' with ${fileNames.size} file(s)"
+    )
     delta(storagePath) match {
       case Some(dt) =>
         import spark.implicits._

--- a/src/main/scala/dev/cjfravel/ariadne/Index.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/Index.scala
@@ -539,7 +539,7 @@ case class Index private (
 
   /** Updates the index with new files and backfills newly added columns. */
   def update: Unit = {
-    batchesSinceCompact = 0
+    batchesSinceCompact = metadata.batches_since_compact
     val startTime = System.currentTimeMillis()
     val lock = IndexLock(updateLockPath, name)
     val correlationId = UUID.randomUUID().toString
@@ -619,6 +619,18 @@ case class Index private (
           logger.warn(f"Recalculated total indexed file size: ${totalSize / (1024.0 * 1024.0 * 1024.0)}%.2f GB")
         }
       }
+      // Persist batch counter for cross-job auto-compaction
+      metadata.batches_since_compact = batchesSinceCompact
+      writeMetadata(metadata)
+
+      // Warn if compaction is overdue and auto-compact is not configured
+      if (autoCompactThreshold.isEmpty && batchesSinceCompact >= 50) {
+        logger.warn(
+          s"Index '$name' has accumulated $batchesSinceCompact update batches without compaction. " +
+          "Consider running index.compact() or setting spark.ariadne.autoCompactThreshold to enable auto-compaction."
+        )
+      }
+
       logger.warn(s"Update complete for index '$name' in ${System.currentTimeMillis() - startTime}ms")
     } finally {
       lock.release(correlationId)
@@ -636,6 +648,9 @@ case class Index private (
     lock.acquire(correlationId)
     try {
       compactDeltaTables()
+      batchesSinceCompact = 0
+      metadata.batches_since_compact = 0
+      writeMetadata(metadata)
       logger.warn(s"Compaction complete in ${System.currentTimeMillis() - startTime}ms")
     } finally {
       lock.release(correlationId)
@@ -924,7 +939,8 @@ object Index {
         new util.HashMap[String, String](),
         new util.ArrayList[RangeIndexConfig](),
         new util.ArrayList[String](),
-        -1L
+        -1L,
+        0
       )
     }
 

--- a/src/main/scala/dev/cjfravel/ariadne/Index.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/Index.scala
@@ -52,9 +52,13 @@ case class Index private (
     *
     * @param columns The column names to select
     * @return This Index instance for method chaining
+    * @throws IllegalArgumentException if columns is null/empty or any column is null/blank
     * @throws ColumnNotFoundException if any specified column doesn't exist in the schema
     */
   def select(columns: String*): Index = {
+    require(columns != null && columns.nonEmpty, "columns must not be null or empty")
+    require(columns.forall(c => c != null && c.trim.nonEmpty), "each column must not be null or blank")
+
     // Validate that all specified columns exist in the schema
     val invalidColumns = columns.filterNot { colName =>
       SchemaHelper.fieldExists(storedSchema, colName)
@@ -79,9 +83,14 @@ case class Index private (
 
   /** Adds files to the index's file list for future indexing.
     * Acquires a file list lock to prevent concurrent modifications.
+    *
     * @param fileNames One or more file paths to register
+    * @throws IllegalArgumentException if fileNames is null/empty or any fileName is null/blank
     */
   def addFile(fileNames: String*): Unit = {
+    require(fileNames != null && fileNames.nonEmpty, "fileNames must not be null or empty")
+    require(fileNames.forall(f => f != null && f.trim.nonEmpty), "each fileName must not be null or blank")
+    logger.warn(s"Adding ${fileNames.size} file(s) to index '$name'")
     val lock = IndexLock(fileListLockPath, name)
     val correlationId = UUID.randomUUID().toString
     lock.acquire(correlationId)
@@ -101,18 +110,19 @@ case class Index private (
   private[ariadne] def unindexedFiles(spark: SparkSession): Set[String] = {
     val files = fileList.files
     if (files.isEmpty) {
-      return Set()
-    }
-    import spark.implicits._
-    index match {
-      case Some(df) =>
-        files
-          .join(df, Seq("filename"), "left_anti")
-          .select("filename")
-          .as[String]
-          .collect()
-          .toSet
-      case None => files.select("filename").as[String].collect().toSet
+      Set.empty[String]
+    } else {
+      import spark.implicits._
+      index match {
+        case Some(df) =>
+          files
+            .join(df, Seq("filename"), "left_anti")
+            .select("filename")
+            .as[String]
+            .collect()
+            .toSet
+        case None => files.select("filename").as[String].collect().toSet
+      }
     }
   }
 
@@ -134,47 +144,63 @@ case class Index private (
           rangeStorageColumns ++ autoBloomStorageColumns
         val existingCols = df.columns.toSet - "filename"
         val missingCols = expectedCols -- existingCols
-        if (missingCols.isEmpty) return Set.empty
-        logger.warn(s"Detected new index columns not yet in index table: ${missingCols.mkString(", ")}")
-        df.select("filename").as[String].collect().toSet
+        if (missingCols.isEmpty) {
+          Set.empty[String]
+        } else {
+          logger.warn(s"Detected new index columns not yet in index table: ${missingCols.mkString(", ")}")
+          df.select("filename").as[String].collect().toSet
+        }
       case None => Set.empty
     }
   }
 
-  /** Adds an index entry.
+  /** Adds a regular (array-of-distinct-values) index for the specified column.
+    *
+    * Idempotent: calling again with the same column is a no-op.
+    *
     * @param index
-    *   The index entry to add.
-    * @throws IllegalArgumentException if column is already a bloom index
+    *   The column name to index.
+    * @throws IllegalArgumentException if the column name is null/blank or already indexed by another type
+    *   (bloom, temporal, or range)
+    * @throws ColumnNotFoundException if the column doesn't exist in the schema
     */
   def addIndex(index: String): Unit = {
-    if (metadata.indexes.contains(index)) return
-    
-    // Check mutual exclusivity with bloom indexes
-    if (metadata.bloom_indexes.asScala.exists(_.column == index)) {
-      throw new IllegalArgumentException(
-        s"Column '$index' is already a bloom index. " +
-        "A column cannot be both a regular index and a bloom index."
-      )
-    }
+    require(index != null && index.trim.nonEmpty, "index column name must not be null or blank")
 
-    // Check mutual exclusivity with temporal indexes
-    if (metadata.temporal_indexes.asScala.exists(_.column == index)) {
-      throw new IllegalArgumentException(
-        s"Column '$index' is already a temporal index. " +
-        "A column cannot be both a regular index and a temporal index."
-      )
-    }
+    if (!metadata.indexes.contains(index)) {
+      // Check mutual exclusivity with bloom indexes
+      if (metadata.bloom_indexes.asScala.exists(_.column == index)) {
+        throw new IllegalArgumentException(
+          s"Column '$index' is already a bloom index. " +
+          "A column cannot be both a regular index and a bloom index."
+        )
+      }
 
-    // Check mutual exclusivity with range indexes
-    if (metadata.range_indexes.asScala.exists(_.column == index)) {
-      throw new IllegalArgumentException(
-        s"Column '$index' is already a range index. " +
-        "A column cannot be both a regular index and a range index."
-      )
+      // Check mutual exclusivity with temporal indexes
+      if (metadata.temporal_indexes.asScala.exists(_.column == index)) {
+        throw new IllegalArgumentException(
+          s"Column '$index' is already a temporal index. " +
+          "A column cannot be both a regular index and a temporal index."
+        )
+      }
+
+      // Check mutual exclusivity with range indexes
+      if (metadata.range_indexes.asScala.exists(_.column == index)) {
+        throw new IllegalArgumentException(
+          s"Column '$index' is already a range index. " +
+          "A column cannot be both a regular index and a range index."
+        )
+      }
+
+      // Validate column exists in schema (only if schema is available)
+      if (metadata.schema != null && !SchemaHelper.fieldExists(storedSchema, index)) {
+        throw new ColumnNotFoundException(s"Column '$index' not found in schema")
+      }
+
+      metadata.indexes.add(index)
+      writeMetadata(metadata)
+      logger.warn(s"Added regular index on column '$index' for index '$name'")
     }
-    
-    metadata.indexes.add(index)
-    writeMetadata(metadata)
   }
 
   /** Adds a bloom filter index for the specified column.
@@ -186,105 +212,122 @@ case class Index private (
     *
     * @param column The column name to index with a bloom filter
     * @param fpr False positive rate between 0.0 and 1.0 (default 0.01 = 1%)
-    * @throws IllegalArgumentException if column is already a regular or computed index
+    * @throws IllegalArgumentException if column is null/blank, FPR out of range, or column is already a regular or computed index
     * @throws ColumnNotFoundException if column doesn't exist in schema
     */
   def addBloomIndex(column: String, fpr: Double = 0.01): Unit = {
+    require(column != null && column.trim.nonEmpty, "bloom index column name must not be null or blank")
     // Validate FPR range
     require(fpr > 0 && fpr < 1, s"FPR must be between 0 and 1, got: $fpr")
-    
-    // Check mutual exclusivity with regular indexes
-    if (metadata.indexes.contains(column)) {
-      throw new IllegalArgumentException(
-        s"Column '$column' is already a regular index. " +
-        "A column cannot be both a bloom index and a regular index."
-      )
+
+    if (!metadata.bloom_indexes.asScala.exists(_.column == column)) {
+      // Check mutual exclusivity with regular indexes
+      if (metadata.indexes.contains(column)) {
+        throw new IllegalArgumentException(
+          s"Column '$column' is already a regular index. " +
+          "A column cannot be both a bloom index and a regular index."
+        )
+      }
+      if (metadata.computed_indexes.containsKey(column)) {
+        throw new IllegalArgumentException(
+          s"Column '$column' is already a computed index. " +
+          "A column cannot be both a bloom index and a computed index."
+        )
+      }
+      if (metadata.temporal_indexes.asScala.exists(_.column == column)) {
+        throw new IllegalArgumentException(
+          s"Column '$column' is already a temporal index. " +
+          "A column cannot be both a bloom index and a temporal index."
+        )
+      }
+      if (metadata.range_indexes.asScala.exists(_.column == column)) {
+        throw new IllegalArgumentException(
+          s"Column '$column' is already a range index. " +
+          "A column cannot be both a bloom index and a range index."
+        )
+      }
+
+      // Validate column exists in schema (only if schema is available)
+      if (metadata.schema != null && !SchemaHelper.fieldExists(storedSchema, column)) {
+        throw new ColumnNotFoundException(s"Column '$column' not found in schema")
+      }
+
+      val config = BloomIndexConfig(column, fpr)
+      metadata.bloom_indexes.add(config)
+      writeMetadata(metadata)
+      logger.warn(s"Added bloom index for column '$column' with FPR=$fpr to index '$name'")
     }
-    if (metadata.computed_indexes.containsKey(column)) {
-      throw new IllegalArgumentException(
-        s"Column '$column' is already a computed index. " +
-        "A column cannot be both a bloom index and a computed index."
-      )
-    }
-    if (metadata.temporal_indexes.asScala.exists(_.column == column)) {
-      throw new IllegalArgumentException(
-        s"Column '$column' is already a temporal index. " +
-        "A column cannot be both a bloom index and a temporal index."
-      )
-    }
-    if (metadata.range_indexes.asScala.exists(_.column == column)) {
-      throw new IllegalArgumentException(
-        s"Column '$column' is already a range index. " +
-        "A column cannot be both a bloom index and a range index."
-      )
-    }
-    
-    // Check if already a bloom index
-    if (metadata.bloom_indexes.asScala.exists(_.column == column)) return
-    
-    // Validate column exists in schema
-    if (!SchemaHelper.fieldExists(storedSchema, column)) {
-      throw new ColumnNotFoundException(s"Column '$column' not found in schema")
-    }
-    
-    val config = BloomIndexConfig(column, fpr)
-    metadata.bloom_indexes.add(config)
-    writeMetadata(metadata)
   }
 
-  /** Adds an exploded field index entry.
+  /** Adds an exploded field index for a nested field inside an array column.
+    *
+    * During [[update]], each element of `arrayColumn` is exploded, the `fieldPath`
+    * is extracted, and the distinct values are stored under `asColumn` in the index.
+    * Joins on `asColumn` will locate files containing any matching array element.
+    * Idempotent: calling again with the same `asColumn` is a no-op.
+    *
     * @param arrayColumn
-    *   The array column to index.
+    *   The array column to explode.
     * @param fieldPath
-    *   The field path to extract from array elements (e.g., "id" or
-    *   "profile.user_id").
+    *   The dot-separated field path to extract from each array element
+    *   (e.g., "id" or "profile.user_id").
     * @param asColumn
-    *   The column name to use in joins.
+    *   The virtual column name exposed for joins.
+    * @throws IllegalArgumentException if any parameter is null/blank, or `asColumn` conflicts with another index type
     */
   def addExplodedFieldIndex(
       arrayColumn: String,
       fieldPath: String,
       asColumn: String
   ): Unit = {
-    // Idempotency check
-    if (metadata.exploded_field_indexes.asScala.exists(_.as_column == asColumn)) return
+    require(arrayColumn != null && arrayColumn.trim.nonEmpty, "arrayColumn must not be null or blank")
+    require(fieldPath != null && fieldPath.trim.nonEmpty, "fieldPath must not be null or blank")
+    require(asColumn != null && asColumn.trim.nonEmpty, "asColumn must not be null or blank")
 
-    // Mutual exclusivity checks
-    if (metadata.indexes.contains(asColumn)) {
-      throw new IllegalArgumentException(
-        s"Column '$asColumn' is already a regular index. " +
-        "A column cannot be both an exploded field index and a regular index."
-      )
-    }
-    if (metadata.computed_indexes.containsKey(asColumn)) {
-      throw new IllegalArgumentException(
-        s"Column '$asColumn' is already a computed index. " +
-        "A column cannot be both an exploded field index and a computed index."
-      )
-    }
-    if (metadata.bloom_indexes.asScala.exists(_.column == asColumn)) {
-      throw new IllegalArgumentException(
-        s"Column '$asColumn' is already a bloom index. " +
-        "A column cannot be both an exploded field index and a bloom index."
-      )
-    }
-    if (metadata.temporal_indexes.asScala.exists(_.column == asColumn)) {
-      throw new IllegalArgumentException(
-        s"Column '$asColumn' is already a temporal index. " +
-        "A column cannot be both an exploded field index and a temporal index."
-      )
-    }
-    if (metadata.range_indexes.asScala.exists(_.column == asColumn)) {
-      throw new IllegalArgumentException(
-        s"Column '$asColumn' is already a range index. " +
-        "A column cannot be both an exploded field index and a range index."
-      )
-    }
+    if (!metadata.exploded_field_indexes.asScala.exists(_.as_column == asColumn)) {
+      // Mutual exclusivity checks
+      if (metadata.indexes.contains(asColumn)) {
+        throw new IllegalArgumentException(
+          s"Column '$asColumn' is already a regular index. " +
+          "A column cannot be both an exploded field index and a regular index."
+        )
+      }
+      if (metadata.computed_indexes.containsKey(asColumn)) {
+        throw new IllegalArgumentException(
+          s"Column '$asColumn' is already a computed index. " +
+          "A column cannot be both an exploded field index and a computed index."
+        )
+      }
+      if (metadata.bloom_indexes.asScala.exists(_.column == asColumn)) {
+        throw new IllegalArgumentException(
+          s"Column '$asColumn' is already a bloom index. " +
+          "A column cannot be both an exploded field index and a bloom index."
+        )
+      }
+      if (metadata.temporal_indexes.asScala.exists(_.column == asColumn)) {
+        throw new IllegalArgumentException(
+          s"Column '$asColumn' is already a temporal index. " +
+          "A column cannot be both an exploded field index and a temporal index."
+        )
+      }
+      if (metadata.range_indexes.asScala.exists(_.column == asColumn)) {
+        throw new IllegalArgumentException(
+          s"Column '$asColumn' is already a range index. " +
+          "A column cannot be both an exploded field index and a range index."
+        )
+      }
 
-    val explodedFieldMapping =
-      ExplodedFieldMapping(arrayColumn, fieldPath, asColumn)
-    metadata.exploded_field_indexes.add(explodedFieldMapping)
-    writeMetadata(metadata)
+      // Validate array column exists in schema (only if schema is available)
+      if (metadata.schema != null && !SchemaHelper.fieldExists(storedSchema, arrayColumn)) {
+        throw new ColumnNotFoundException(s"Array column '$arrayColumn' not found in schema")
+      }
+
+      val explodedFieldMapping =
+        ExplodedFieldMapping(arrayColumn, fieldPath, asColumn)
+      metadata.exploded_field_indexes.add(explodedFieldMapping)
+      writeMetadata(metadata)
+      logger.warn(s"Added exploded field index '$asColumn' (array='$arrayColumn', path='$fieldPath') to index '$name'")
+    }
   }
 
   /** Returns all column names that can be used in joins across all index types.
@@ -303,48 +346,56 @@ case class Index private (
       metadata.range_indexes.asScala.map(_.column).toSet
 
   /** Adds a computed index derived from a SQL expression.
+    *
+    * The expression is evaluated during [[update]] to produce a virtual column
+    * whose distinct values are stored in the index. Idempotent: calling again
+    * with the same name is a no-op.
+    *
     * @param name The alias name for the computed column
-    * @param sql_expression The SQL expression to compute the column value
-    * @throws IllegalArgumentException if name conflicts with another index type
+    * @param sql_expression A Spark SQL expression evaluated against each data file
+    * @throws IllegalArgumentException if name or sql_expression is null/blank, or name conflicts with another index type
     */
   def addComputedIndex(name: String, sql_expression: String): Unit = {
-    // Idempotency check
-    if (metadata.computed_indexes.containsKey(name)) return
+    require(name != null && name.trim.nonEmpty, "computed index name must not be null or blank")
+    require(sql_expression != null && sql_expression.trim.nonEmpty, "sql_expression must not be null or blank")
 
-    // Mutual exclusivity checks
-    if (metadata.indexes.contains(name)) {
-      throw new IllegalArgumentException(
-        s"Column '$name' is already a regular index. " +
-        "A column cannot be both a computed index and a regular index."
-      )
-    }
-    if (metadata.bloom_indexes.asScala.exists(_.column == name)) {
-      throw new IllegalArgumentException(
-        s"Column '$name' is already a bloom index. " +
-        "A column cannot be both a computed index and a bloom index."
-      )
-    }
-    if (metadata.temporal_indexes.asScala.exists(_.column == name)) {
-      throw new IllegalArgumentException(
-        s"Column '$name' is already a temporal index. " +
-        "A column cannot be both a computed index and a temporal index."
-      )
-    }
-    if (metadata.range_indexes.asScala.exists(_.column == name)) {
-      throw new IllegalArgumentException(
-        s"Column '$name' is already a range index. " +
-        "A column cannot be both a computed index and a range index."
-      )
-    }
-    if (metadata.exploded_field_indexes.asScala.exists(_.as_column == name)) {
-      throw new IllegalArgumentException(
-        s"Column '$name' is already an exploded field index. " +
-        "A column cannot be both a computed index and an exploded field index."
-      )
-    }
+    if (!metadata.computed_indexes.containsKey(name)) {
+      // Mutual exclusivity checks
+      if (metadata.indexes.contains(name)) {
+        throw new IllegalArgumentException(
+          s"Column '$name' is already a regular index. " +
+          "A column cannot be both a computed index and a regular index."
+        )
+      }
+      if (metadata.bloom_indexes.asScala.exists(_.column == name)) {
+        throw new IllegalArgumentException(
+          s"Column '$name' is already a bloom index. " +
+          "A column cannot be both a computed index and a bloom index."
+        )
+      }
+      if (metadata.temporal_indexes.asScala.exists(_.column == name)) {
+        throw new IllegalArgumentException(
+          s"Column '$name' is already a temporal index. " +
+          "A column cannot be both a computed index and a temporal index."
+        )
+      }
+      if (metadata.range_indexes.asScala.exists(_.column == name)) {
+        throw new IllegalArgumentException(
+          s"Column '$name' is already a range index. " +
+          "A column cannot be both a computed index and a range index."
+        )
+      }
+      if (metadata.exploded_field_indexes.asScala.exists(_.as_column == name)) {
+        throw new IllegalArgumentException(
+          s"Column '$name' is already an exploded field index. " +
+          "A column cannot be both a computed index and an exploded field index."
+        )
+      }
 
-    metadata.computed_indexes.put(name, sql_expression)
-    writeMetadata(metadata)
+      metadata.computed_indexes.put(name, sql_expression)
+      writeMetadata(metadata)
+      logger.warn(s"Added computed index '$name' with expression to index '${this.name}'")
+    }
   }
 
   /** Adds a temporal index for the specified column using a timestamp for versioning.
@@ -355,52 +406,57 @@ case class Index private (
     *
     * @param column The value column to index on (e.g., "user_id")
     * @param timestampColumn The timestamp column for ordering versions (e.g., "updated_at")
-    * @throws IllegalArgumentException if column is already indexed by another type
+    * @throws IllegalArgumentException if column or timestampColumn is null/blank, or column is already indexed by another type
     * @throws ColumnNotFoundException if either column doesn't exist in schema
     */
   def addTemporalIndex(column: String, timestampColumn: String): Unit = {
-    // Idempotency check
-    if (metadata.temporal_indexes.asScala.exists(_.column == column)) return
+    require(column != null && column.trim.nonEmpty, "temporal index column must not be null or blank")
+    require(timestampColumn != null && timestampColumn.trim.nonEmpty, "timestampColumn must not be null or blank")
 
-    // Mutual exclusivity checks
-    if (metadata.indexes.contains(column)) {
-      throw new IllegalArgumentException(
-        s"Column '$column' is already a regular index. " +
-        "A column cannot be both a temporal index and a regular index."
-      )
-    }
-    if (metadata.computed_indexes.containsKey(column)) {
-      throw new IllegalArgumentException(
-        s"Column '$column' is already a computed index. " +
-        "A column cannot be both a temporal index and a computed index."
-      )
-    }
-    if (metadata.bloom_indexes.asScala.exists(_.column == column)) {
-      throw new IllegalArgumentException(
-        s"Column '$column' is already a bloom index. " +
-        "A column cannot be both a temporal index and a bloom index."
-      )
-    }
-    if (metadata.range_indexes.asScala.exists(_.column == column)) {
-      throw new IllegalArgumentException(
-        s"Column '$column' is already a range index. " +
-        "A column cannot be both a temporal index and a range index."
-      )
-    }
+    if (!metadata.temporal_indexes.asScala.exists(_.column == column)) {
+      // Mutual exclusivity checks
+      if (metadata.indexes.contains(column)) {
+        throw new IllegalArgumentException(
+          s"Column '$column' is already a regular index. " +
+          "A column cannot be both a temporal index and a regular index."
+        )
+      }
+      if (metadata.computed_indexes.containsKey(column)) {
+        throw new IllegalArgumentException(
+          s"Column '$column' is already a computed index. " +
+          "A column cannot be both a temporal index and a computed index."
+        )
+      }
+      if (metadata.bloom_indexes.asScala.exists(_.column == column)) {
+        throw new IllegalArgumentException(
+          s"Column '$column' is already a bloom index. " +
+          "A column cannot be both a temporal index and a bloom index."
+        )
+      }
+      if (metadata.range_indexes.asScala.exists(_.column == column)) {
+        throw new IllegalArgumentException(
+          s"Column '$column' is already a range index. " +
+          "A column cannot be both a temporal index and a range index."
+        )
+      }
 
-    // Validate both columns exist in schema
-    if (!SchemaHelper.fieldExists(storedSchema, column)) {
-      throw new ColumnNotFoundException(s"Column '$column' not found in schema")
-    }
-    if (!SchemaHelper.fieldExists(storedSchema, timestampColumn)) {
-      throw new ColumnNotFoundException(
-        s"Timestamp column '$timestampColumn' not found in schema"
-      )
-    }
+      // Validate both columns exist in schema (only if schema is available)
+      if (metadata.schema != null) {
+        if (!SchemaHelper.fieldExists(storedSchema, column)) {
+          throw new ColumnNotFoundException(s"Column '$column' not found in schema")
+        }
+        if (!SchemaHelper.fieldExists(storedSchema, timestampColumn)) {
+          throw new ColumnNotFoundException(
+            s"Timestamp column '$timestampColumn' not found in schema"
+          )
+        }
+      }
 
-    val config = TemporalIndexConfig(column, timestampColumn)
-    metadata.temporal_indexes.add(config)
-    writeMetadata(metadata)
+      val config = TemporalIndexConfig(column, timestampColumn)
+      metadata.temporal_indexes.add(config)
+      writeMetadata(metadata)
+      logger.warn(s"Added temporal index for column '$column' (timestamp='$timestampColumn') to index '$name'")
+    }
   }
 
   /** Adds a range index for the specified column.
@@ -410,47 +466,49 @@ case class Index private (
     * queried values are skipped.
     *
     * @param column The column to index with min/max range
-    * @throws IllegalArgumentException if column is already indexed by another type
+    * @throws IllegalArgumentException if column is null/blank or already indexed by another type
     * @throws ColumnNotFoundException if column doesn't exist in schema
     */
   def addRangeIndex(column: String): Unit = {
-    // Idempotency check
-    if (metadata.range_indexes.asScala.exists(_.column == column)) return
+    require(column != null && column.trim.nonEmpty, "range index column must not be null or blank")
 
-    // Mutual exclusivity checks
-    if (metadata.indexes.contains(column)) {
-      throw new IllegalArgumentException(
-        s"Column '$column' is already a regular index. " +
-        "A column cannot be both a range index and a regular index."
-      )
-    }
-    if (metadata.computed_indexes.containsKey(column)) {
-      throw new IllegalArgumentException(
-        s"Column '$column' is already a computed index. " +
-        "A column cannot be both a range index and a computed index."
-      )
-    }
-    if (metadata.bloom_indexes.asScala.exists(_.column == column)) {
-      throw new IllegalArgumentException(
-        s"Column '$column' is already a bloom index. " +
-        "A column cannot be both a range index and a bloom index."
-      )
-    }
-    if (metadata.temporal_indexes.asScala.exists(_.column == column)) {
-      throw new IllegalArgumentException(
-        s"Column '$column' is already a temporal index. " +
-        "A column cannot be both a range index and a temporal index."
-      )
-    }
+    if (!metadata.range_indexes.asScala.exists(_.column == column)) {
+      // Mutual exclusivity checks
+      if (metadata.indexes.contains(column)) {
+        throw new IllegalArgumentException(
+          s"Column '$column' is already a regular index. " +
+          "A column cannot be both a range index and a regular index."
+        )
+      }
+      if (metadata.computed_indexes.containsKey(column)) {
+        throw new IllegalArgumentException(
+          s"Column '$column' is already a computed index. " +
+          "A column cannot be both a range index and a computed index."
+        )
+      }
+      if (metadata.bloom_indexes.asScala.exists(_.column == column)) {
+        throw new IllegalArgumentException(
+          s"Column '$column' is already a bloom index. " +
+          "A column cannot be both a range index and a bloom index."
+        )
+      }
+      if (metadata.temporal_indexes.asScala.exists(_.column == column)) {
+        throw new IllegalArgumentException(
+          s"Column '$column' is already a temporal index. " +
+          "A column cannot be both a range index and a temporal index."
+        )
+      }
 
-    // Validate column exists in schema
-    if (!SchemaHelper.fieldExists(storedSchema, column)) {
-      throw new ColumnNotFoundException(s"Column '$column' not found in schema")
-    }
+      // Validate column exists in schema (only if schema is available)
+      if (metadata.schema != null && !SchemaHelper.fieldExists(storedSchema, column)) {
+        throw new ColumnNotFoundException(s"Column '$column' not found in schema")
+      }
 
-    val config = RangeIndexConfig(column)
-    metadata.range_indexes.add(config)
-    writeMetadata(metadata)
+      val config = RangeIndexConfig(column)
+      metadata.range_indexes.add(config)
+      writeMetadata(metadata)
+      logger.warn(s"Added range index for column '$column' to index '$name'")
+    }
   }
 
   /** Deletes the specified files from the index, large index tables, and file list.
@@ -463,14 +521,13 @@ case class Index private (
     *   One or more filenames to remove from the index.
     */
   def deleteFiles(filenames: String*): Unit = {
-    if (filenames.isEmpty) return
-
-    val startTime = System.currentTimeMillis()
-    logger.warn(s"Deleting ${filenames.size} file(s) from index '$name'")
-    val lock = IndexLock(updateLockPath, name)
-    val correlationId = UUID.randomUUID().toString
-    lock.acquire(correlationId)
-    try {
+    if (filenames.nonEmpty) {
+      val startTime = System.currentTimeMillis()
+      logger.warn(s"Deleting ${filenames.size} file(s) from index '$name'")
+      val lock = IndexLock(updateLockPath, name)
+      val correlationId = UUID.randomUUID().toString
+      lock.acquire(correlationId)
+      try {
       import spark.implicits._
       val toDelete = filenames.toDF("filename")
 
@@ -534,6 +591,7 @@ case class Index private (
       logger.warn(s"Successfully deleted ${filenames.size} file(s) from index '$name' in ${System.currentTimeMillis() - startTime}ms")
     } finally {
       lock.release(correlationId)
+    }
     }
   }
 
@@ -810,8 +868,13 @@ case class Index private (
 }
 
 /** Companion object for the Index class.
+  *
+  * Provides factory methods for creating or reconnecting to indexes, as well as
+  * utility methods for checking existence and removing indexes.
   */
 object Index {
+  private val logger: Logger = LogManager.getLogger("ariadne")
+
   /** Returns the file list name for an index.
     * @param name The index name
     * @return The file list identifier
@@ -901,19 +964,30 @@ object Index {
     Some(readOptions)
   )
 
-  /** Factory method to create an Index instance.
+  /** Primary factory method to create or reconnect to an Index instance.
+    *
+    * If metadata exists at the storage path, reconnects to the existing index and validates
+    * schema/format compatibility. If metadata does not exist, creates a new index with the
+    * provided schema and format.
+    *
     * @param name
-    *   The name of the index.
+    *   Unique index name (must be a valid Hadoop path component).
     * @param schema
-    *   The optional schema.
+    *   Optional Spark schema of the data files. Required for new indexes.
     * @param format
-    *   The optional format.
+    *   Optional data file format (e.g., "parquet", "csv"). Required for new indexes.
     * @param allowSchemaMismatch
-    *   The optional flag to allow new schema.
+    *   When true and metadata exists, allows updating the stored schema. Validates that all
+    *   existing index columns still exist in the new schema before applying the change.
     * @param readOptions
-    *   Optional map of read options for format-specific configuration.
+    *   Optional map of read options for format-specific configuration (e.g., CSV delimiter).
     * @return
-    *   An Index instance.
+    *   A fully initialized Index instance.
+    * @throws SchemaMismatchException if schema differs and allowSchemaMismatch is false
+    * @throws FormatMismatchException if format differs from stored format
+    * @throws SchemaNotProvidedException if creating a new index without a schema
+    * @throws MissingFormatException if creating a new index without a format
+    * @throws IndexNotFoundInNewSchemaException if allowSchemaMismatch is true but an indexed column is missing
     */
   def apply(
       name: String,
@@ -925,6 +999,7 @@ object Index {
     val index = Index(name, schema)(spark)
 
     val metadataExists = index.metadataExists
+    logger.warn(s"Index '$name': ${if (metadataExists) "reconnecting" else "creating new"}")
     val metadata = if (metadataExists) {
       index.metadata
     } else {
@@ -950,11 +1025,11 @@ object Index {
           if (allowSchemaMismatch) {
             if (metadata.schema != s.json) {
               // Validate regular indexes
-              metadata.indexes.forEach(col => {
+              metadata.indexes.asScala.foreach { col =>
                 if (!SchemaHelper.fieldExists(s, col)) {
                   throw new IndexNotFoundInNewSchemaException(col)
                 }
-              })
+              }
               // Validate bloom indexes
               metadata.bloom_indexes.asScala.foreach { bi =>
                 if (!SchemaHelper.fieldExists(s, bi.column)) {
@@ -982,6 +1057,7 @@ object Index {
                 // We validate the output column name exists conceptually but
                 // cannot validate the expression references without executing it
               }
+              logger.warn(s"Index '$name': schema evolved (allowSchemaMismatch=true)")
             }
             metadata.schema = s.json
           } else if (metadata.schema != s.json) {
@@ -1036,6 +1112,12 @@ object Index {
     * This provides the reverse join direction compared to [[Index.join]]:
     * the driving DataFrame is on the left and the index-located data is on the right.
     *
+    * Usage:
+    * {{{
+    * import dev.cjfravel.ariadne.Index.DataFrameOps
+    * val result = myDataFrame.join(index, Seq("user_id"), "inner")
+    * }}}
+    *
     * @param df The DataFrame to enrich with implicit join capability
     */
   implicit class DataFrameOps(df: DataFrame) {
@@ -1056,6 +1138,7 @@ object Index {
         usingColumns: Seq[String],
         joinType: String = "inner"
     ): DataFrame = {
+      logger.warn(s"DataFrameOps.join: $joinType join on columns ${usingColumns.mkString(", ")} against index '${index.name}'")
       val indexDf = index.joinDf(df, usingColumns)
       df.join(indexDf, usingColumns, joinType)
     }

--- a/src/main/scala/dev/cjfravel/ariadne/Index.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/Index.scala
@@ -238,8 +238,40 @@ case class Index private (
       fieldPath: String,
       asColumn: String
   ): Unit = {
-    // Check if this asColumn is already used
-    if (indexes.contains(asColumn)) return
+    // Idempotency check
+    if (metadata.exploded_field_indexes.asScala.exists(_.as_column == asColumn)) return
+
+    // Mutual exclusivity checks
+    if (metadata.indexes.contains(asColumn)) {
+      throw new IllegalArgumentException(
+        s"Column '$asColumn' is already a regular index. " +
+        "A column cannot be both an exploded field index and a regular index."
+      )
+    }
+    if (metadata.computed_indexes.containsKey(asColumn)) {
+      throw new IllegalArgumentException(
+        s"Column '$asColumn' is already a computed index. " +
+        "A column cannot be both an exploded field index and a computed index."
+      )
+    }
+    if (metadata.bloom_indexes.asScala.exists(_.column == asColumn)) {
+      throw new IllegalArgumentException(
+        s"Column '$asColumn' is already a bloom index. " +
+        "A column cannot be both an exploded field index and a bloom index."
+      )
+    }
+    if (metadata.temporal_indexes.asScala.exists(_.column == asColumn)) {
+      throw new IllegalArgumentException(
+        s"Column '$asColumn' is already a temporal index. " +
+        "A column cannot be both an exploded field index and a temporal index."
+      )
+    }
+    if (metadata.range_indexes.asScala.exists(_.column == asColumn)) {
+      throw new IllegalArgumentException(
+        s"Column '$asColumn' is already a range index. " +
+        "A column cannot be both an exploded field index and a range index."
+      )
+    }
 
     val explodedFieldMapping =
       ExplodedFieldMapping(arrayColumn, fieldPath, asColumn)
@@ -261,7 +293,41 @@ case class Index private (
       metadata.range_indexes.asScala.map(_.column).toSet
 
   def addComputedIndex(name: String, sql_expression: String): Unit = {
+    // Idempotency check
     if (metadata.computed_indexes.containsKey(name)) return
+
+    // Mutual exclusivity checks
+    if (metadata.indexes.contains(name)) {
+      throw new IllegalArgumentException(
+        s"Column '$name' is already a regular index. " +
+        "A column cannot be both a computed index and a regular index."
+      )
+    }
+    if (metadata.bloom_indexes.asScala.exists(_.column == name)) {
+      throw new IllegalArgumentException(
+        s"Column '$name' is already a bloom index. " +
+        "A column cannot be both a computed index and a bloom index."
+      )
+    }
+    if (metadata.temporal_indexes.asScala.exists(_.column == name)) {
+      throw new IllegalArgumentException(
+        s"Column '$name' is already a temporal index. " +
+        "A column cannot be both a computed index and a temporal index."
+      )
+    }
+    if (metadata.range_indexes.asScala.exists(_.column == name)) {
+      throw new IllegalArgumentException(
+        s"Column '$name' is already a range index. " +
+        "A column cannot be both a computed index and a range index."
+      )
+    }
+    if (metadata.exploded_field_indexes.asScala.exists(_.as_column == name)) {
+      throw new IllegalArgumentException(
+        s"Column '$name' is already an exploded field index. " +
+        "A column cannot be both a computed index and an exploded field index."
+      )
+    }
+
     metadata.computed_indexes.put(name, sql_expression)
     writeMetadata(metadata)
   }
@@ -450,7 +516,7 @@ case class Index private (
 
       // Remove from file list
       fileList.removeFile(filenames: _*)
-      logger.warn(s"deleteFiles completed in ${System.currentTimeMillis() - startTime}ms")
+      logger.warn(s"Successfully deleted ${filenames.size} file(s) from index '$name' in ${System.currentTimeMillis() - startTime}ms")
     } finally {
       lock.release(correlationId)
     }
@@ -458,6 +524,7 @@ case class Index private (
 
   /** Updates the index with new files and backfills newly added columns. */
   def update: Unit = {
+    val startTime = System.currentTimeMillis()
     val lock = IndexLock(updateLockPath, name)
     val correlationId = UUID.randomUUID().toString
     lock.acquire(correlationId)
@@ -515,8 +582,8 @@ case class Index private (
         updateBatched(needsColumnUpdate, lock, correlationId, isBackfill = true)
       }
       val unindexed = unindexedFiles
+      logger.warn(s"Found ${unindexed.size} unindexed file(s) for index '$name'")
       if (unindexed.nonEmpty) {
-        logger.warn(s"Updating index for ${unindexed.size} files")
         updateBatched(unindexed, lock, correlationId, isBackfill = false)
       }
 
@@ -534,6 +601,7 @@ case class Index private (
           logger.warn(f"Recalculated total indexed file size: ${totalSize / (1024.0 * 1024.0 * 1024.0)}%.2f GB")
         }
       }
+      logger.warn(s"Update complete for index '$name' in ${System.currentTimeMillis() - startTime}ms")
     } finally {
       lock.release(correlationId)
     }

--- a/src/main/scala/dev/cjfravel/ariadne/Index.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/Index.scala
@@ -82,7 +82,9 @@ case class Index private (
     this
   }
 
-  /** Gets the currently selected columns for reading. */
+  /** Gets the currently selected columns for reading.
+    * @return the selected columns, or None if no column selection has been applied
+    */
   private[ariadne] def getSelectedColumns: Option[Seq[String]] = selectedColumns
 
   /** Checks if a file is tracked by this index's file list.
@@ -106,6 +108,7 @@ case class Index private (
   def addFile(fileNames: String*): Unit = {
     require(fileNames != null && fileNames.nonEmpty, "fileNames must not be null or empty")
     require(fileNames.forall(f => f != null && f.trim.nonEmpty), "each fileName must not be null or blank")
+    val startTime = System.currentTimeMillis()
     logger.warn(s"Adding ${fileNames.size} file(s) to index '$name'")
     val lock = IndexLock(fileListLockPath, name)
     val correlationId = UUID.randomUUID().toString
@@ -115,16 +118,30 @@ case class Index private (
     } finally {
       lock.release(correlationId)
     }
+    logger.warn(s"Added ${fileNames.size} file(s) to index '$name' in ${System.currentTimeMillis() - startTime}ms")
   }
 
-  /** Helper function to get a list of files that haven't yet been indexed
+  /** Returns file paths registered via [[addFile]] that have not yet been indexed.
+    *
+    * Delegates to [[unindexedFiles(spark:org\.apache\.spark\.sql\.SparkSession)* unindexedFiles(SparkSession)]].
     *
     * @note This method calls `collect()` on the driver, which can cause OOM
     *       if the number of unindexed files is very large.
-    * @return
-    *   Set of filenames
+    * @return Set[String] of file paths not yet present in the index
     */
   private[ariadne] def unindexedFiles: Set[String] = unindexedFiles(spark)
+
+  /** Returns file paths registered via [[addFile]] that have not yet been indexed,
+    * using the provided SparkSession for implicit conversions.
+    *
+    * Performs a `left_anti` join between the file list and the existing index table
+    * to identify files that still need to be processed.
+    *
+    * @note This method calls `collect()` on the driver, which can cause OOM
+    *       if the number of unindexed files is very large.
+    * @param spark The SparkSession to use for implicit conversions
+    * @return Set[String] of file paths not yet present in the index
+    */
   private[ariadne] def unindexedFiles(spark: SparkSession): Set[String] = {
     val files = fileList.files
     if (files.isEmpty) {
@@ -150,8 +167,7 @@ case class Index private (
     * Delta index table schema. If any metadata columns are missing from the table,
     * all indexed files need to be re-processed for the new columns.
     *
-    * @return
-    *   Set of filenames needing column backfill
+    * @return Set[String] of filenames needing column backfill, empty if no backfill needed
     */
   private[ariadne] def filesNeedingColumnUpdate: Set[String] = {
     import spark.implicits._
@@ -226,6 +242,7 @@ case class Index private (
       writeMetadata(metadata)
       logger.warn(s"Added regular index on column '$index' for index '$name'")
     }
+    logger.debug(s"addIndex completed for column '$index' on index '$name'")
   }
 
   /** Adds a bloom filter index for the specified column.
@@ -289,6 +306,7 @@ case class Index private (
       writeMetadata(metadata)
       logger.warn(s"Added bloom index for column '$column' with FPR=$fpr to index '$name'")
     }
+    logger.debug(s"addBloomIndex completed for column '$column' on index '$name'")
   }
 
   /** Adds an exploded field index for a nested field inside an array column.
@@ -379,6 +397,7 @@ case class Index private (
       writeMetadata(metadata)
       logger.warn(s"Added exploded field index '$asColumn' (array='$arrayColumn', path='$fieldPath') to index '$name'")
     }
+    logger.debug(s"addExplodedFieldIndex completed for column '$asColumn' on index '$name'")
   }
 
   /** Returns all column names that can be used in joins across all index types.
@@ -453,6 +472,7 @@ case class Index private (
       writeMetadata(metadata)
       logger.warn(s"Added computed index '$name' with expression to index '${this.name}'")
     }
+    logger.debug(s"addComputedIndex completed for column '$name' on index '${this.name}'")
   }
 
   /** Adds a temporal index for the specified column using a timestamp for versioning.
@@ -520,6 +540,7 @@ case class Index private (
       writeMetadata(metadata)
       logger.warn(s"Added temporal index for column '$column' (timestamp='$timestampColumn') to index '$name'")
     }
+    logger.debug(s"addTemporalIndex completed for column '$column' on index '$name'")
   }
 
   /** Adds a range index for the specified column.
@@ -578,6 +599,7 @@ case class Index private (
       writeMetadata(metadata)
       logger.warn(s"Added range index for column '$column' to index '$name'")
     }
+    logger.debug(s"addRangeIndex completed for column '$column' on index '$name'")
   }
 
   /** Deletes the specified files from the index, large index tables, and file list.
@@ -864,6 +886,8 @@ case class Index private (
     * @param files Set of files to process
     * @param lock The update lock to refresh during processing
     * @param correlationId The correlation ID for lock refresh
+    * @param isBackfill When true, indicates this is a column backfill rather than new file indexing;
+    *                   file sizes will not be re-counted toward the total
     */
   private def updateBatched(files: Set[String], lock: IndexLock, correlationId: String, isBackfill: Boolean = false): Unit = {
     val updateBatchedStart = System.currentTimeMillis()
@@ -915,6 +939,8 @@ case class Index private (
   /** Updates the index with a single batch of files.
     *
     * @param files Set of files to process in this batch
+    * @param isBackfill When true, indicates this is a column backfill rather than new file indexing;
+    *                   file sizes will not be re-counted toward the total
     */
   private def updateSingleBatch(files: Set[String], isBackfill: Boolean = false): Unit = {
     val singleBatchStart = System.currentTimeMillis()

--- a/src/main/scala/dev/cjfravel/ariadne/Index.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/Index.scala
@@ -288,7 +288,11 @@ case class Index private (
   }
 
   /** Returns all column names that can be used in joins across all index types.
-    * @return Set of joinable column names (regular, computed, exploded, bloom, temporal, range)
+    *
+    * Includes regular, computed, exploded field, bloom, temporal, and range
+    * index columns.
+    *
+    * @return Set of all joinable column names
     */
   def indexes: Set[String] =
     metadata.indexes.asScala.toSet ++
@@ -535,6 +539,7 @@ case class Index private (
 
   /** Updates the index with new files and backfills newly added columns. */
   def update: Unit = {
+    batchesSinceCompact = 0
     val startTime = System.currentTimeMillis()
     val lock = IndexLock(updateLockPath, name)
     val correlationId = UUID.randomUUID().toString
@@ -661,6 +666,7 @@ case class Index private (
     * @param correlationId The correlation ID for lock refresh
     */
   private def updateBatched(files: Set[String], lock: IndexLock, correlationId: String, isBackfill: Boolean = false): Unit = {
+    val updateBatchedStart = System.currentTimeMillis()
     logger.warn(s"Using intelligent batched update for ${files.size} files")
 
     // Perform pre-flight analysis to determine optimal batching
@@ -673,8 +679,10 @@ case class Index private (
     var batchesSinceRefresh = 0
 
     batches.zipWithIndex.foreach { case (batch, idx) =>
+      val batchStart = System.currentTimeMillis()
       logger.warn(s"Processing batch ${idx + 1}/${batches.size} with ${batch.size} files")
       updateSingleBatch(batch, isBackfill)
+      logger.warn(s"Batch ${idx + 1}/${batches.size} completed in ${System.currentTimeMillis() - batchStart}ms")
       batchesSinceConsolidation += 1
       batchesSinceRefresh += 1
       batchesSinceCompact += 1
@@ -701,7 +709,7 @@ case class Index private (
       maybeAutoCompact()
     }
 
-    logger.warn(s"Completed batched update of ${files.size} files in ${batches.size} batches")
+    logger.warn(s"Completed batched update of ${files.size} files in ${batches.size} batches in ${System.currentTimeMillis() - updateBatchedStart}ms")
   }
 
   /** Updates the index with a single batch of files.
@@ -709,6 +717,8 @@ case class Index private (
     * @param files Set of files to process in this batch
     */
   private def updateSingleBatch(files: Set[String], isBackfill: Boolean = false): Unit = {
+    val singleBatchStart = System.currentTimeMillis()
+    logger.warn(s"Processing single batch of ${files.size} files")
     val baseDf = createBaseDataFrame(files)
     val withComputedIndexes = applyComputedIndexes(baseDf)
     val withFilename = addFilenameColumn(withComputedIndexes, files)
@@ -780,6 +790,7 @@ case class Index private (
 
     // Persist any metadata changes (e.g., auto-bloom column detection) after data is safely staged
     writeMetadata(metadata)
+    logger.warn(s"Single batch of ${files.size} files completed in ${System.currentTimeMillis() - singleBatchStart}ms")
   }
 }
 
@@ -805,15 +816,13 @@ object Index {
     */
   def remove(name: String)(implicit spark: SparkSession): Boolean = IndexPathUtils.remove(name)
 
-  /** Factory method to create an Index instance.
-    * @param name
-    *   The name of the index.
-    * @param schema
-    *   The schema.
-    * @param format
-    *   The format.
-    * @return
-    *   An Index instance.
+  /** Convenience factory: creates or reconnects with schema, format, and no schema mismatch.
+    *
+    * @param name   Unique index name
+    * @param schema Spark schema of the data files
+    * @param format Data file format (e.g., "parquet")
+    * @return A fully initialized Index instance
+    * @see [[apply(name:String,schema:Option[StructType],format:Option[String],allowSchemaMismatch:Boolean,readOptions:Option[Map[String,String]])*]]
     */
   def apply(
       name: String,
@@ -821,17 +830,14 @@ object Index {
       format: String
   )(implicit spark: SparkSession): Index = apply(name, Some(schema), Some(format), false)
 
-  /** Factory method to create an Index instance.
-    * @param name
-    *   The name of the index.
-    * @param schema
-    *   The schema.
-    * @param format
-    *   The format.
-    * @param allowSchemaMismatch
-    *   The allows schema to be a mismatch.
-    * @return
-    *   An Index instance.
+  /** Convenience factory: creates or reconnects with optional schema mismatch tolerance.
+    *
+    * @param name               Unique index name
+    * @param schema             Spark schema of the data files
+    * @param format             Data file format (e.g., "parquet")
+    * @param allowSchemaMismatch When true, allows updating the stored schema
+    * @return A fully initialized Index instance
+    * @see [[apply(name:String,schema:Option[StructType],format:Option[String],allowSchemaMismatch:Boolean,readOptions:Option[Map[String,String]])*]]
     */
   def apply(
       name: String,
@@ -840,17 +846,14 @@ object Index {
       allowSchemaMismatch: Boolean
   )(implicit spark: SparkSession): Index = apply(name, Some(schema), Some(format), allowSchemaMismatch)
 
-  /** Factory method to create an Index instance with read options.
-    * @param name
-    *   The name of the index.
-    * @param schema
-    *   The schema.
-    * @param format
-    *   The format.
-    * @param readOptions
-    *   Map of read options for format-specific configuration.
-    * @return
-    *   An Index instance.
+  /** Convenience factory: creates or reconnects with read options.
+    *
+    * @param name        Unique index name
+    * @param schema      Spark schema of the data files
+    * @param format      Data file format (e.g., "parquet")
+    * @param readOptions Format-specific read options (e.g., CSV delimiter)
+    * @return A fully initialized Index instance
+    * @see [[apply(name:String,schema:Option[StructType],format:Option[String],allowSchemaMismatch:Boolean,readOptions:Option[Map[String,String]])*]]
     */
   def apply(
       name: String,
@@ -859,19 +862,15 @@ object Index {
       readOptions: Map[String, String]
   )(implicit spark: SparkSession): Index = apply(name, Some(schema), Some(format), false, Some(readOptions))
 
-  /** Factory method to create an Index instance with read options.
-    * @param name
-    *   The name of the index.
-    * @param schema
-    *   The schema.
-    * @param format
-    *   The format.
-    * @param allowSchemaMismatch
-    *   The allows schema to be a mismatch.
-    * @param readOptions
-    *   Map of read options for format-specific configuration.
-    * @return
-    *   An Index instance.
+  /** Convenience factory: creates or reconnects with schema mismatch tolerance and read options.
+    *
+    * @param name               Unique index name
+    * @param schema             Spark schema of the data files
+    * @param format             Data file format (e.g., "parquet")
+    * @param allowSchemaMismatch When true, allows updating the stored schema
+    * @param readOptions        Format-specific read options (e.g., CSV delimiter)
+    * @return A fully initialized Index instance
+    * @see [[apply(name:String,schema:Option[StructType],format:Option[String],allowSchemaMismatch:Boolean,readOptions:Option[Map[String,String]])*]]
     */
   def apply(
       name: String,
@@ -1000,13 +999,11 @@ object Index {
       case Some(options) =>
         if (metadataExists) {
           // Merge with existing options, with new options taking precedence
-          import collection.JavaConverters._
           options.foreach { case (key, value) =>
             metadata.read_options.put(key, value)
           }
         } else {
           // Set initial options
-          import collection.JavaConverters._
           options.foreach { case (key, value) =>
             metadata.read_options.put(key, value)
           }
@@ -1018,20 +1015,25 @@ object Index {
     index
   }
 
-  /** Implicit class enabling DataFrame-to-Index join syntax.
-    * Allows calling df.join(index, columns, joinType) directly.
+  /** Implicit enrichment enabling `df.join(index, columns, joinType)` syntax.
+    *
+    * This provides the reverse join direction compared to [[Index.join]]:
+    * the driving DataFrame is on the left and the index-located data is on the right.
+    *
+    * @param df The DataFrame to enrich with implicit join capability
     */
   implicit class DataFrameOps(df: DataFrame) {
 
-    /** Joins the DataFrame with an Index.
-      * @param index
-      *   The Index instance.
-      * @param usingColumns
-      *   The columns to use for the join.
-      * @param joinType
-      *   The type of join (default is "inner").
-      * @return
-      *   The joined DataFrame.
+    /** Joins this DataFrame with the data files identified by the Index.
+      *
+      * Locates relevant data files via the index, reads them, applies temporal
+      * deduplication if configured, and joins the result with this DataFrame.
+      *
+      * @param index       The Index instance to join against
+      * @param usingColumns Column names to join on (must be indexed columns)
+      * @param joinType    Spark join type: "inner", "left_outer", etc. (default "inner")
+      * @return The joined DataFrame
+      * @throws ColumnNotFoundException if join columns are not in the schema or indexes
       */
     def join(
         index: Index,

--- a/src/main/scala/dev/cjfravel/ariadne/Index.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/Index.scala
@@ -52,6 +52,13 @@ case class Index private (
 
   /** Selects specific columns for optimized reading.
     *
+    * When set, only the selected columns (plus any join columns) are read from
+    * data files, reducing I/O. Returns this Index for method chaining.
+    *
+    * @example
+    * {{{
+    * val result = index.select("name", "email").join(df, Seq("userId"))
+    * }}}
     *
     * @param columns The column names to select
     * @return This Index instance for method chaining
@@ -86,6 +93,12 @@ case class Index private (
 
   /** Adds files to the index's file list for future indexing.
     * Acquires a file list lock to prevent concurrent modifications.
+    *
+    * @example
+    * {{{
+    * index.addFile("/data/events/2024-01-01.parquet")
+    * index.addFile("/data/events/2024-01-02.parquet", "/data/events/2024-01-03.parquet")
+    * }}}
     *
     * @param fileNames One or more file paths to register
     * @throws IllegalArgumentException if fileNames is null/empty or any fileName is null/blank
@@ -163,6 +176,12 @@ case class Index private (
     *
     * Idempotent: calling again with the same column is a no-op.
     *
+    * @example
+    * {{{
+    * val index = Index("myIndex", schema, "parquet")
+    * index.addIndex("userId")
+    * }}}
+    *
     * @param index
     *   The column name to index.
     * @throws IllegalArgumentException if the column name is null/blank or already indexed by another type
@@ -215,6 +234,12 @@ case class Index private (
     * - Guaranteed NO false negatives (if filter says "no", value definitely absent)
     * - Configurable false positive rate (if filter says "yes", value MIGHT be present)
     * - Space-efficient storage (approximately 10 bits per element at 1% FPR)
+    *
+    * @example
+    * {{{
+    * index.addBloomIndex("sessionId")
+    * index.addBloomIndex("ipAddress", 0.001)
+    * }}}
     *
     * @param column The column name to index with a bloom filter
     * @param fpr False positive rate between 0.0 and 1.0 (default 0.01 = 1%)
@@ -272,6 +297,12 @@ case class Index private (
     * is extracted, and the distinct values are stored under `asColumn` in the index.
     * Joins on `asColumn` will locate files containing any matching array element.
     * Idempotent: calling again with the same `asColumn` is a no-op.
+    *
+    * @example
+    * {{{
+    * // Index the "id" field from each element of the "items" array column
+    * index.addExplodedFieldIndex("items", "id", "item_id")
+    * }}}
     *
     * @param arrayColumn
     *   The array column to explode.
@@ -343,7 +374,7 @@ case class Index private (
     * Includes regular, computed, exploded field, bloom, temporal, and range
     * index columns.
     *
-    * @return Set of all joinable column names
+    * @return the union of all indexed column names across every index type
     */
   def indexes: Set[String] =
     metadata.indexes.asScala.toSet ++
@@ -358,6 +389,11 @@ case class Index private (
     * The expression is evaluated during [[update]] to produce a virtual column
     * whose distinct values are stored in the index. Idempotent: calling again
     * with the same name is a no-op.
+    *
+    * @example
+    * {{{
+    * index.addComputedIndex("yearMonth", "date_format(event_date, 'yyyy-MM')")
+    * }}}
     *
     * @param name The alias name for the computed column
     * @param sql_expression A Spark SQL expression evaluated against each data file
@@ -412,6 +448,11 @@ case class Index private (
     * When joining on a temporal index column, only the latest version (by timestamp)
     * of each value is returned. This is useful when multiple files contain the same
     * entity at different points in time.
+    *
+    * @example
+    * {{{
+    * index.addTemporalIndex("userId", "updated_at")
+    * }}}
     *
     * @param column The value column to index on (e.g., "user_id")
     * @param timestampColumn The timestamp column for ordering versions (e.g., "updated_at")
@@ -475,6 +516,11 @@ case class Index private (
     * query time. Files whose [min, max] range does not overlap with the
     * queried values are skipped.
     *
+    * @example
+    * {{{
+    * index.addRangeIndex("timestamp")
+    * }}}
+    *
     * @param column The column to index with min/max range
     * @throws IllegalArgumentException if column is null/blank or already indexed by another type
     * @throws ColumnNotFoundException if column doesn't exist in schema
@@ -528,8 +574,16 @@ case class Index private (
     * all large index Delta tables, and the FileList. If a filename doesn't exist
     * in the index, it is silently ignored.
     *
+    * @example
+    * {{{
+    * index.deleteFiles("/data/events/2024-01-01.parquet")
+    * index.deleteFiles("/data/old1.parquet", "/data/old2.parquet")
+    * }}}
+    *
     * @param filenames
     *   One or more filenames to remove from the index.
+    * @throws IllegalArgumentException if filenames is null/empty or contains null/blank entries
+    * @throws IndexLockException if the update lock cannot be acquired within the configured timeout
     */
   def deleteFiles(filenames: String*): Unit = {
     require(filenames != null && filenames.nonEmpty, "filenames must not be null or empty")
@@ -610,7 +664,22 @@ case class Index private (
     }
   }
 
-  /** Updates the index with new files and backfills newly added columns. */
+  /** Updates the index with new files and backfills newly added columns.
+    *
+    * Processes all unindexed files registered via [[addFile]], using intelligent
+    * batching based on pre-flight analysis. Also backfills existing files when
+    * new index columns have been added since the last update.
+    *
+    * @example
+    * {{{
+    * val index = Index("myIndex", schema, "parquet")
+    * index.addIndex("userId")
+    * index.addFile("/data/events/2024-01-01.parquet")
+    * index.update
+    * }}}
+    *
+    * @throws IndexLockException if the update lock cannot be acquired within the configured timeout
+    */
   def update: Unit = {
     logger.warn(s"Starting index update for '$name'")
     batchesSinceCompact = metadata.batches_since_compact
@@ -717,6 +786,13 @@ case class Index private (
 
   /** Compacts all Delta tables belonging to this index using OPTIMIZE.
     * Acquires the update lock to prevent concurrent modifications.
+    *
+    * @example
+    * {{{
+    * index.compact()
+    * }}}
+    *
+    * @throws IndexLockException if the update lock cannot be acquired within the configured timeout
     */
   def compact(): Unit = {
     val startTime = System.currentTimeMillis()
@@ -742,7 +818,14 @@ case class Index private (
   /** Vacuums all Delta tables belonging to this index to remove old files.
     * Acquires the update lock to prevent concurrent modifications.
     *
+    * @example
+    * {{{
+    * index.vacuum()          // default 7 days retention
+    * index.vacuum(24)        // 1 day retention
+    * }}}
+    *
     * @param retentionHours number of hours of history to retain (default 168 = 7 days)
+    * @throws IndexLockException if the update lock cannot be acquired within the configured timeout
     */
   def vacuum(retentionHours: Int = 168): Unit = {
     val startTime = System.currentTimeMillis()
@@ -899,7 +982,15 @@ case class Index private (
 
   /** Joins the indexed data with the provided DataFrame.
     *
-    * Validates inputs then delegates to the inherited join implementation.
+    * Locates relevant data files via the index, reads them, applies temporal
+    * deduplication if configured, and joins the result with the provided DataFrame.
+    *
+    * @example
+    * {{{
+    * val lookupDf = spark.read.parquet("/data/lookups")
+    * val result = index.join(lookupDf, Seq("userId"))
+    * val leftResult = index.join(lookupDf, Seq("userId"), "left_outer")
+    * }}}
     *
     * @param df The DataFrame to join against indexed data
     * @param usingColumns The column names to join on (must be indexed columns)
@@ -1190,6 +1281,7 @@ object Index {
         usingColumns: Seq[String],
         joinType: String = "inner"
     ): DataFrame = {
+      require(index != null, "index must not be null")
       require(usingColumns != null && usingColumns.nonEmpty, "usingColumns must not be null or empty")
       logger.warn(s"DataFrameOps.join: $joinType join on columns ${usingColumns.mkString(", ")} against index '${index.name}'")
       val indexDf = index.joinDf(df, usingColumns)

--- a/src/main/scala/dev/cjfravel/ariadne/Index.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/Index.scala
@@ -71,8 +71,16 @@ case class Index private (
   /** Gets the currently selected columns for reading. */
   private[ariadne] def getSelectedColumns: Option[Seq[String]] = selectedColumns
 
+  /** Checks if a file is tracked by this index's file list.
+    * @param fileName The file path to check
+    * @return true if the file is in the file list
+    */
   def hasFile(fileName: String): Boolean = fileList.hasFile(fileName)
 
+  /** Adds files to the index's file list for future indexing.
+    * Acquires a file list lock to prevent concurrent modifications.
+    * @param fileNames One or more file paths to register
+    */
   def addFile(fileNames: String*): Unit = {
     val lock = IndexLock(fileListLockPath, name)
     val correlationId = UUID.randomUUID().toString
@@ -279,10 +287,8 @@ case class Index private (
     writeMetadata(metadata)
   }
 
-  /** Helper function to get all index column names that can be used in joins.
-    *
-    * @return
-    *   Set of all column names that can be used in joins
+  /** Returns all column names that can be used in joins across all index types.
+    * @return Set of joinable column names (regular, computed, exploded, bloom, temporal, range)
     */
   def indexes: Set[String] =
     metadata.indexes.asScala.toSet ++
@@ -292,6 +298,11 @@ case class Index private (
       metadata.temporal_indexes.asScala.map(_.column).toSet ++
       metadata.range_indexes.asScala.map(_.column).toSet
 
+  /** Adds a computed index derived from a SQL expression.
+    * @param name The alias name for the computed column
+    * @param sql_expression The SQL expression to compute the column value
+    * @throws IllegalArgumentException if name conflicts with another index type
+    */
   def addComputedIndex(name: String, sql_expression: String): Unit = {
     // Idempotency check
     if (metadata.computed_indexes.containsKey(name)) return
@@ -542,33 +553,35 @@ case class Index private (
             logger.warn(s"Backfilling file sizes for ${nullSizeFiles.size} files")
             val sizes = getFileSizes(nullSizeFiles)
             val sizesBroadcast = spark.sparkContext.broadcast(sizes)
-            val sizeUdf = udf((filename: String) => sizesBroadcast.value.getOrElse(filename, 0L))
-
-            import spark.implicits._
-            val updateDf = nullSizeFiles.toSeq.toDF("filename")
-              .withColumn("file_size", sizeUdf(col("filename")))
-
-            val previousAutoMerge = spark.conf.getOption("spark.databricks.delta.schema.autoMerge.enabled")
-            spark.conf.set("spark.databricks.delta.schema.autoMerge.enabled", "true")
             try {
-              dt.as("target")
-                .merge(updateDf.as("source"), "target.filename = source.filename")
-                .whenMatched()
-                .update(Map("file_size" -> col("source.file_size")))
-                .execute()
-            } finally {
-              previousAutoMerge match {
-                case Some(v) => spark.conf.set("spark.databricks.delta.schema.autoMerge.enabled", v)
-                case None => spark.conf.unset("spark.databricks.delta.schema.autoMerge.enabled")
+              val sizeUdf = udf((filename: String) => sizesBroadcast.value.getOrElse(filename, 0L))
+
+              import spark.implicits._
+              val updateDf = nullSizeFiles.toSeq.toDF("filename")
+                .withColumn("file_size", sizeUdf(col("filename")))
+
+              val previousAutoMerge = spark.conf.getOption("spark.databricks.delta.schema.autoMerge.enabled")
+              spark.conf.set("spark.databricks.delta.schema.autoMerge.enabled", "true")
+              try {
+                dt.as("target")
+                  .merge(updateDf.as("source"), "target.filename = source.filename")
+                  .whenMatched()
+                  .update(Map("file_size" -> col("source.file_size")))
+                  .execute()
+              } finally {
+                previousAutoMerge match {
+                  case Some(v) => spark.conf.set("spark.databricks.delta.schema.autoMerge.enabled", v)
+                  case None => spark.conf.unset("spark.databricks.delta.schema.autoMerge.enabled")
+                }
               }
+
+              // Update total from the full index table
+              val totalResult = dt.toDF.agg(sum("file_size")).head()
+              metadata.total_indexed_file_size = if (totalResult.isNullAt(0)) 0L else totalResult.getLong(0)
+              writeMetadata(metadata)
+            } finally {
+              sizesBroadcast.destroy()
             }
-
-            // Update total from the full index table
-            val totalResult = dt.toDF.agg(sum("file_size")).head()
-            metadata.total_indexed_file_size = if (totalResult.isNullAt(0)) 0L else totalResult.getLong(0)
-            writeMetadata(metadata)
-
-            sizesBroadcast.destroy()
             logger.warn(s"Backfilled file sizes for ${nullSizeFiles.size} files")
           }
         }
@@ -773,10 +786,23 @@ case class Index private (
 /** Companion object for the Index class.
   */
 object Index {
+  /** Returns the file list name for an index.
+    * @param name The index name
+    * @return The file list identifier
+    */
   def fileListName(name: String): String = IndexPathUtils.fileListName(name)
 
+  /** Checks if an index exists.
+    * @param name The index name
+    * @return true if the index exists
+    */
   def exists(name: String)(implicit spark: SparkSession): Boolean = IndexPathUtils.exists(name)
 
+  /** Removes an index and its associated data.
+    * @param name The index name
+    * @return true if removal was successful
+    * @throws IndexNotFoundException if the index does not exist
+    */
   def remove(name: String)(implicit spark: SparkSession): Boolean = IndexPathUtils.remove(name)
 
   /** Factory method to create an Index instance.
@@ -908,11 +934,39 @@ object Index {
         if (metadataExists) {
           if (allowSchemaMismatch) {
             if (metadata.schema != s.json) {
+              // Validate regular indexes
               metadata.indexes.forEach(col => {
                 if (!SchemaHelper.fieldExists(s, col)) {
                   throw new IndexNotFoundInNewSchemaException(col)
                 }
               })
+              // Validate bloom indexes
+              metadata.bloom_indexes.asScala.foreach { bi =>
+                if (!SchemaHelper.fieldExists(s, bi.column)) {
+                  throw new IndexNotFoundInNewSchemaException(bi.column)
+                }
+              }
+              // Validate temporal indexes
+              metadata.temporal_indexes.asScala.foreach { ti =>
+                if (!SchemaHelper.fieldExists(s, ti.column)) {
+                  throw new IndexNotFoundInNewSchemaException(ti.column)
+                }
+                if (!SchemaHelper.fieldExists(s, ti.timestamp_column)) {
+                  throw new IndexNotFoundInNewSchemaException(ti.timestamp_column)
+                }
+              }
+              // Validate range indexes
+              metadata.range_indexes.asScala.foreach { ri =>
+                if (!SchemaHelper.fieldExists(s, ri.column)) {
+                  throw new IndexNotFoundInNewSchemaException(ri.column)
+                }
+              }
+              // Validate computed indexes
+              metadata.computed_indexes.keySet().asScala.foreach { ci =>
+                // Computed indexes use SQL expressions, not schema fields directly
+                // We validate the output column name exists conceptually but
+                // cannot validate the expression references without executing it
+              }
             }
             metadata.schema = s.json
           } else if (metadata.schema != s.json) {
@@ -964,8 +1018,8 @@ object Index {
     index
   }
 
-  /** Implicit class for enhancing DataFrame operations with index based
-    * operations.
+  /** Implicit class enabling DataFrame-to-Index join syntax.
+    * Allows calling df.join(index, columns, joinType) directly.
     */
   implicit class DataFrameOps(df: DataFrame) {
 

--- a/src/main/scala/dev/cjfravel/ariadne/Index.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/Index.scala
@@ -123,7 +123,7 @@ case class Index private (
       case Some(df) =>
         val expectedCols = storageColumns ++ bloomStorageColumns ++
           metadata.temporal_indexes.asScala.map(_.column).toSet ++
-          rangeStorageColumns
+          rangeStorageColumns ++ autoBloomStorageColumns
         val existingCols = df.columns.toSet - "filename"
         val missingCols = expectedCols -- existingCols
         if (missingCols.isEmpty) return Set.empty

--- a/src/main/scala/dev/cjfravel/ariadne/Index.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/Index.scala
@@ -122,7 +122,8 @@ case class Index private (
     index match {
       case Some(df) =>
         val expectedCols = storageColumns ++ bloomStorageColumns ++
-          metadata.temporal_indexes.asScala.map(_.column).toSet
+          metadata.temporal_indexes.asScala.map(_.column).toSet ++
+          rangeStorageColumns
         val existingCols = df.columns.toSet - "filename"
         val missingCols = expectedCols -- existingCols
         if (missingCols.isEmpty) return Set.empty
@@ -153,6 +154,14 @@ case class Index private (
       throw new IllegalArgumentException(
         s"Column '$index' is already a temporal index. " +
         "A column cannot be both a regular index and a temporal index."
+      )
+    }
+
+    // Check mutual exclusivity with range indexes
+    if (metadata.range_indexes.asScala.exists(_.column == index)) {
+      throw new IllegalArgumentException(
+        s"Column '$index' is already a range index. " +
+        "A column cannot be both a regular index and a range index."
       )
     }
     
@@ -193,6 +202,12 @@ case class Index private (
       throw new IllegalArgumentException(
         s"Column '$column' is already a temporal index. " +
         "A column cannot be both a bloom index and a temporal index."
+      )
+    }
+    if (metadata.range_indexes.asScala.exists(_.column == column)) {
+      throw new IllegalArgumentException(
+        s"Column '$column' is already a range index. " +
+        "A column cannot be both a bloom index and a range index."
       )
     }
     
@@ -242,7 +257,8 @@ case class Index private (
       metadata.computed_indexes.keySet().asScala ++
       metadata.exploded_field_indexes.asScala.map(_.as_column).toSet ++
       metadata.bloom_indexes.asScala.map(_.column).toSet ++
-      metadata.temporal_indexes.asScala.map(_.column).toSet
+      metadata.temporal_indexes.asScala.map(_.column).toSet ++
+      metadata.range_indexes.asScala.map(_.column).toSet
 
   def addComputedIndex(name: String, sql_expression: String): Unit = {
     if (metadata.computed_indexes.containsKey(name)) return
@@ -284,6 +300,12 @@ case class Index private (
         "A column cannot be both a temporal index and a bloom index."
       )
     }
+    if (metadata.range_indexes.asScala.exists(_.column == column)) {
+      throw new IllegalArgumentException(
+        s"Column '$column' is already a range index. " +
+        "A column cannot be both a temporal index and a range index."
+      )
+    }
 
     // Validate both columns exist in schema
     if (!SchemaHelper.fieldExists(storedSchema, column)) {
@@ -298,6 +320,105 @@ case class Index private (
     val config = TemporalIndexConfig(column, timestampColumn)
     metadata.temporal_indexes.add(config)
     writeMetadata(metadata)
+  }
+
+  /** Adds a range index for the specified column.
+    *
+    * Range indexes store min/max values per file, enabling file pruning at
+    * query time. Files whose [min, max] range does not overlap with the
+    * queried values are skipped.
+    *
+    * @param column The column to index with min/max range
+    * @throws IllegalArgumentException if column is already indexed by another type
+    * @throws ColumnNotFoundException if column doesn't exist in schema
+    */
+  def addRangeIndex(column: String): Unit = {
+    // Idempotency check
+    if (metadata.range_indexes.asScala.exists(_.column == column)) return
+
+    // Mutual exclusivity checks
+    if (metadata.indexes.contains(column)) {
+      throw new IllegalArgumentException(
+        s"Column '$column' is already a regular index. " +
+        "A column cannot be both a range index and a regular index."
+      )
+    }
+    if (metadata.computed_indexes.containsKey(column)) {
+      throw new IllegalArgumentException(
+        s"Column '$column' is already a computed index. " +
+        "A column cannot be both a range index and a computed index."
+      )
+    }
+    if (metadata.bloom_indexes.asScala.exists(_.column == column)) {
+      throw new IllegalArgumentException(
+        s"Column '$column' is already a bloom index. " +
+        "A column cannot be both a range index and a bloom index."
+      )
+    }
+    if (metadata.temporal_indexes.asScala.exists(_.column == column)) {
+      throw new IllegalArgumentException(
+        s"Column '$column' is already a temporal index. " +
+        "A column cannot be both a range index and a temporal index."
+      )
+    }
+
+    // Validate column exists in schema
+    if (!SchemaHelper.fieldExists(storedSchema, column)) {
+      throw new ColumnNotFoundException(s"Column '$column' not found in schema")
+    }
+
+    val config = RangeIndexConfig(column)
+    metadata.range_indexes.add(config)
+    writeMetadata(metadata)
+  }
+
+  /** Deletes the specified files from the index, large index tables, and file list.
+    *
+    * Acquires the update lock, removes matching rows from the main index Delta table,
+    * all large index Delta tables, and the FileList. If a filename doesn't exist
+    * in the index, it is silently ignored.
+    *
+    * @param filenames
+    *   One or more filenames to remove from the index.
+    */
+  def deleteFiles(filenames: String*): Unit = {
+    if (filenames.isEmpty) return
+
+    val lock = IndexLock(updateLockPath, name)
+    val correlationId = UUID.randomUUID().toString
+    lock.acquire(correlationId)
+    try {
+      import spark.implicits._
+      val toDelete = filenames.toDF("filename")
+
+      // Remove from main index
+      delta(indexFilePath).foreach { dt =>
+        dt.as("target")
+          .merge(toDelete.as("source"), "target.filename = source.filename")
+          .whenMatched()
+          .delete()
+          .execute()
+        logger.warn(s"Deleted ${filenames.size} file(s) from main index")
+      }
+
+      // Remove from all large index tables
+      largeIndexColumns.foreach { colName =>
+        val largePath = new Path(largeIndexesFilePath, colName)
+        delta(largePath).foreach { dt =>
+          dt.as("target")
+            .merge(toDelete.as("source"), "target.filename = source.filename")
+            .whenMatched()
+            .delete()
+            .execute()
+          logger.warn(s"Deleted file(s) from large index column '$colName'")
+        }
+      }
+
+      // Remove from file list
+      fileList.removeFile(filenames: _*)
+    } finally {
+      lock.release(correlationId)
+    }
   }
 
   /** Updates the index with new files and backfills newly added columns. */
@@ -318,6 +439,37 @@ case class Index private (
         logger.warn(s"Updating index for ${unindexed.size} files")
         updateBatched(unindexed, lock, correlationId)
       }
+      maybeAutoCompact()
+    } finally {
+      lock.release(correlationId)
+    }
+  }
+
+  /** Compacts all Delta tables belonging to this index using OPTIMIZE.
+    * Acquires the update lock to prevent concurrent modifications.
+    */
+  def compact(): Unit = {
+    val lock = IndexLock(updateLockPath, name)
+    val correlationId = UUID.randomUUID().toString
+    lock.acquire(correlationId)
+    try {
+      compactDeltaTables()
+    } finally {
+      lock.release(correlationId)
+    }
+  }
+
+  /** Vacuums all Delta tables belonging to this index to remove old files.
+    * Acquires the update lock to prevent concurrent modifications.
+    *
+    * @param retentionHours number of hours of history to retain (default 168 = 7 days)
+    */
+  def vacuum(retentionHours: Int = 168): Unit = {
+    val lock = IndexLock(updateLockPath, name)
+    val correlationId = UUID.randomUUID().toString
+    lock.acquire(correlationId)
+    try {
+      vacuumDeltaTables(retentionHours)
     } finally {
       lock.release(correlationId)
     }
@@ -404,6 +556,19 @@ case class Index private (
     } else if (temporalConfigs.nonEmpty) {
       combinedDf = temporalDf
     }
+
+    // Build range indexes (struct with min/max per file)
+    val rangeDf = buildRangeIndexes(withFilename)
+
+    val rangeConfigs = metadata.range_indexes.asScala.toSeq
+    if (rangeConfigs.nonEmpty && combinedDf.columns.length > 1) {
+      combinedDf = combinedDf.join(rangeDf, Seq("filename"), "full_outer")
+    } else if (rangeConfigs.nonEmpty) {
+      combinedDf = rangeDf
+    }
+
+    // Build auto-bloom filters for columns that exceed largeIndexLimit
+    combinedDf = buildAutoBloomIndexes(combinedDf)
 
     handleLargeIndexes(combinedDf)
     appendToStaging(combinedDf)
@@ -536,7 +701,9 @@ object Index {
         new util.ArrayList[ExplodedFieldMapping](),
         new util.ArrayList[BloomIndexConfig](),
         new util.ArrayList[TemporalIndexConfig](),
-        new util.HashMap[String, String]()
+        new util.HashMap[String, String](),
+        new util.ArrayList[RangeIndexConfig](),
+        new util.ArrayList[String]()
       )
     }
 

--- a/src/main/scala/dev/cjfravel/ariadne/Index.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/Index.scala
@@ -384,6 +384,8 @@ case class Index private (
   def deleteFiles(filenames: String*): Unit = {
     if (filenames.isEmpty) return
 
+    val startTime = System.currentTimeMillis()
+    logger.warn(s"Deleting ${filenames.size} file(s) from index '$name'")
     val lock = IndexLock(updateLockPath, name)
     val correlationId = UUID.randomUUID().toString
     lock.acquire(correlationId)
@@ -398,11 +400,12 @@ case class Index private (
           .whenMatched()
           .delete()
           .execute()
-        logger.warn(s"Deleted ${filenames.size} file(s) from main index")
+        logger.warn(s"Deleted ${filenames.size} file(s) from main index in ${System.currentTimeMillis() - startTime}ms")
       }
 
       // Remove from all large index tables
-      largeIndexColumns.foreach { colName =>
+      val largeCols = largeIndexColumns
+      largeCols.foreach { colName =>
         val largePath = new Path(largeIndexesFilePath, colName)
         delta(largePath).foreach { dt =>
           dt.as("target")
@@ -413,9 +416,23 @@ case class Index private (
           logger.warn(s"Deleted file(s) from large index column '$colName'")
         }
       }
+      if (largeCols.nonEmpty) {
+        logger.warn(s"Deleted from ${largeCols.size} large index tables")
+      }
+
+      // Remove from staging table if it exists
+      delta(stagingFilePath).foreach { dt =>
+        dt.as("target")
+          .merge(toDelete.as("source"), "target.filename = source.filename")
+          .whenMatched()
+          .delete()
+          .execute()
+        logger.warn(s"Deleted file(s) from staging table")
+      }
 
       // Remove from file list
       fileList.removeFile(filenames: _*)
+      logger.warn(s"deleteFiles completed in ${System.currentTimeMillis() - startTime}ms")
     } finally {
       lock.release(correlationId)
     }
@@ -449,11 +466,14 @@ case class Index private (
     * Acquires the update lock to prevent concurrent modifications.
     */
   def compact(): Unit = {
+    val startTime = System.currentTimeMillis()
+    logger.warn(s"Starting compaction for index '$name'")
     val lock = IndexLock(updateLockPath, name)
     val correlationId = UUID.randomUUID().toString
     lock.acquire(correlationId)
     try {
       compactDeltaTables()
+      logger.warn(s"Compaction complete in ${System.currentTimeMillis() - startTime}ms")
     } finally {
       lock.release(correlationId)
     }
@@ -465,6 +485,7 @@ case class Index private (
     * @param retentionHours number of hours of history to retain (default 168 = 7 days)
     */
   def vacuum(retentionHours: Int = 168): Unit = {
+    logger.warn(s"Vacuuming index '$name' with retention=$retentionHours hours")
     val lock = IndexLock(updateLockPath, name)
     val correlationId = UUID.randomUUID().toString
     lock.acquire(correlationId)
@@ -572,6 +593,9 @@ case class Index private (
 
     handleLargeIndexes(combinedDf)
     appendToStaging(combinedDf)
+
+    // Persist any metadata changes (e.g., auto-bloom column detection) after data is safely staged
+    writeMetadata(metadata)
   }
 }
 

--- a/src/main/scala/dev/cjfravel/ariadne/Index.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/Index.scala
@@ -361,6 +361,18 @@ case class Index private (
         throw new ColumnNotFoundException(s"Array column '$arrayColumn' not found in schema")
       }
 
+      // Validate that the column is actually an ArrayType (only if schema is available)
+      if (metadata.schema != null) {
+        SchemaHelper.fieldType(storedSchema, arrayColumn).foreach { dt =>
+          if (!dt.isInstanceOf[ArrayType]) {
+            throw new IllegalArgumentException(
+              s"Column '$arrayColumn' is ${dt.typeName}, not ArrayType. " +
+              "addExplodedFieldIndex requires an array column."
+            )
+          }
+        }
+      }
+
       val explodedFieldMapping =
         ExplodedFieldMapping(arrayColumn, fieldPath, asColumn)
       metadata.exploded_field_indexes.add(explodedFieldMapping)
@@ -709,6 +721,8 @@ case class Index private (
                 .withColumn("file_size", sizeUdf(col("filename")))
 
               val previousAutoMerge = spark.conf.getOption("spark.databricks.delta.schema.autoMerge.enabled")
+              // NOTE: SparkConf mutation is not thread-safe — concurrent Index instances
+              // sharing the same SparkSession could clobber each other's config values.
               spark.conf.set("spark.databricks.delta.schema.autoMerge.enabled", "true")
               try {
                 dt.as("target")

--- a/src/main/scala/dev/cjfravel/ariadne/Index.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/Index.scala
@@ -519,7 +519,6 @@ case class Index private (
         logger.warn(s"Updating index for ${unindexed.size} files")
         updateBatched(unindexed, lock, correlationId, isBackfill = false)
       }
-      maybeAutoCompact()
 
       // Recalculate total file size if it was unknown (migration from older version)
       if (metadata.total_indexed_file_size < 0) {
@@ -597,6 +596,7 @@ case class Index private (
       updateSingleBatch(batch, isBackfill)
       batchesSinceConsolidation += 1
       batchesSinceRefresh += 1
+      batchesSinceCompact += 1
 
       // Periodic lock refresh to prevent stale lock detection
       if (batchesSinceRefresh >= lockRefreshInterval) {
@@ -608,6 +608,7 @@ case class Index private (
       if (batchesSinceConsolidation >= stagingConsolidationThreshold) {
         logger.warn(s"Reached consolidation threshold ($stagingConsolidationThreshold batches), consolidating...")
         consolidateStaging()
+        maybeAutoCompact()
         batchesSinceConsolidation = 0
       }
     }
@@ -616,6 +617,7 @@ case class Index private (
     if (batchesSinceConsolidation > 0) {
       logger.warn("Consolidating remaining staged data...")
       consolidateStaging()
+      maybeAutoCompact()
     }
 
     logger.warn(s"Completed batched update of ${files.size} files in ${batches.size} batches")

--- a/src/main/scala/dev/cjfravel/ariadne/Index.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/Index.scala
@@ -19,6 +19,9 @@ import java.util.{Collections, UUID}
   * in Spark using Delta Lake. It supports schema enforcement, metadata
   * persistence, and file tracking.
   *
+  * @note Index instances are NOT safe for concurrent use from multiple threads.
+  *       Each thread should use its own Index instance.
+  *
   * @constructor
   *   Private: use the factory methods in the companion object.
   * @param spark
@@ -166,6 +169,7 @@ case class Index private (
     */
   def addIndex(index: String): Unit = {
     require(index != null && index.trim.nonEmpty, "index column name must not be null or blank")
+    logger.warn(s"Adding regular index on column '$index' for index '$name'")
 
     if (!metadata.indexes.contains(index)) {
       // Check mutual exclusivity with bloom indexes
@@ -219,6 +223,7 @@ case class Index private (
     require(column != null && column.trim.nonEmpty, "bloom index column name must not be null or blank")
     // Validate FPR range
     require(fpr > 0 && fpr < 1, s"FPR must be between 0 and 1, got: $fpr")
+    logger.warn(s"Adding bloom index on column '$column' for index '$name'")
 
     if (!metadata.bloom_indexes.asScala.exists(_.column == column)) {
       // Check mutual exclusivity with regular indexes
@@ -283,6 +288,7 @@ case class Index private (
     require(arrayColumn != null && arrayColumn.trim.nonEmpty, "arrayColumn must not be null or blank")
     require(fieldPath != null && fieldPath.trim.nonEmpty, "fieldPath must not be null or blank")
     require(asColumn != null && asColumn.trim.nonEmpty, "asColumn must not be null or blank")
+    logger.warn(s"Adding exploded field index '$asColumn' on column '$arrayColumn' for index '$name'")
 
     if (!metadata.exploded_field_indexes.asScala.exists(_.as_column == asColumn)) {
       // Mutual exclusivity checks
@@ -358,6 +364,7 @@ case class Index private (
   def addComputedIndex(name: String, sql_expression: String): Unit = {
     require(name != null && name.trim.nonEmpty, "computed index name must not be null or blank")
     require(sql_expression != null && sql_expression.trim.nonEmpty, "sql_expression must not be null or blank")
+    logger.warn(s"Adding computed index '$name' for index '${this.name}'")
 
     if (!metadata.computed_indexes.containsKey(name)) {
       // Mutual exclusivity checks
@@ -412,6 +419,7 @@ case class Index private (
   def addTemporalIndex(column: String, timestampColumn: String): Unit = {
     require(column != null && column.trim.nonEmpty, "temporal index column must not be null or blank")
     require(timestampColumn != null && timestampColumn.trim.nonEmpty, "timestampColumn must not be null or blank")
+    logger.warn(s"Adding temporal index on column '$column' for index '$name'")
 
     if (!metadata.temporal_indexes.asScala.exists(_.column == column)) {
       // Mutual exclusivity checks
@@ -471,6 +479,7 @@ case class Index private (
     */
   def addRangeIndex(column: String): Unit = {
     require(column != null && column.trim.nonEmpty, "range index column must not be null or blank")
+    logger.warn(s"Adding range index on column '$column' for index '$name'")
 
     if (!metadata.range_indexes.asScala.exists(_.column == column)) {
       // Mutual exclusivity checks
@@ -521,7 +530,8 @@ case class Index private (
     *   One or more filenames to remove from the index.
     */
   def deleteFiles(filenames: String*): Unit = {
-    if (filenames.nonEmpty) {
+    require(filenames != null && filenames.nonEmpty, "filenames must not be null or empty")
+    require(filenames.forall(f => f != null && f.trim.nonEmpty), "filenames must not contain null or blank entries")
       val startTime = System.currentTimeMillis()
       logger.warn(s"Deleting ${filenames.size} file(s) from index '$name'")
       val lock = IndexLock(updateLockPath, name)
@@ -591,7 +601,6 @@ case class Index private (
       logger.warn(s"Successfully deleted ${filenames.size} file(s) from index '$name' in ${System.currentTimeMillis() - startTime}ms")
     } finally {
       lock.release(correlationId)
-    }
     }
   }
 
@@ -721,12 +730,14 @@ case class Index private (
     * @param retentionHours number of hours of history to retain (default 168 = 7 days)
     */
   def vacuum(retentionHours: Int = 168): Unit = {
+    val startTime = System.currentTimeMillis()
     logger.warn(s"Vacuuming index '$name' with retention=$retentionHours hours")
     val lock = IndexLock(updateLockPath, name)
     val correlationId = UUID.randomUUID().toString
     lock.acquire(correlationId)
     try {
       vacuumDeltaTables(retentionHours)
+      logger.warn(s"Vacuum complete for index '$name' in ${System.currentTimeMillis() - startTime}ms")
     } finally {
       lock.release(correlationId)
     }
@@ -799,71 +810,92 @@ case class Index private (
     // Compute file sizes from HDFS and add as a column
     val fileSizes = getFileSizes(files)
     val fileSizesBroadcast = spark.sparkContext.broadcast(fileSizes)
-    val fileSizeUdf = udf((filename: String) => fileSizesBroadcast.value.getOrElse(filename, 0L))
+    try {
+      val fileSizeUdf = udf((filename: String) => fileSizesBroadcast.value.getOrElse(filename, 0L))
 
-    // Build regular indexes
-    val regularIndexesDf = buildRegularIndexes(withFilename)
-    val withExploded = buildExplodedFieldIndexes(withFilename, regularIndexesDf)
-    
-    // Build bloom filter indexes
-    val bloomDf = buildBloomFilterIndexes(withFilename)
+      // Build regular indexes
+      val regularIndexesDf = buildRegularIndexes(withFilename)
+      val withExploded = buildExplodedFieldIndexes(withFilename, regularIndexesDf)
 
-    // Build temporal indexes (struct arrays with value + max_ts)
-    val temporalDf = buildTemporalIndexes(withFilename)
-    
-    // Combine all index types
-    var combinedDf = withExploded
+      // Build bloom filter indexes
+      val bloomDf = buildBloomFilterIndexes(withFilename)
 
-    if (bloomIndexConfigs.nonEmpty && combinedDf.columns.length > 1) {
-      combinedDf = combinedDf.join(bloomDf, Seq("filename"), "full_outer")
-    } else if (bloomIndexConfigs.nonEmpty) {
-      combinedDf = bloomDf
-    }
+      // Build temporal indexes (struct arrays with value + max_ts)
+      val temporalDf = buildTemporalIndexes(withFilename)
 
-    val temporalConfigs = metadata.temporal_indexes.asScala.toSeq
-    if (temporalConfigs.nonEmpty && combinedDf.columns.length > 1) {
-      combinedDf = combinedDf.join(temporalDf, Seq("filename"), "full_outer")
-    } else if (temporalConfigs.nonEmpty) {
-      combinedDf = temporalDf
-    }
+      // Combine all index types
+      var combinedDf = withExploded
 
-    // Build range indexes (struct with min/max per file)
-    val rangeDf = buildRangeIndexes(withFilename)
-
-    val rangeConfigs = metadata.range_indexes.asScala.toSeq
-    if (rangeConfigs.nonEmpty && combinedDf.columns.length > 1) {
-      combinedDf = combinedDf.join(rangeDf, Seq("filename"), "full_outer")
-    } else if (rangeConfigs.nonEmpty) {
-      combinedDf = rangeDf
-    }
-
-    // Build auto-bloom filters for columns that exceed largeIndexLimit
-    combinedDf = buildAutoBloomIndexes(combinedDf)
-
-    combinedDf = combinedDf.withColumn("file_size", fileSizeUdf(col("filename")))
-
-    handleLargeIndexes(combinedDf)
-    appendToStaging(combinedDf)
-
-    // Clean up cached DataFrame from auto-bloom processing
-    lastAutoBloomCache.foreach(_.unpersist())
-    lastAutoBloomCache = None
-
-    // Update total indexed file size (skip for backfill — already counted)
-    if (!isBackfill) {
-      val batchFileSize = fileSizes.values.sum
-      if (metadata.total_indexed_file_size < 0) {
-        metadata.total_indexed_file_size = batchFileSize
-      } else {
-        metadata.total_indexed_file_size = metadata.total_indexed_file_size + batchFileSize
+      if (bloomIndexConfigs.nonEmpty && combinedDf.columns.length > 1) {
+        combinedDf = combinedDf.join(bloomDf, Seq("filename"), "full_outer")
+      } else if (bloomIndexConfigs.nonEmpty) {
+        combinedDf = bloomDf
       }
+
+      val temporalConfigs = metadata.temporal_indexes.asScala.toSeq
+      if (temporalConfigs.nonEmpty && combinedDf.columns.length > 1) {
+        combinedDf = combinedDf.join(temporalDf, Seq("filename"), "full_outer")
+      } else if (temporalConfigs.nonEmpty) {
+        combinedDf = temporalDf
+      }
+
+      // Build range indexes (struct with min/max per file)
+      val rangeDf = buildRangeIndexes(withFilename)
+
+      val rangeConfigs = metadata.range_indexes.asScala.toSeq
+      if (rangeConfigs.nonEmpty && combinedDf.columns.length > 1) {
+        combinedDf = combinedDf.join(rangeDf, Seq("filename"), "full_outer")
+      } else if (rangeConfigs.nonEmpty) {
+        combinedDf = rangeDf
+      }
+
+      // Build auto-bloom filters for columns that exceed largeIndexLimit
+      combinedDf = buildAutoBloomIndexes(combinedDf)
+
+      combinedDf = combinedDf.withColumn("file_size", fileSizeUdf(col("filename")))
+
+      handleLargeIndexes(combinedDf)
+      appendToStaging(combinedDf)
+
+      // Update total indexed file size (skip for backfill — already counted)
+      if (!isBackfill) {
+        val batchFileSize = fileSizes.values.sum
+        if (metadata.total_indexed_file_size < 0) {
+          metadata.total_indexed_file_size = batchFileSize
+        } else {
+          metadata.total_indexed_file_size = metadata.total_indexed_file_size + batchFileSize
+        }
+      }
+
+      // Persist any metadata changes (e.g., auto-bloom column detection) after data is safely staged
+      writeMetadata(metadata)
+      logger.warn(s"Single batch of ${files.size} files completed in ${System.currentTimeMillis() - singleBatchStart}ms")
+    } finally {
+      // Clean up cached DataFrame from auto-bloom processing
+      lastAutoBloomCache.foreach(_.unpersist())
+      lastAutoBloomCache = None
+      fileSizesBroadcast.destroy()
     }
+  }
 
-    fileSizesBroadcast.destroy()
-
-    // Persist any metadata changes (e.g., auto-bloom column detection) after data is safely staged
-    writeMetadata(metadata)
-    logger.warn(s"Single batch of ${files.size} files completed in ${System.currentTimeMillis() - singleBatchStart}ms")
+  /** Joins the indexed data with the provided DataFrame.
+    *
+    * Validates inputs then delegates to the inherited join implementation.
+    *
+    * @param df The DataFrame to join against indexed data
+    * @param usingColumns The column names to join on (must be indexed columns)
+    * @param joinType The Spark join type (default: "inner")
+    * @return The joined DataFrame
+    * @throws IllegalArgumentException if df is null or usingColumns is null/empty
+    */
+  override def join(
+      df: DataFrame,
+      usingColumns: Seq[String],
+      joinType: String = "inner"
+  ): DataFrame = {
+    require(df != null, "DataFrame must not be null")
+    require(usingColumns != null && usingColumns.nonEmpty, "usingColumns must not be null or empty")
+    super.join(df, usingColumns, joinType)
   }
 }
 
@@ -996,6 +1028,7 @@ object Index {
       allowSchemaMismatch: Boolean = false,
       readOptions: Option[Map[String, String]] = None
   )(implicit spark: SparkSession): Index = {
+    require(name != null && name.trim.nonEmpty, "index name must not be null or blank")
     val index = Index(name, schema)(spark)
 
     val metadataExists = index.metadataExists

--- a/src/main/scala/dev/cjfravel/ariadne/Index.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/Index.scala
@@ -398,7 +398,7 @@ case class Index private (
         val indexDf = dt.toDF
         if (indexDf.columns.contains("file_size")) {
           val result = indexDf
-            .where(col("filename").isin(filenames.map(lit(_)): _*))
+            .join(toDelete, Seq("filename"), "inner")
             .agg(sum("file_size"))
             .head()
           if (result.isNullAt(0)) 0L else result.getLong(0)
@@ -496,8 +496,9 @@ case class Index private (
               }
             }
 
-            // Update total
-            metadata.total_indexed_file_size = sizes.values.sum
+            // Update total from the full index table
+            val totalResult = dt.toDF.agg(sum("file_size")).head()
+            metadata.total_indexed_file_size = if (totalResult.isNullAt(0)) 0L else totalResult.getLong(0)
             writeMetadata(metadata)
 
             sizesBroadcast.destroy()
@@ -511,12 +512,12 @@ case class Index private (
       val needsColumnUpdate = filesNeedingColumnUpdate
       if (needsColumnUpdate.nonEmpty) {
         logger.warn(s"Backfilling ${needsColumnUpdate.size} files for new index columns")
-        updateBatched(needsColumnUpdate, lock, correlationId)
+        updateBatched(needsColumnUpdate, lock, correlationId, isBackfill = true)
       }
       val unindexed = unindexedFiles
       if (unindexed.nonEmpty) {
         logger.warn(s"Updating index for ${unindexed.size} files")
-        updateBatched(unindexed, lock, correlationId)
+        updateBatched(unindexed, lock, correlationId, isBackfill = false)
       }
       maybeAutoCompact()
 
@@ -579,7 +580,7 @@ case class Index private (
     * @param lock The update lock to refresh during processing
     * @param correlationId The correlation ID for lock refresh
     */
-  private def updateBatched(files: Set[String], lock: IndexLock, correlationId: String): Unit = {
+  private def updateBatched(files: Set[String], lock: IndexLock, correlationId: String, isBackfill: Boolean = false): Unit = {
     logger.warn(s"Using intelligent batched update for ${files.size} files")
 
     // Perform pre-flight analysis to determine optimal batching
@@ -593,7 +594,7 @@ case class Index private (
 
     batches.zipWithIndex.foreach { case (batch, idx) =>
       logger.warn(s"Processing batch ${idx + 1}/${batches.size} with ${batch.size} files")
-      updateSingleBatch(batch)
+      updateSingleBatch(batch, isBackfill)
       batchesSinceConsolidation += 1
       batchesSinceRefresh += 1
 
@@ -624,7 +625,7 @@ case class Index private (
     *
     * @param files Set of files to process in this batch
     */
-  private def updateSingleBatch(files: Set[String]): Unit = {
+  private def updateSingleBatch(files: Set[String], isBackfill: Boolean = false): Unit = {
     val baseDf = createBaseDataFrame(files)
     val withComputedIndexes = applyComputedIndexes(baseDf)
     val withFilename = addFilenameColumn(withComputedIndexes, files)
@@ -678,12 +679,18 @@ case class Index private (
     handleLargeIndexes(combinedDf)
     appendToStaging(combinedDf)
 
-    // Update total indexed file size
-    val batchFileSize = fileSizes.values.sum
-    if (metadata.total_indexed_file_size < 0) {
-      metadata.total_indexed_file_size = batchFileSize
-    } else {
-      metadata.total_indexed_file_size = metadata.total_indexed_file_size + batchFileSize
+    // Clean up cached DataFrame from auto-bloom processing
+    lastAutoBloomCache.foreach(_.unpersist())
+    lastAutoBloomCache = None
+
+    // Update total indexed file size (skip for backfill — already counted)
+    if (!isBackfill) {
+      val batchFileSize = fileSizes.values.sum
+      if (metadata.total_indexed_file_size < 0) {
+        metadata.total_indexed_file_size = batchFileSize
+      } else {
+        metadata.total_indexed_file_size = metadata.total_indexed_file_size + batchFileSize
+      }
     }
 
     fileSizesBroadcast.destroy()

--- a/src/main/scala/dev/cjfravel/ariadne/Index.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/Index.scala
@@ -106,6 +106,8 @@ case class Index private (
 
   /** Helper function to get a list of files that haven't yet been indexed
     *
+    * @note This method calls `collect()` on the driver, which can cause OOM
+    *       if the number of unindexed files is very large.
     * @return
     *   Set of filenames
     */
@@ -599,6 +601,10 @@ case class Index private (
       // Remove from file list
       fileList.removeFile(filenames: _*)
       logger.warn(s"Successfully deleted ${filenames.size} file(s) from index '$name' in ${System.currentTimeMillis() - startTime}ms")
+    } catch {
+      case e: Throwable =>
+        logger.warn(s"deleteFiles failed for index '$name': ${e.getMessage}", e)
+        throw e
     } finally {
       lock.release(correlationId)
     }
@@ -606,6 +612,7 @@ case class Index private (
 
   /** Updates the index with new files and backfills newly added columns. */
   def update: Unit = {
+    logger.warn(s"Starting index update for '$name'")
     batchesSinceCompact = metadata.batches_since_compact
     val startTime = System.currentTimeMillis()
     val lock = IndexLock(updateLockPath, name)
@@ -699,6 +706,10 @@ case class Index private (
       }
 
       logger.warn(s"Update complete for index '$name' in ${System.currentTimeMillis() - startTime}ms")
+    } catch {
+      case e: Throwable =>
+        logger.warn(s"update failed for index '$name': ${e.getMessage}", e)
+        throw e
     } finally {
       lock.release(correlationId)
     }
@@ -719,6 +730,10 @@ case class Index private (
       metadata.batches_since_compact = 0
       writeMetadata(metadata)
       logger.warn(s"Compaction complete in ${System.currentTimeMillis() - startTime}ms")
+    } catch {
+      case e: Throwable =>
+        logger.warn(s"compact failed for index '$name': ${e.getMessage}", e)
+        throw e
     } finally {
       lock.release(correlationId)
     }
@@ -738,6 +753,10 @@ case class Index private (
     try {
       vacuumDeltaTables(retentionHours)
       logger.warn(s"Vacuum complete for index '$name' in ${System.currentTimeMillis() - startTime}ms")
+    } catch {
+      case e: Throwable =>
+        logger.warn(s"vacuum failed for index '$name': ${e.getMessage}", e)
+        throw e
     } finally {
       lock.release(correlationId)
     }
@@ -1094,7 +1113,7 @@ object Index {
             }
             metadata.schema = s.json
           } else if (metadata.schema != s.json) {
-            throw new SchemaMismatchException()
+            throw new SchemaMismatchException(name)
           }
         } else {
           metadata.schema = s.json
@@ -1108,7 +1127,7 @@ object Index {
       case Some(f) =>
         if (metadataExists) {
           if (metadata.format != f) {
-            throw new FormatMismatchException()
+            throw new FormatMismatchException(name, metadata.format, f)
           }
         } else {
           metadata.format = f
@@ -1171,6 +1190,7 @@ object Index {
         usingColumns: Seq[String],
         joinType: String = "inner"
     ): DataFrame = {
+      require(usingColumns != null && usingColumns.nonEmpty, "usingColumns must not be null or empty")
       logger.warn(s"DataFrameOps.join: $joinType join on columns ${usingColumns.mkString(", ")} against index '${index.name}'")
       val indexDf = index.joinDf(df, usingColumns)
       df.join(indexDf, usingColumns, joinType)

--- a/src/main/scala/dev/cjfravel/ariadne/Index.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/Index.scala
@@ -393,6 +393,18 @@ case class Index private (
       import spark.implicits._
       val toDelete = filenames.toDF("filename")
 
+      // Read file sizes before deleting (to update total)
+      val deletedFileSize = delta(indexFilePath).map { dt =>
+        val indexDf = dt.toDF
+        if (indexDf.columns.contains("file_size")) {
+          val result = indexDf
+            .where(col("filename").isin(filenames.map(lit(_)): _*))
+            .agg(sum("file_size"))
+            .head()
+          if (result.isNullAt(0)) 0L else result.getLong(0)
+        } else 0L
+      }.getOrElse(0L)
+
       // Remove from main index
       delta(indexFilePath).foreach { dt =>
         dt.as("target")
@@ -430,6 +442,12 @@ case class Index private (
         logger.warn(s"Deleted file(s) from staging table")
       }
 
+      // Update total indexed file size
+      if (metadata.total_indexed_file_size > 0) {
+        metadata.total_indexed_file_size = math.max(0L, metadata.total_indexed_file_size - deletedFileSize)
+        writeMetadata(metadata)
+      }
+
       // Remove from file list
       fileList.removeFile(filenames: _*)
       logger.warn(s"deleteFiles completed in ${System.currentTimeMillis() - startTime}ms")
@@ -444,6 +462,50 @@ case class Index private (
     val correlationId = UUID.randomUUID().toString
     lock.acquire(correlationId)
     try {
+      // Backfill file_size for existing index rows that don't have it
+      delta(indexFilePath).foreach { dt =>
+        val indexDf = dt.toDF
+        if (!indexDf.columns.contains("file_size") || indexDf.where(col("file_size").isNull).limit(1).count() > 0) {
+          val nullSizeFiles = if (indexDf.columns.contains("file_size")) {
+            indexDf.where(col("file_size").isNull).select("filename").collect().map(_.getString(0)).toSet
+          } else {
+            indexDf.select("filename").collect().map(_.getString(0)).toSet
+          }
+          if (nullSizeFiles.nonEmpty) {
+            logger.warn(s"Backfilling file sizes for ${nullSizeFiles.size} files")
+            val sizes = getFileSizes(nullSizeFiles)
+            val sizesBroadcast = spark.sparkContext.broadcast(sizes)
+            val sizeUdf = udf((filename: String) => sizesBroadcast.value.getOrElse(filename, 0L))
+
+            import spark.implicits._
+            val updateDf = nullSizeFiles.toSeq.toDF("filename")
+              .withColumn("file_size", sizeUdf(col("filename")))
+
+            val previousAutoMerge = spark.conf.getOption("spark.databricks.delta.schema.autoMerge.enabled")
+            spark.conf.set("spark.databricks.delta.schema.autoMerge.enabled", "true")
+            try {
+              dt.as("target")
+                .merge(updateDf.as("source"), "target.filename = source.filename")
+                .whenMatched()
+                .update(Map("file_size" -> col("source.file_size")))
+                .execute()
+            } finally {
+              previousAutoMerge match {
+                case Some(v) => spark.conf.set("spark.databricks.delta.schema.autoMerge.enabled", v)
+                case None => spark.conf.unset("spark.databricks.delta.schema.autoMerge.enabled")
+              }
+            }
+
+            // Update total
+            metadata.total_indexed_file_size = sizes.values.sum
+            writeMetadata(metadata)
+
+            sizesBroadcast.destroy()
+            logger.warn(s"Backfilled file sizes for ${nullSizeFiles.size} files")
+          }
+        }
+      }
+
       // Backfill existing files for new columns first, so the index schema
       // is complete before processing new files
       val needsColumnUpdate = filesNeedingColumnUpdate
@@ -457,6 +519,21 @@ case class Index private (
         updateBatched(unindexed, lock, correlationId)
       }
       maybeAutoCompact()
+
+      // Recalculate total file size if it was unknown (migration from older version)
+      if (metadata.total_indexed_file_size < 0) {
+        delta(indexFilePath).foreach { dt =>
+          val totalSize = if (dt.toDF.columns.contains("file_size")) {
+            val result = dt.toDF.agg(sum("file_size")).head()
+            if (result.isNullAt(0)) 0L else result.getLong(0)
+          } else {
+            0L
+          }
+          metadata.total_indexed_file_size = totalSize
+          writeMetadata(metadata)
+          logger.warn(f"Recalculated total indexed file size: ${totalSize / (1024.0 * 1024.0 * 1024.0)}%.2f GB")
+        }
+      }
     } finally {
       lock.release(correlationId)
     }
@@ -552,6 +629,11 @@ case class Index private (
     val withComputedIndexes = applyComputedIndexes(baseDf)
     val withFilename = addFilenameColumn(withComputedIndexes, files)
 
+    // Compute file sizes from HDFS and add as a column
+    val fileSizes = getFileSizes(files)
+    val fileSizesBroadcast = spark.sparkContext.broadcast(fileSizes)
+    val fileSizeUdf = udf((filename: String) => fileSizesBroadcast.value.getOrElse(filename, 0L))
+
     // Build regular indexes
     val regularIndexesDf = buildRegularIndexes(withFilename)
     val withExploded = buildExplodedFieldIndexes(withFilename, regularIndexesDf)
@@ -591,8 +673,20 @@ case class Index private (
     // Build auto-bloom filters for columns that exceed largeIndexLimit
     combinedDf = buildAutoBloomIndexes(combinedDf)
 
+    combinedDf = combinedDf.withColumn("file_size", fileSizeUdf(col("filename")))
+
     handleLargeIndexes(combinedDf)
     appendToStaging(combinedDf)
+
+    // Update total indexed file size
+    val batchFileSize = fileSizes.values.sum
+    if (metadata.total_indexed_file_size < 0) {
+      metadata.total_indexed_file_size = batchFileSize
+    } else {
+      metadata.total_indexed_file_size = metadata.total_indexed_file_size + batchFileSize
+    }
+
+    fileSizesBroadcast.destroy()
 
     // Persist any metadata changes (e.g., auto-bloom column detection) after data is safely staged
     writeMetadata(metadata)
@@ -727,7 +821,8 @@ object Index {
         new util.ArrayList[TemporalIndexConfig](),
         new util.HashMap[String, String](),
         new util.ArrayList[RangeIndexConfig](),
-        new util.ArrayList[String]()
+        new util.ArrayList[String](),
+        -1L
       )
     }
 

--- a/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
@@ -404,6 +404,7 @@ trait IndexBuildOperations extends BloomFilterOperations {
     * @param df the combined index DataFrame to stage
     */
   protected def appendToStaging(df: DataFrame): Unit = {
+    val startTime = System.currentTimeMillis()
     val allStorageColumns = storageColumns
     
     // Create small grouped DataFrame (filter out large indexes)
@@ -428,6 +429,7 @@ trait IndexBuildOperations extends BloomFilterOperations {
       .option("mergeSchema", "true")
       .mode("append")
       .save(stagingFilePath.toString)
+    logger.warn(s"Staging append completed for '$name' ($rowCount rows) in ${System.currentTimeMillis() - startTime}ms")
   }
 
   /** Appends large index data to per-column Delta tables under `large_indexes/`.
@@ -448,6 +450,7 @@ trait IndexBuildOperations extends BloomFilterOperations {
     * @param df the combined index DataFrame with array columns
     */
   protected def appendToLargeIndex(df: DataFrame): Unit = {
+    val startTime = System.currentTimeMillis()
     val allStorageColumns = storageColumns
     if (allStorageColumns.nonEmpty) {
     
@@ -493,6 +496,7 @@ trait IndexBuildOperations extends BloomFilterOperations {
           .save(columnPath.toString)
       }
     }
+    logger.warn(s"Large index append completed for '$name' (${allStorageColumns.size} columns) in ${System.currentTimeMillis() - startTime}ms")
     }
   }
 
@@ -661,6 +665,11 @@ trait IndexBuildOperations extends BloomFilterOperations {
     * the transaction log. Temporarily disables the retention duration safety check
     * when `retentionHours` is zero or negative.
     *
+    * @note '''Thread-safety:''' This method temporarily mutates the shared SparkConf
+    *       (`retentionDurationCheck.enabled`). Concurrent `Index` instances sharing
+    *       the same `SparkSession` may race on this setting. The value is restored
+    *       in a `finally` block, but a TOCTOU window exists between set and restore.
+    *
     * @param retentionHours number of hours of history to retain (default 168 = 7 days)
     */
   protected def vacuumDeltaTables(retentionHours: Int = 168): Unit = {
@@ -731,8 +740,9 @@ trait IndexBuildOperations extends BloomFilterOperations {
         case Some(deltaTable) =>
           logger.warn(s"Merging staging data into main index at ${indexFilePath}")
           // Enable schema auto-merge so new index columns evolve the target table.
-          // NOTE: SparkConf mutation is not thread-safe — concurrent Index instances
-          // sharing the same SparkSession could clobber each other's config values.
+          // NOTE: THREAD-SAFETY: SparkConf mutation is not thread-safe — concurrent
+          // Index instances sharing the same SparkSession may race on this setting.
+          // Delta MERGE requires the global config (per-writer .option does not apply).
           val previousAutoMerge = spark.conf.getOption("spark.databricks.delta.schema.autoMerge.enabled")
           spark.conf.set("spark.databricks.delta.schema.autoMerge.enabled", "true")
           try {

--- a/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
@@ -72,6 +72,9 @@ trait IndexBuildOperations extends BloomFilterOperations {
         case e: java.io.IOException =>
           logger.warn(s"I/O error computing file size for $f: ${e.getMessage}, skipping")
           None
+        case e: Exception =>
+          logger.warn(s"Unexpected error computing file size for $f: ${e.getMessage}", e)
+          None
       }
     }.toMap
   }
@@ -430,6 +433,13 @@ trait IndexBuildOperations extends BloomFilterOperations {
     * same filenames are removed via Delta MERGE to prevent duplicates (important
     * during column backfill or re-indexing).
     *
+    * @note The `count()` call before the write is intentional: it materializes the
+    *       DataFrame to determine whether any large-index rows exist for this column,
+    *       avoiding the overhead of a Delta MERGE + write when no rows qualify. This
+    *       results in a double computation (count + write), but the alternative—writing
+    *       unconditionally—would create empty Delta commits and unnecessary MERGE
+    *       operations for columns that are within the limit.
+    *
     * @param df the combined index DataFrame with array columns
     */
   protected def appendToLargeIndex(df: DataFrame): Unit = {
@@ -576,6 +586,7 @@ trait IndexBuildOperations extends BloomFilterOperations {
       }
       } catch {
         case e: Exception =>
+          logger.warn(s"Failed to build auto-bloom indexes for $name: ${e.getMessage}", e)
           cachedDf.unpersist()
           throw e
       }

--- a/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
@@ -273,7 +273,8 @@ trait IndexBuildOperations extends BloomFilterOperations {
   protected def handleLargeIndexes(df: DataFrame): Unit = {
     val allStorageColumns = storageColumns
     if (allStorageColumns.isEmpty) return
-    
+
+    logger.warn(s"Checking ${allStorageColumns.size} columns for large index separation (limit=$largeIndexLimit)")
     appendToLargeIndex(df)
   }
 

--- a/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
@@ -1,26 +1,63 @@
 package dev.cjfravel.ariadne
 
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions._
 import org.apache.hadoop.fs.Path
-import io.delta.tables.DeltaTable
 import scala.collection.JavaConverters._
 
-/** Trait providing index building and maintenance operations for Index instances.
+/** Trait providing index building and maintenance operations for [[Index]] instances.
   *
-  * Handles the core data pipeline for building indexes:
-  * - Pre-flight file analysis for optimal batching
-  * - Regular, exploded, temporal, range, and auto-bloom index construction
-  * - Staging and large index management
-  * - Delta table compaction and vacuuming
+  * This trait implements the core data pipeline for building and maintaining file-level
+  * indexes. It is mixed into [[Index]] via the trait hierarchy and handles the complete
+  * update lifecycle:
   *
-  * Large indexes (columns exceeding `largeIndexLimit` distinct values) are
-  * automatically separated into dedicated Delta tables under `large_indexes/`.
+  * Update pipeline (data flow):
+  *  1. [[analyzeFiles]] — Pre-flight scan that computes per-file distinct value
+  *     counts for all indexed columns. This information drives batching decisions.
+  *  2. [[createOptimalBatches]] — Groups files into batches so that the sum of
+  *     `maxDistinctCount` per batch stays below `largeIndexLimit`.
+  *     Files that individually exceed the limit are isolated into single-file batches.
+  *  3. Per-batch processing (in `updateSingleBatch`):
+  *     - Read source files, apply computed indexes, add filename column
+  *     - Build regular indexes (array aggregation per file)
+  *     - Build exploded field, bloom filter, temporal, and range indexes
+  *     - Build auto-bloom filters for columns exceeding `largeIndexLimit`
+  *     - [[appendToStaging]] (small columns to staging Delta table)
+  *     - [[appendToLargeIndex]] (large columns to per-column Delta tables)
+  *  4. Periodic consolidation — Every `stagingConsolidationThreshold`
+  *     batches, [[consolidateStaging]] merges staging into the main index via Delta
+  *     MERGE (upsert on filename). Auto-compaction may follow via [[maybeAutoCompact]].
+  *  5. Final consolidation — After all batches complete, any remaining staged data
+  *     is consolidated and the staging table is deleted.
+  *
+  * Batching strategy:
+  * Files are sorted by `maxDistinctCount` (largest first) and packed sequentially into
+  * batches. This greedy approach keeps each batch under the large index limit while
+  * maximizing batch sizes for efficiency.
+  *
+  * Staging:
+  * Each batch is appended to a transient staging Delta table. Periodic consolidation
+  * merges staged rows into the main index, providing fault tolerance (partially
+  * processed updates can be recovered).
+  *
+  * Large index handling:
+  * Columns whose array size exceeds `largeIndexLimit` for any file are stored in
+  * separate Delta tables under `large_indexes/{column}/` as exploded (one row per
+  * value) rather than array-per-file. Auto-bloom filters are built for these columns
+  * in the main index to enable pre-filtering at query time.
+  *
+  * @see [[BloomFilterOperations]] for bloom filter creation and querying
+  * @see [[Index.update]] for the public entry point
   */
 trait IndexBuildOperations extends BloomFilterOperations {
   self: Index =>
 
-  /** Computes file sizes in bytes for the given files using HDFS FileSystem.
+  /** Computes file sizes in bytes for the given files using the Hadoop FileSystem.
+    *
+    * Files that cannot be found or read are silently skipped with a warning log.
+    *
+    * @param files set of fully-qualified file paths to measure
+    * @return map from file path to size in bytes; missing/unreadable files are omitted
     */
   protected def getFileSizes(files: Set[String]): Map[String, Long] = {
     logger.warn(s"Computing file sizes for ${files.size} files")
@@ -39,20 +76,27 @@ trait IndexBuildOperations extends BloomFilterOperations {
     }.toMap
   }
 
-  /** Hadoop root path for large index delta tables */
+  /** Hadoop root path for large index Delta tables (`{storagePath}/large_indexes/`). */
   protected def largeIndexesFilePath: Path =
     new Path(storagePath, "large_indexes")
 
-  /** Hadoop path for the index delta table */
+  /** Hadoop path for the main index Delta table (`{storagePath}/index/`). */
   protected def indexFilePath: Path = new Path(storagePath, "index")
 
-  /** Hadoop path for the staging delta table (used during batch processing) */
+  /** Hadoop path for the staging Delta table (`{storagePath}/staging/`).
+    *
+    * The staging table accumulates batch results during [[Index.update update]] and
+    * is merged into the main index by [[consolidateStaging]].
+    */
   protected def stagingFilePath: Path = new Path(storagePath, "staging")
 
-  /** Helper function to get the storage column names for internal use.
+  /** Returns the set of all storage column names across regular, computed,
+    * exploded-field, and temporal index types.
     *
-    * @return
-    *   Set of column names used for internal storage
+    * This is used internally to determine which columns to check for large-index
+    * separation and to build aggregation expressions.
+    *
+    * @return set of column names used for index storage (excludes bloom, range, and auto-bloom)
     */
   protected def storageColumns: Set[String] =
     metadata.indexes.asScala.toSet ++
@@ -60,7 +104,10 @@ trait IndexBuildOperations extends BloomFilterOperations {
       metadata.exploded_field_indexes.asScala.map(_.array_column).toSet ++
       metadata.temporal_indexes.asScala.map(_.column).toSet
 
-  /** Get the set of range index storage column names (with prefix) */
+  /** Returns the set of range index storage column names (each prefixed with `range_`).
+    *
+    * @return set of prefixed column names (e.g., `range_event_date`)
+    */
   protected def rangeStorageColumns: Set[String] =
     metadata.range_indexes.asScala.map(c => s"range_${c.column}").toSet
 
@@ -78,12 +125,22 @@ trait IndexBuildOperations extends BloomFilterOperations {
 
   /** Performs pre-flight analysis on unindexed files to determine optimal batching strategy.
     *
-    * @param files Set of file names to analyze
-    * @return Sequence of FileAnalysis objects with distinct count information
+    * Reads the source files, applies computed indexes, and counts distinct values per
+    * indexed column per file. The resulting [[FileAnalysis]] objects are used by
+    * [[createOptimalBatches]] to group files into batches that stay under the
+    * `largeIndexLimit`.
+    *
+    * If no storage columns are configured (e.g., only bloom or range indexes), returns
+    * trivial analyses with zero distinct counts.
+    *
+    * @param files set of file paths to analyze
+    * @return sequence of [[FileAnalysis]] objects with per-column distinct counts;
+    *         empty if `files` is empty
     */
   protected def analyzeFiles(files: Set[String]): Seq[FileAnalysis] = {
     if (files.isEmpty) return Seq.empty
     
+    val startTime = System.currentTimeMillis()
     logger.warn(s"Performing pre-flight analysis on ${files.size} files")
     
     val allStorageColumns = storageColumns
@@ -108,7 +165,7 @@ trait IndexBuildOperations extends BloomFilterOperations {
     
     val analysisResults = fileAnalysisDf.collect()
     
-    analysisResults.map { row =>
+    val results = analysisResults.map { row =>
       val filename = row.getAs[String]("filename")
       val distinctCounts = analysisColumns.map { colName =>
         colName -> row.getAs[Long](s"${colName}_distinct")
@@ -117,13 +174,22 @@ trait IndexBuildOperations extends BloomFilterOperations {
       
       FileAnalysis(filename, distinctCounts, maxCount)
     }.toSeq
+
+    logger.warn(s"Pre-flight analysis of ${files.size} files completed in ${System.currentTimeMillis() - startTime}ms")
+    results
   }
 
-  /** Groups files into batches based on their distinct value counts to stay under largeIndexLimit.
-    * Uses simplified sequential batching based on maxDistinctCount sum for performance.
+  /** Groups files into batches whose aggregate `maxDistinctCount` stays below
+    * `largeIndexLimit`.
     *
-    * @param fileAnalyses Sequence of FileAnalysis objects
-    * @return Sequence of file batches, where each batch is a set of filenames
+    * The algorithm sorts files by `maxDistinctCount` (largest first) and packs them
+    * sequentially into batches. When adding a file would push the batch total past
+    * the limit, a new batch is started. Files that individually exceed the limit
+    * are placed into single-file batches to guarantee progress.
+    *
+    * @param fileAnalyses sequence of [[FileAnalysis]] objects from [[analyzeFiles]]
+    * @return sequence of file batches (each a `Set[String]` of filenames);
+    *         empty if `fileAnalyses` is empty
     */
   protected def createOptimalBatches(fileAnalyses: Seq[FileAnalysis]): Seq[Set[String]] = {
     if (fileAnalyses.isEmpty) return Seq.empty
@@ -184,10 +250,14 @@ trait IndexBuildOperations extends BloomFilterOperations {
     allBatches
   }
 
-  /** Builds regular indexes DataFrame from the base data.
+  /** Builds regular (array-aggregated) indexes for all configured regular and computed columns.
     *
-    * @param df The base DataFrame with filename column
-    * @return DataFrame with regular indexes aggregated by filename
+    * Groups the input data by filename and collects distinct values into arrays via
+    * `collect_set`. If no regular or computed indexes are configured, returns a
+    * distinct filename-only DataFrame.
+    *
+    * @param df the base DataFrame with `filename` column and all indexed source columns
+    * @return DataFrame with `filename` plus one array column per regular/computed index
     */
   protected def buildRegularIndexes(df: DataFrame): DataFrame = {
     val regularIndexes = metadata.indexes.asScala.toSet ++
@@ -203,11 +273,15 @@ trait IndexBuildOperations extends BloomFilterOperations {
     }
   }
 
-  /** Builds exploded field indexes and joins them to the result DataFrame.
+  /** Builds exploded field indexes and joins them onto the result DataFrame.
     *
-    * @param baseData The base DataFrame with all columns
-    * @param resultDf The initial result DataFrame to join with
-    * @return DataFrame with exploded field indexes joined
+    * For each configured exploded field index, extracts the nested field path from
+    * the array column, explodes it, collects distinct values back into an array per
+    * file, and joins the result onto `resultDf`.
+    *
+    * @param baseData the full base DataFrame with all source columns
+    * @param resultDf the accumulating result DataFrame to join with (must have `filename`)
+    * @return DataFrame with exploded field index columns joined via `full_outer`
     */
   protected def buildExplodedFieldIndexes(baseData: DataFrame, resultDf: DataFrame): DataFrame = {
     val explodedFieldMappings = metadata.exploded_field_indexes.asScala.toSeq
@@ -223,13 +297,16 @@ trait IndexBuildOperations extends BloomFilterOperations {
     }
   }
 
-  /** Builds temporal indexes storing Array[Struct(value, max_ts)] per file.
+  /** Builds temporal indexes storing `Array[Struct(value, max_ts)]` per file.
     *
-    * For each temporal index config, groups by (filename, value_column) to find
-    * the max timestamp per value per file, then collects into struct arrays.
+    * For each temporal index configuration, groups by `(filename, value_column)` to
+    * find the maximum timestamp per value per file, then collects the
+    * `(value, max_ts)` structs into an array per file. This enables temporal
+    * deduplication at query time.
     *
-    * @param df The base DataFrame with filename column and source data
-    * @return DataFrame with temporal struct array columns, or filename-only if none configured
+    * @param df the base DataFrame with `filename`, value, and timestamp columns
+    * @return DataFrame with `filename` plus one struct-array column per temporal index;
+    *         filename-only DataFrame if no temporal indexes are configured
     */
   protected def buildTemporalIndexes(df: DataFrame): DataFrame = {
     val temporalConfigs = metadata.temporal_indexes.asScala.toSeq
@@ -250,13 +327,15 @@ trait IndexBuildOperations extends BloomFilterOperations {
     }
   }
 
-  /** Builds range indexes storing Struct(min, max) per file.
+  /** Builds range indexes storing `Struct(min, max)` per file.
     *
-    * For each range index config, groups by filename and computes
-    * the min and max of the column per file.
+    * For each range index configuration, groups by `filename` and computes the
+    * `min` and `max` of the column per file. The result is a struct column named
+    * `range_{column}`.
     *
-    * @param df The base DataFrame with filename column and source data
-    * @return DataFrame with range struct columns, or filename-only if none configured
+    * @param df the base DataFrame with `filename` column and range-indexed source columns
+    * @return DataFrame with `filename` plus one range struct column per configured range index;
+    *         filename-only DataFrame if no range indexes are configured
     */
   protected def buildRangeIndexes(df: DataFrame): DataFrame = {
     val rangeConfigs = metadata.range_indexes.asScala.toSeq
@@ -279,9 +358,10 @@ trait IndexBuildOperations extends BloomFilterOperations {
     }
   }
 
-  /** Handles large indexes by appending directly to large_indexes/{column}.
+  /** Checks all storage columns for arrays exceeding `largeIndexLimit`
+    * and delegates to [[appendToLargeIndex]] for separation.
     *
-    * @param df The DataFrame to process for large indexes
+    * @param df the combined index DataFrame with array columns
     */
   protected def handleLargeIndexes(df: DataFrame): Unit = {
     val allStorageColumns = storageColumns
@@ -293,7 +373,11 @@ trait IndexBuildOperations extends BloomFilterOperations {
 
   /** Appends the processed DataFrame to the staging Delta table.
     *
-    * @param df The DataFrame to append to staging
+    * Before writing, any column whose array size meets or exceeds `largeIndexLimit`
+    * is nulled out (those values are stored separately via [[appendToLargeIndex]]).
+    * The DataFrame is written in append mode with schema merge enabled.
+    *
+    * @param df the combined index DataFrame to stage
     */
   protected def appendToStaging(df: DataFrame): Unit = {
     val allStorageColumns = storageColumns
@@ -312,6 +396,9 @@ trait IndexBuildOperations extends BloomFilterOperations {
       df
     }
 
+    val rowCount = smallGroupedDf.count()
+    logger.warn(s"Appending $rowCount rows to staging at $stagingFilePath")
+
     smallGroupedDf.write
       .format("delta")
       .option("mergeSchema", "true")
@@ -319,11 +406,15 @@ trait IndexBuildOperations extends BloomFilterOperations {
       .save(stagingFilePath.toString)
   }
 
-  /** Appends large index data directly to large_indexes/{column} Delta tables.
-    * When files already exist in the large index (e.g., during column backfill),
-    * existing rows for those files are removed before appending to prevent duplicates.
+  /** Appends large index data to per-column Delta tables under `large_indexes/`.
     *
-    * @param df The DataFrame with large index data to append
+    * For each storage column, identifies rows where the array size meets or exceeds
+    * `largeIndexLimit`, explodes those arrays into individual rows, and writes them
+    * to `large_indexes/{column}/`. Before appending, any existing rows for the
+    * same filenames are removed via Delta MERGE to prevent duplicates (important
+    * during column backfill or re-indexing).
+    *
+    * @param df the combined index DataFrame with array columns
     */
   protected def appendToLargeIndex(df: DataFrame): Unit = {
     val allStorageColumns = storageColumns
@@ -351,7 +442,8 @@ trait IndexBuildOperations extends BloomFilterOperations {
       
       if (!columnData.isEmpty) {
         val columnPath = new Path(largeIndexesFilePath, colName)
-        logger.warn(s"Appending large index data for column $colName to ${columnPath}")
+        val rowCount = columnData.count()
+        logger.warn(s"Appending $rowCount rows to large index for column '$colName' at $columnPath")
         
         // Remove existing rows for these files to prevent duplicates during re-indexing
         delta(columnPath) match {
@@ -372,33 +464,51 @@ trait IndexBuildOperations extends BloomFilterOperations {
     }
   }
 
-  /** Column name prefix for auto-bloom filter storage */
+  /** Column name prefix for auto-bloom filter storage in the main index table. */
   protected val autoBloomColumnPrefix = "auto_bloom_"
 
-  /** Get the set of auto-bloom storage column names (with prefix) */
+  /** Returns the set of auto-bloom storage column names (each prefixed with `auto_bloom_`).
+    *
+    * @return set of prefixed column names (e.g., `auto_bloom_user_id`)
+    */
   protected def autoBloomStorageColumns: Set[String] =
     metadata.auto_bloom_indexes.asScala.map(c => autoBloomColumnPrefix + c).toSet
 
-  /** Get the set of columns eligible for auto-bloom filtering (excludes temporal columns) */
+  /** Returns the set of columns eligible for auto-bloom filtering.
+    *
+    * Eligible columns are regular, computed, and exploded-field indexes. Temporal
+    * indexes are excluded because they use struct arrays rather than simple value arrays.
+    *
+    * @return set of eligible column names
+    */
   private def autoBloomEligibleColumns: Set[String] =
     metadata.indexes.asScala.toSet ++
       metadata.computed_indexes.keySet().asScala ++
       metadata.exploded_field_indexes.asScala.map(_.array_column).toSet
 
-  /** Tracks the cached DataFrame from buildAutoBloomIndexes for deferred cleanup. */
+  /** Tracks the cached DataFrame from [[buildAutoBloomIndexes]] for deferred cleanup.
+    *
+    * Set during auto-bloom processing and unpersisted after staging is complete.
+    */
   @transient protected var lastAutoBloomCache: Option[DataFrame] = None
 
   /** Builds auto-bloom filters for columns that exceed the large index limit.
     *
-    * When a column's array exceeds largeIndexLimit for any file, a bloom filter
-    * is automatically built and stored in the main index with the auto_bloom_ prefix.
-    * At query time, this bloom filter is used to pre-filter which files need to
-    * load large index data.
+    * Scans the combined DataFrame to identify columns with any file whose array size
+    * meets or exceeds `largeIndexLimit`. For each such column, a bloom filter is
+    * built from the full array and stored in the main index with the `auto_bloom_`
+    * prefix. At query time, these bloom filters enable fast pre-filtering to determine
+    * which files need to load large index data.
     *
-    * @param combinedDf The combined index DataFrame with array columns
-    * @return DataFrame with auto-bloom columns added for large columns
+    * The input DataFrame is cached during processing to avoid redundant computation;
+    * the cache reference is stored in [[lastAutoBloomCache]] for deferred cleanup.
+    *
+    * @param combinedDf the combined index DataFrame with array columns
+    * @return DataFrame with `auto_bloom_{column}` binary columns added for columns
+    *         exceeding the limit; unchanged DataFrame if no columns qualify
     */
   protected def buildAutoBloomIndexes(combinedDf: DataFrame): DataFrame = {
+    val startTime = System.currentTimeMillis()
     val eligible = autoBloomEligibleColumns
     if (eligible.isEmpty) return combinedDf
 
@@ -429,6 +539,7 @@ trait IndexBuildOperations extends BloomFilterOperations {
 
     if (autoBloomColumns.isEmpty) {
       cachedDf.unpersist()
+      logger.warn(s"Auto-bloom: no columns to build, completed in ${System.currentTimeMillis() - startTime}ms")
       return combinedDf
     }
 
@@ -441,13 +552,15 @@ trait IndexBuildOperations extends BloomFilterOperations {
       df.withColumn(bloomColumn, bloomUdf(col(colName)))
     }
     lastAutoBloomCache = Some(cachedDf)
+    logger.warn(s"Auto-bloom: build completed in ${System.currentTimeMillis() - startTime}ms")
     result
   }
 
-  /** Compacts all Delta tables (main index and large index tables) using OPTIMIZE.
+  /** Compacts all Delta tables (main index and large index tables) using Delta OPTIMIZE.
     *
-    * Runs Delta Lake's OPTIMIZE command on the main index table and all
-    * large index column tables to consolidate small files for better read performance.
+    * Runs Delta Lake's OPTIMIZE command to consolidate small files into larger ones,
+    * improving read performance. Processes the main index table first, then each
+    * large index column table.
     */
   protected def compactDeltaTables(): Unit = {
     delta(indexFilePath).foreach { dt =>
@@ -469,15 +582,18 @@ trait IndexBuildOperations extends BloomFilterOperations {
   }
 
   /** Counter tracking batches processed since the last auto-compaction.
-    * Reset to zero after each compaction cycle.
+    *
+    * Incremented after each batch in `updateBatched` and reset to zero after each
+    * compaction cycle or at the start of each [[Index.update update]] call to prevent
+    * stale counts from a previous `update` from triggering premature compaction.
     */
   protected var batchesSinceCompact: Int = 0
 
   /** Triggers compaction if the auto-compact threshold has been reached.
     *
-    * Checks the `batchesSinceCompact` counter against the configured
-    * `autoCompactThreshold`. If the threshold is met, compacts all Delta tables
-    * and resets the counter.
+    * Checks the [[batchesSinceCompact]] counter against the configured
+    * `autoCompactThreshold`. If the threshold is met,
+    * compacts all Delta tables and resets the counter to zero.
     */
   protected def maybeAutoCompact(): Unit = {
     autoCompactThreshold.foreach { threshold =>
@@ -490,6 +606,10 @@ trait IndexBuildOperations extends BloomFilterOperations {
   }
 
   /** Vacuums all Delta tables (main index and large index tables) to remove old files.
+    *
+    * Uses Delta Lake's VACUUM command to delete data files no longer referenced by
+    * the transaction log. Temporarily disables the retention duration safety check
+    * when `retentionHours` is zero or negative.
     *
     * @param retentionHours number of hours of history to retain (default 168 = 7 days)
     */
@@ -521,20 +641,26 @@ trait IndexBuildOperations extends BloomFilterOperations {
 
   /** Consolidates staged data into the main index table.
     *
-    * Merges all data accumulated in the staging Delta table into the main
-    * index table, then deletes the staging table.
+    * Delegates to [[consolidateMainStaging]] which performs a Delta MERGE (upsert)
+    * of all staged rows into the main index, then deletes the staging table. Logs
+    * the total time taken.
     */
   protected def consolidateStaging(): Unit = {
+    val startTime = System.currentTimeMillis()
     logger.warn("Starting consolidation of staged data")
     consolidateMainStaging()
     
-    logger.warn("Consolidation complete")
+    logger.warn(s"Consolidation complete in ${System.currentTimeMillis() - startTime}ms")
   }
 
-  /** Consolidates the main staging table into the main index.
+  /** Consolidates the main staging table into the main index via Delta MERGE.
     *
-    * Performs a Delta MERGE (upsert) of staging rows into the main index,
-    * matching on filename. Creates the main index if it does not yet exist.
+    * Performs an upsert (match on `filename`): existing rows are updated, new rows
+    * are inserted. Creates the main index if it does not yet exist by writing the
+    * staging data directly. Schema auto-merge is temporarily enabled to support
+    * new columns added since the index was first created.
+    *
+    * After successful merge, the staging Delta table is deleted.
     */
   private def consolidateMainStaging(): Unit = {
     if (!exists(stagingFilePath)) {

--- a/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
@@ -11,6 +11,15 @@ import scala.collection.JavaConverters._
 trait IndexBuildOperations extends BloomFilterOperations {
   self: Index =>
 
+  /** Computes file sizes in bytes for the given files using HDFS FileSystem.
+    */
+  protected def getFileSizes(files: Set[String]): Map[String, Long] = {
+    files.toSeq.map { f =>
+      val path = new org.apache.hadoop.fs.Path(f)
+      f -> fs.getFileStatus(path).getLen
+    }.toMap
+  }
+
   /** Hadoop root path for large index delta tables */
   protected def largeIndexesFilePath: Path =
     new Path(storagePath, "large_indexes")

--- a/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
@@ -6,7 +6,16 @@ import org.apache.hadoop.fs.Path
 import io.delta.tables.DeltaTable
 import scala.collection.JavaConverters._
 
-/** Trait providing index building operations for Index instances.
+/** Trait providing index building and maintenance operations for Index instances.
+  *
+  * Handles the core data pipeline for building indexes:
+  * - Pre-flight file analysis for optimal batching
+  * - Regular, exploded, temporal, range, and auto-bloom index construction
+  * - Staging and large index management
+  * - Delta table compaction and vacuuming
+  *
+  * Large indexes (columns exceeding `largeIndexLimit` distinct values) are
+  * automatically separated into dedicated Delta tables under `large_indexes/`.
   */
 trait IndexBuildOperations extends BloomFilterOperations {
   self: Index =>
@@ -14,6 +23,7 @@ trait IndexBuildOperations extends BloomFilterOperations {
   /** Computes file sizes in bytes for the given files using HDFS FileSystem.
     */
   protected def getFileSizes(files: Set[String]): Map[String, Long] = {
+    logger.warn(s"Computing file sizes for ${files.size} files")
     files.toSeq.flatMap { f =>
       try {
         val path = new org.apache.hadoop.fs.Path(f)
@@ -21,6 +31,9 @@ trait IndexBuildOperations extends BloomFilterOperations {
       } catch {
         case _: java.io.FileNotFoundException =>
           logger.warn(s"File not found when computing size, skipping: $f")
+          None
+        case e: java.io.IOException =>
+          logger.warn(s"I/O error computing file size for $f: ${e.getMessage}, skipping")
           None
       }
     }.toMap
@@ -431,7 +444,11 @@ trait IndexBuildOperations extends BloomFilterOperations {
     result
   }
 
-  /** Compacts all Delta tables (main index and large index tables) using OPTIMIZE. */
+  /** Compacts all Delta tables (main index and large index tables) using OPTIMIZE.
+    *
+    * Runs Delta Lake's OPTIMIZE command on the main index table and all
+    * large index column tables to consolidate small files for better read performance.
+    */
   protected def compactDeltaTables(): Unit = {
     delta(indexFilePath).foreach { dt =>
       val compactStart = System.currentTimeMillis()
@@ -451,10 +468,17 @@ trait IndexBuildOperations extends BloomFilterOperations {
     }
   }
 
-  /** Counter tracking batches processed since the last auto-compaction. */
+  /** Counter tracking batches processed since the last auto-compaction.
+    * Reset to zero after each compaction cycle.
+    */
   protected var batchesSinceCompact: Int = 0
 
-  /** Runs compaction if auto-compact threshold is met. */
+  /** Triggers compaction if the auto-compact threshold has been reached.
+    *
+    * Checks the `batchesSinceCompact` counter against the configured
+    * `autoCompactThreshold`. If the threshold is met, compacts all Delta tables
+    * and resets the counter.
+    */
   protected def maybeAutoCompact(): Unit = {
     autoCompactThreshold.foreach { threshold =>
       if (batchesSinceCompact >= threshold) {
@@ -495,7 +519,11 @@ trait IndexBuildOperations extends BloomFilterOperations {
     }
   }
 
-  /** Consolidates staged data into the main index table. */
+  /** Consolidates staged data into the main index table.
+    *
+    * Merges all data accumulated in the staging Delta table into the main
+    * index table, then deletes the staging table.
+    */
   protected def consolidateStaging(): Unit = {
     logger.warn("Starting consolidation of staged data")
     consolidateMainStaging()
@@ -503,7 +531,11 @@ trait IndexBuildOperations extends BloomFilterOperations {
     logger.warn("Consolidation complete")
   }
 
-  /** Consolidates the main staging table into the main index. */
+  /** Consolidates the main staging table into the main index.
+    *
+    * Performs a Delta MERGE (upsert) of staging rows into the main index,
+    * matching on filename. Creates the main index if it does not yet exist.
+    */
   private def consolidateMainStaging(): Unit = {
     if (!exists(stagingFilePath)) {
       logger.warn("No staging data to consolidate for main index")

--- a/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
@@ -133,21 +133,25 @@ trait IndexBuildOperations extends BloomFilterOperations {
     * If no storage columns are configured (e.g., only bloom or range indexes), returns
     * trivial analyses with zero distinct counts.
     *
+    * @note This method calls `.collect()` to bring per-file distinct counts to the
+    *       driver. For indexes covering millions of files with many indexed columns,
+    *       the collected result set can be large enough to cause driver OOM. Consider
+    *       limiting the number of files analyzed per call or increasing driver memory.
+    *
     * @param files set of file paths to analyze
     * @return sequence of [[FileAnalysis]] objects with per-column distinct counts;
     *         empty if `files` is empty
     */
   protected def analyzeFiles(files: Set[String]): Seq[FileAnalysis] = {
-    if (files.isEmpty) return Seq.empty
-    
-    val startTime = System.currentTimeMillis()
-    logger.warn(s"Performing pre-flight analysis on ${files.size} files")
-    
-    val allStorageColumns = storageColumns
-    if (allStorageColumns.isEmpty) {
-      return files.map(f => FileAnalysis(f, Map.empty, 0L)).toSeq
-    }
-    
+    if (files.isEmpty) Seq.empty
+    else {
+      val startTime = System.currentTimeMillis()
+      logger.warn(s"Performing pre-flight analysis on ${files.size} files")
+      
+      val allStorageColumns = storageColumns
+      if (allStorageColumns.isEmpty) {
+        files.map(f => FileAnalysis(f, Map.empty, 0L)).toSeq
+      } else {
     // Read files with just indexed columns + filename
     val baseDf = createBaseDataFrame(files)
     val withComputedIndexes = applyComputedIndexes(baseDf)
@@ -177,6 +181,8 @@ trait IndexBuildOperations extends BloomFilterOperations {
 
     logger.warn(s"Pre-flight analysis of ${files.size} files completed in ${System.currentTimeMillis() - startTime}ms")
     results
+      }
+    }
   }
 
   /** Groups files into batches whose aggregate `maxDistinctCount` stays below
@@ -192,14 +198,13 @@ trait IndexBuildOperations extends BloomFilterOperations {
     *         empty if `fileAnalyses` is empty
     */
   protected def createOptimalBatches(fileAnalyses: Seq[FileAnalysis]): Seq[Set[String]] = {
-    if (fileAnalyses.isEmpty) return Seq.empty
-    
-    val allStorageColumns = storageColumns
-    if (allStorageColumns.isEmpty) {
-      return Seq(fileAnalyses.map(_.filename).toSet)
-    }
-    
-    logger.warn(s"Creating optimal batches for ${fileAnalyses.size} files with largeIndexLimit=$largeIndexLimit")
+    if (fileAnalyses.isEmpty) Seq.empty
+    else {
+      val allStorageColumns = storageColumns
+      if (allStorageColumns.isEmpty) {
+        Seq(fileAnalyses.map(_.filename).toSet)
+      } else {
+        logger.warn(s"Creating optimal batches for ${fileAnalyses.size} files with largeIndexLimit=$largeIndexLimit")
     
     // Separate files that individually exceed the limit (will be processed individually)
     val (largeFiles, regularFiles) = fileAnalyses.partition(_.maxDistinctCount >= largeIndexLimit)
@@ -248,6 +253,8 @@ trait IndexBuildOperations extends BloomFilterOperations {
     logger.warn(s"Created ${allBatches.size} batches: ${batches.size} regular batches + ${largeBatches.size} large file batches")
     
     allBatches
+      }
+    }
   }
 
   /** Builds regular (array-aggregated) indexes for all configured regular and computed columns.
@@ -263,6 +270,8 @@ trait IndexBuildOperations extends BloomFilterOperations {
     val regularIndexes = metadata.indexes.asScala.toSet ++
       metadata.computed_indexes.keySet().asScala
     
+    logger.debug(s"Building regular indexes for ${regularIndexes.size} columns: ${regularIndexes.mkString(", ")}")
+
     if (regularIndexes.nonEmpty) {
       val regularCols = (regularIndexes + "filename").toList
       val selectedDf = df.select(regularCols.map(col): _*).distinct
@@ -286,6 +295,8 @@ trait IndexBuildOperations extends BloomFilterOperations {
   protected def buildExplodedFieldIndexes(baseData: DataFrame, resultDf: DataFrame): DataFrame = {
     val explodedFieldMappings = metadata.exploded_field_indexes.asScala.toSeq
     
+    logger.debug(s"Building exploded field indexes for ${explodedFieldMappings.size} mapping(s)")
+
     explodedFieldMappings.foldLeft(resultDf) { (accumDf, explodedField) =>
       val explodedDf = baseData
         .select("filename", explodedField.array_column)
@@ -310,20 +321,24 @@ trait IndexBuildOperations extends BloomFilterOperations {
     */
   protected def buildTemporalIndexes(df: DataFrame): DataFrame = {
     val temporalConfigs = metadata.temporal_indexes.asScala.toSeq
-    if (temporalConfigs.isEmpty) return df.select("filename").distinct()
+    if (temporalConfigs.isEmpty) {
+      df.select("filename").distinct()
+    } else {
+      logger.debug(s"Building temporal indexes for ${temporalConfigs.size} columns: ${temporalConfigs.map(_.column).mkString(", ")}")
 
-    temporalConfigs.foldLeft(df.select("filename").distinct()) { (accumDf, config) =>
-      val perFilePerValue = df
-        .select("filename", config.column, config.timestamp_column)
-        .groupBy("filename", config.column)
-        .agg(max(col(config.timestamp_column)).alias("_ariadne_max_ts"))
+      temporalConfigs.foldLeft(df.select("filename").distinct()) { (accumDf, config) =>
+        val perFilePerValue = df
+          .select("filename", config.column, config.timestamp_column)
+          .groupBy("filename", config.column)
+          .agg(max(col(config.timestamp_column)).alias("_ariadne_max_ts"))
 
-      val structPerFile = perFilePerValue
-        .withColumn("_struct", struct(col(config.column).as("value"), col("_ariadne_max_ts").as("max_ts")))
-        .groupBy("filename")
-        .agg(collect_set(col("_struct")).alias(config.column))
+        val structPerFile = perFilePerValue
+          .withColumn("_struct", struct(col(config.column).as("value"), col("_ariadne_max_ts").as("max_ts")))
+          .groupBy("filename")
+          .agg(collect_set(col("_struct")).alias(config.column))
 
-      accumDf.join(structPerFile, Seq("filename"), "full_outer")
+        accumDf.join(structPerFile, Seq("filename"), "full_outer")
+      }
     }
   }
 
@@ -339,11 +354,11 @@ trait IndexBuildOperations extends BloomFilterOperations {
     */
   protected def buildRangeIndexes(df: DataFrame): DataFrame = {
     val rangeConfigs = metadata.range_indexes.asScala.toSeq
-    if (rangeConfigs.isEmpty) return df.select("filename").distinct()
+    if (rangeConfigs.isEmpty) df.select("filename").distinct()
+    else {
+      logger.warn(s"Building range indexes for ${rangeConfigs.size} columns: ${rangeConfigs.map(_.column).mkString(", ")}")
 
-    logger.warn(s"Building range indexes for ${rangeConfigs.size} columns: ${rangeConfigs.map(_.column).mkString(", ")}")
-
-    rangeConfigs.foldLeft(df.select("filename").distinct()) { (accumDf, config) =>
+      rangeConfigs.foldLeft(df.select("filename").distinct()) { (accumDf, config) =>
       val rangeCol = s"range_${config.column}"
       val perFile = df
         .select("filename", config.column)
@@ -355,6 +370,7 @@ trait IndexBuildOperations extends BloomFilterOperations {
           ).alias(rangeCol)
         )
       accumDf.join(perFile, Seq("filename"), "full_outer")
+      }
     }
   }
 
@@ -365,10 +381,10 @@ trait IndexBuildOperations extends BloomFilterOperations {
     */
   protected def handleLargeIndexes(df: DataFrame): Unit = {
     val allStorageColumns = storageColumns
-    if (allStorageColumns.isEmpty) return
-
-    logger.warn(s"Checking ${allStorageColumns.size} columns for large index separation (limit=$largeIndexLimit)")
-    appendToLargeIndex(df)
+    if (allStorageColumns.nonEmpty) {
+      logger.warn(s"Checking ${allStorageColumns.size} columns for large index separation (limit=$largeIndexLimit)")
+      appendToLargeIndex(df)
+    }
   }
 
   /** Appends the processed DataFrame to the staging Delta table.
@@ -418,7 +434,7 @@ trait IndexBuildOperations extends BloomFilterOperations {
     */
   protected def appendToLargeIndex(df: DataFrame): Unit = {
     val allStorageColumns = storageColumns
-    if (allStorageColumns.isEmpty) return
+    if (allStorageColumns.nonEmpty) {
     
     val largeGroupedDf = allStorageColumns.foldLeft(df) {
       case (accumDf, colName) =>
@@ -440,10 +456,10 @@ trait IndexBuildOperations extends BloomFilterOperations {
         .filter(col(colName).isNotNull)
         .distinct()
       
-      if (!columnData.isEmpty) {
+      val count = columnData.count()
+      if (count > 0) {
         val columnPath = new Path(largeIndexesFilePath, colName)
-        val rowCount = columnData.count()
-        logger.warn(s"Appending $rowCount rows to large index for column '$colName' at $columnPath")
+        logger.warn(s"Appending $count rows to large index for column '$colName' at $columnPath")
         
         // Remove existing rows for these files to prevent duplicates during re-indexing
         delta(columnPath) match {
@@ -461,6 +477,7 @@ trait IndexBuildOperations extends BloomFilterOperations {
           .mode("append")
           .save(columnPath.toString)
       }
+    }
     }
   }
 
@@ -502,6 +519,8 @@ trait IndexBuildOperations extends BloomFilterOperations {
     *
     * The input DataFrame is cached during processing to avoid redundant computation;
     * the cache reference is stored in [[lastAutoBloomCache]] for deferred cleanup.
+    * If an exception occurs during processing, the cached DataFrame is unpersisted
+    * before the exception is rethrown.
     *
     * @param combinedDf the combined index DataFrame with array columns
     * @return DataFrame with `auto_bloom_{column}` binary columns added for columns
@@ -510,50 +529,57 @@ trait IndexBuildOperations extends BloomFilterOperations {
   protected def buildAutoBloomIndexes(combinedDf: DataFrame): DataFrame = {
     val startTime = System.currentTimeMillis()
     val eligible = autoBloomEligibleColumns
-    if (eligible.isEmpty) return combinedDf
+    if (eligible.isEmpty) combinedDf
+    else {
+      // Cache combinedDf to ensure consistent evaluation when checking column sizes
+      // and building bloom filters
+      val cachedDf = combinedDf.cache()
 
-    // Cache combinedDf to ensure consistent evaluation when checking column sizes
-    // and building bloom filters
-    val cachedDf = combinedDf.cache()
+      try {
+      val columnsExceedingLimit = eligible.filter { colName =>
+        cachedDf.columns.contains(colName) &&
+        cachedDf
+          .select("filename", colName)
+          .where(col(colName).isNotNull)
+          .where(size(col(colName)) >= largeIndexLimit)
+          .count() > 0
+      }
 
-    val columnsExceedingLimit = eligible.filter { colName =>
-      cachedDf.columns.contains(colName) &&
-      cachedDf
-        .select("filename", colName)
-        .where(col(colName).isNotNull)
-        .where(size(col(colName)) >= largeIndexLimit)
-        .count() > 0
-    }
+      logger.warn(s"Auto-bloom: checked ${eligible.size} columns, ${columnsExceedingLimit.size} exceed limit")
 
-    logger.warn(s"Auto-bloom: checked ${eligible.size} columns, ${columnsExceedingLimit.size} exceed limit")
+      columnsExceedingLimit.foreach { colName =>
+        if (!metadata.auto_bloom_indexes.contains(colName)) {
+          metadata.auto_bloom_indexes.add(colName)
+        }
+      }
 
-    columnsExceedingLimit.foreach { colName =>
-      if (!metadata.auto_bloom_indexes.contains(colName)) {
-        metadata.auto_bloom_indexes.add(colName)
+      val autoBloomColumns = metadata.auto_bloom_indexes.asScala.toSet
+        .intersect(eligible)
+        .filter(cachedDf.columns.contains)
+
+      if (autoBloomColumns.isEmpty) {
+        cachedDf.unpersist()
+        logger.warn(s"Auto-bloom: no columns to build, completed in ${System.currentTimeMillis() - startTime}ms")
+        combinedDf
+      } else {
+        logger.warn(s"Building auto-bloom filters for columns: ${autoBloomColumns.mkString(", ")}")
+        val fpr = autoBloomFpr
+        val result = autoBloomColumns.foldLeft(cachedDf) { (df, colName) =>
+          logger.warn(s"Auto-bloom: building filter for '$colName' with FPR=$fpr")
+          val bloomColumn = autoBloomColumnPrefix + colName
+          val bloomUdf = createBloomFilterUdf(fpr)
+          df.withColumn(bloomColumn, bloomUdf(col(colName)))
+        }
+        lastAutoBloomCache = Some(cachedDf)
+        logger.warn(s"Auto-bloom: build completed in ${System.currentTimeMillis() - startTime}ms")
+        result
+      }
+      } catch {
+        case e: Exception =>
+          cachedDf.unpersist()
+          throw e
       }
     }
-
-    val autoBloomColumns = metadata.auto_bloom_indexes.asScala.toSet
-      .intersect(eligible)
-      .filter(cachedDf.columns.contains)
-
-    if (autoBloomColumns.isEmpty) {
-      cachedDf.unpersist()
-      logger.warn(s"Auto-bloom: no columns to build, completed in ${System.currentTimeMillis() - startTime}ms")
-      return combinedDf
-    }
-
-    logger.warn(s"Building auto-bloom filters for columns: ${autoBloomColumns.mkString(", ")}")
-    val fpr = autoBloomFpr
-    val result = autoBloomColumns.foldLeft(cachedDf) { (df, colName) =>
-      logger.warn(s"Auto-bloom: building filter for '$colName' with FPR=$fpr")
-      val bloomColumn = autoBloomColumnPrefix + colName
-      val bloomUdf = createBloomFilterUdf(fpr)
-      df.withColumn(bloomColumn, bloomUdf(col(colName)))
-    }
-    lastAutoBloomCache = Some(cachedDf)
-    logger.warn(s"Auto-bloom: build completed in ${System.currentTimeMillis() - startTime}ms")
-    result
   }
 
   /** Compacts all Delta tables (main index and large index tables) using Delta OPTIMIZE.
@@ -563,6 +589,9 @@ trait IndexBuildOperations extends BloomFilterOperations {
     * large index column table.
     */
   protected def compactDeltaTables(): Unit = {
+    val overallStart = System.currentTimeMillis()
+    val largeIdxCols = largeIndexColumns
+
     delta(indexFilePath).foreach { dt =>
       val compactStart = System.currentTimeMillis()
       logger.warn(s"Compacting main index at $indexFilePath")
@@ -570,7 +599,7 @@ trait IndexBuildOperations extends BloomFilterOperations {
       logger.warn(s"Compacted main index in ${System.currentTimeMillis() - compactStart}ms")
     }
 
-    largeIndexColumns.foreach { colName =>
+    largeIdxCols.foreach { colName =>
       val columnPath = new Path(largeIndexesFilePath, colName)
       delta(columnPath).foreach { dt =>
         val compactStart = System.currentTimeMillis()
@@ -579,6 +608,8 @@ trait IndexBuildOperations extends BloomFilterOperations {
         logger.warn(s"Compacted large index '$colName' in ${System.currentTimeMillis() - compactStart}ms")
       }
     }
+
+    logger.warn(s"Compaction completed for main index and ${largeIdxCols.size} large index table(s) in ${System.currentTimeMillis() - overallStart}ms")
   }
 
   /** Counter tracking batches processed since the last auto-compaction.
@@ -617,6 +648,8 @@ trait IndexBuildOperations extends BloomFilterOperations {
     * @param retentionHours number of hours of history to retain (default 168 = 7 days)
     */
   protected def vacuumDeltaTables(retentionHours: Int = 168): Unit = {
+    val overallStart = System.currentTimeMillis()
+    val largeIdxCols = largeIndexColumns
     val previousCheck = spark.conf.getOption("spark.databricks.delta.retentionDurationCheck.enabled")
     if (retentionHours <= 0) {
       spark.conf.set("spark.databricks.delta.retentionDurationCheck.enabled", "false")
@@ -627,13 +660,15 @@ trait IndexBuildOperations extends BloomFilterOperations {
         dt.vacuum(retentionHours.toDouble)
       }
 
-      largeIndexColumns.foreach { colName =>
+      largeIdxCols.foreach { colName =>
         val columnPath = new Path(largeIndexesFilePath, colName)
         delta(columnPath).foreach { dt =>
           logger.warn(s"Vacuuming large index for column $colName at $columnPath with retention $retentionHours hours")
           dt.vacuum(retentionHours.toDouble)
         }
       }
+
+      logger.warn(s"Vacuum completed for main index and ${largeIdxCols.size} large index table(s) in ${System.currentTimeMillis() - overallStart}ms")
     } finally {
       previousCheck match {
         case Some(v) => spark.conf.set("spark.databricks.delta.retentionDurationCheck.enabled", v)
@@ -668,11 +703,12 @@ trait IndexBuildOperations extends BloomFilterOperations {
   private def consolidateMainStaging(): Unit = {
     if (!exists(stagingFilePath)) {
       logger.warn("No staging data to consolidate for main index")
-      return
-    }
+    } else {
     
     val allStorageColumns = storageColumns ++ bloomStorageColumns ++ rangeStorageColumns ++ autoBloomStorageColumns
     val stagingDf = spark.read.format("delta").load(stagingFilePath.toString)
+    val stagingRowCount = stagingDf.count()
+    logger.warn(s"Merging $stagingRowCount staged rows into main index")
     
     if (allStorageColumns.nonEmpty) {
       delta(indexFilePath) match {
@@ -716,6 +752,7 @@ trait IndexBuildOperations extends BloomFilterOperations {
     // Delete staging after successful consolidation
     delete(stagingFilePath)
     logger.warn("Deleted main staging table after consolidation")
+    }
   }
 
 }

--- a/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
@@ -365,6 +365,9 @@ trait IndexBuildOperations extends BloomFilterOperations {
       metadata.computed_indexes.keySet().asScala ++
       metadata.exploded_field_indexes.asScala.map(_.array_column).toSet
 
+  /** Tracks the cached DataFrame from buildAutoBloomIndexes for deferred cleanup. */
+  @transient protected var lastAutoBloomCache: Option[DataFrame] = None
+
   /** Builds auto-bloom filters for columns that exceed the large index limit.
     *
     * When a column's array exceeds largeIndexLimit for any file, a bloom filter
@@ -382,44 +385,43 @@ trait IndexBuildOperations extends BloomFilterOperations {
     // Cache combinedDf to ensure consistent evaluation when checking column sizes
     // and building bloom filters
     val cachedDf = combinedDf.cache()
-    try {
-      val columnsExceedingLimit = eligible.filter { colName =>
-        cachedDf.columns.contains(colName) &&
-        cachedDf
-          .select("filename", colName)
-          .where(col(colName).isNotNull)
-          .where(size(col(colName)) >= largeIndexLimit)
-          .count() > 0
-      }
 
-      logger.warn(s"Auto-bloom: checked ${eligible.size} columns, ${columnsExceedingLimit.size} exceed limit")
-
-      columnsExceedingLimit.foreach { colName =>
-        if (!metadata.auto_bloom_indexes.contains(colName)) {
-          metadata.auto_bloom_indexes.add(colName)
-        }
-      }
-
-      val autoBloomColumns = metadata.auto_bloom_indexes.asScala.toSet
-        .intersect(eligible)
-        .filter(cachedDf.columns.contains)
-
-      if (autoBloomColumns.isEmpty) {
-        return combinedDf
-      }
-
-      logger.warn(s"Building auto-bloom filters for columns: ${autoBloomColumns.mkString(", ")}")
-      val fpr = autoBloomFpr
-      val result = autoBloomColumns.foldLeft(cachedDf) { (df, colName) =>
-        logger.warn(s"Auto-bloom: building filter for '$colName' with FPR=$fpr")
-        val bloomColumn = autoBloomColumnPrefix + colName
-        val bloomUdf = createBloomFilterUdf(fpr)
-        df.withColumn(bloomColumn, bloomUdf(col(colName)))
-      }
-      result
-    } finally {
-      cachedDf.unpersist()
+    val columnsExceedingLimit = eligible.filter { colName =>
+      cachedDf.columns.contains(colName) &&
+      cachedDf
+        .select("filename", colName)
+        .where(col(colName).isNotNull)
+        .where(size(col(colName)) >= largeIndexLimit)
+        .count() > 0
     }
+
+    logger.warn(s"Auto-bloom: checked ${eligible.size} columns, ${columnsExceedingLimit.size} exceed limit")
+
+    columnsExceedingLimit.foreach { colName =>
+      if (!metadata.auto_bloom_indexes.contains(colName)) {
+        metadata.auto_bloom_indexes.add(colName)
+      }
+    }
+
+    val autoBloomColumns = metadata.auto_bloom_indexes.asScala.toSet
+      .intersect(eligible)
+      .filter(cachedDf.columns.contains)
+
+    if (autoBloomColumns.isEmpty) {
+      cachedDf.unpersist()
+      return combinedDf
+    }
+
+    logger.warn(s"Building auto-bloom filters for columns: ${autoBloomColumns.mkString(", ")}")
+    val fpr = autoBloomFpr
+    val result = autoBloomColumns.foldLeft(cachedDf) { (df, colName) =>
+      logger.warn(s"Auto-bloom: building filter for '$colName' with FPR=$fpr")
+      val bloomColumn = autoBloomColumnPrefix + colName
+      val bloomUdf = createBloomFilterUdf(fpr)
+      df.withColumn(bloomColumn, bloomUdf(col(colName)))
+    }
+    lastAutoBloomCache = Some(cachedDf)
+    result
   }
 
   /** Compacts all Delta tables (main index and large index tables) using OPTIMIZE. */
@@ -442,24 +444,18 @@ trait IndexBuildOperations extends BloomFilterOperations {
     }
   }
 
-  /** Returns true when auto-compaction should run based on the number of Delta log files. */
-  protected def shouldAutoCompact: Boolean = {
-    autoCompactThreshold match {
-      case Some(threshold) =>
-        val logPath = new Path(indexFilePath, "_delta_log")
-        if (exists(logPath)) {
-          val logFileCount = fs.listStatus(logPath).count(_.getPath.getName.endsWith(".json"))
-          logFileCount >= threshold
-        } else false
-      case None => false
-    }
-  }
+  /** Counter tracking batches processed since the last auto-compaction. */
+  protected var batchesSinceCompact: Int = 0
 
   /** Runs compaction if auto-compact threshold is met. */
   protected def maybeAutoCompact(): Unit = {
-    if (shouldAutoCompact) {
-      logger.warn("Auto-compact threshold reached, compacting Delta tables")
-      compactDeltaTables()
+    autoCompactThreshold.foreach { threshold =>
+      batchesSinceCompact += 1
+      if (batchesSinceCompact >= threshold) {
+        logger.warn(s"Auto-compact threshold reached ($batchesSinceCompact batches), compacting Delta tables")
+        compactDeltaTables()
+        batchesSinceCompact = 0
+      }
     }
   }
 

--- a/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
@@ -761,8 +761,14 @@ trait IndexBuildOperations extends BloomFilterOperations {
     }
     
     // Delete staging after successful consolidation
-    delete(stagingFilePath)
-    logger.warn("Deleted main staging table after consolidation")
+    try {
+      delete(stagingFilePath)
+      logger.warn(s"Deleted main staging table after consolidation for index '$name'")
+    } catch {
+      case e: Exception =>
+        logger.warn(s"Failed to delete staging table after consolidation for index '$name': ${e.getMessage}. " +
+          "Staging data may be re-merged on next consolidation (idempotent).", e)
+    }
     }
   }
 

--- a/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
@@ -14,9 +14,15 @@ trait IndexBuildOperations extends BloomFilterOperations {
   /** Computes file sizes in bytes for the given files using HDFS FileSystem.
     */
   protected def getFileSizes(files: Set[String]): Map[String, Long] = {
-    files.toSeq.map { f =>
-      val path = new org.apache.hadoop.fs.Path(f)
-      f -> fs.getFileStatus(path).getLen
+    files.toSeq.flatMap { f =>
+      try {
+        val path = new org.apache.hadoop.fs.Path(f)
+        Some(f -> fs.getFileStatus(path).getLen)
+      } catch {
+        case _: java.io.FileNotFoundException =>
+          logger.warn(s"File not found when computing size, skipping: $f")
+          None
+      }
     }.toMap
   }
 
@@ -450,7 +456,6 @@ trait IndexBuildOperations extends BloomFilterOperations {
   /** Runs compaction if auto-compact threshold is met. */
   protected def maybeAutoCompact(): Unit = {
     autoCompactThreshold.foreach { threshold =>
-      batchesSinceCompact += 1
       if (batchesSinceCompact >= threshold) {
         logger.warn(s"Auto-compact threshold reached ($batchesSinceCompact batches), compacting Delta tables")
         compactDeltaTables()

--- a/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
@@ -32,6 +32,10 @@ trait IndexBuildOperations extends BloomFilterOperations {
       metadata.exploded_field_indexes.asScala.map(_.array_column).toSet ++
       metadata.temporal_indexes.asScala.map(_.column).toSet
 
+  /** Get the set of range index storage column names (with prefix) */
+  protected def rangeStorageColumns: Set[String] =
+    metadata.range_indexes.asScala.map(c => s"range_${c.column}").toSet
+
   /** Case class to hold file analysis results for batching decisions.
     *
     * @param filename The name of the file
@@ -218,6 +222,33 @@ trait IndexBuildOperations extends BloomFilterOperations {
     }
   }
 
+  /** Builds range indexes storing Struct(min, max) per file.
+    *
+    * For each range index config, groups by filename and computes
+    * the min and max of the column per file.
+    *
+    * @param df The base DataFrame with filename column and source data
+    * @return DataFrame with range struct columns, or filename-only if none configured
+    */
+  protected def buildRangeIndexes(df: DataFrame): DataFrame = {
+    val rangeConfigs = metadata.range_indexes.asScala.toSeq
+    if (rangeConfigs.isEmpty) return df.select("filename").distinct()
+
+    rangeConfigs.foldLeft(df.select("filename").distinct()) { (accumDf, config) =>
+      val rangeCol = s"range_${config.column}"
+      val perFile = df
+        .select("filename", config.column)
+        .groupBy("filename")
+        .agg(
+          struct(
+            min(col(config.column)).alias("min"),
+            max(col(config.column)).alias("max")
+          ).alias(rangeCol)
+        )
+      accumDf.join(perFile, Seq("filename"), "full_outer")
+    }
+  }
+
   /** Handles large indexes by appending directly to large_indexes/{column}.
     *
     * @param df The DataFrame to process for large indexes
@@ -310,6 +341,141 @@ trait IndexBuildOperations extends BloomFilterOperations {
     }
   }
 
+  /** Column name prefix for auto-bloom filter storage */
+  protected val autoBloomColumnPrefix = "auto_bloom_"
+
+  /** Get the set of auto-bloom storage column names (with prefix) */
+  protected def autoBloomStorageColumns: Set[String] =
+    metadata.auto_bloom_indexes.asScala.map(c => autoBloomColumnPrefix + c).toSet
+
+  /** Get the set of columns eligible for auto-bloom filtering (excludes temporal columns) */
+  private def autoBloomEligibleColumns: Set[String] =
+    metadata.indexes.asScala.toSet ++
+      metadata.computed_indexes.keySet().asScala ++
+      metadata.exploded_field_indexes.asScala.map(_.array_column).toSet
+
+  /** Builds auto-bloom filters for columns that exceed the large index limit.
+    *
+    * When a column's array exceeds largeIndexLimit for any file, a bloom filter
+    * is automatically built and stored in the main index with the auto_bloom_ prefix.
+    * At query time, this bloom filter is used to pre-filter which files need to
+    * load large index data.
+    *
+    * @param combinedDf The combined index DataFrame with array columns
+    * @return DataFrame with auto-bloom columns added for large columns
+    */
+  protected def buildAutoBloomIndexes(combinedDf: DataFrame): DataFrame = {
+    val eligible = autoBloomEligibleColumns
+    if (eligible.isEmpty) return combinedDf
+
+    // Cache combinedDf to ensure consistent evaluation when checking column sizes
+    // and building bloom filters
+    val cachedDf = combinedDf.cache()
+
+    val columnsExceedingLimit = eligible.filter { colName =>
+      cachedDf.columns.contains(colName) &&
+      cachedDf
+        .select("filename", colName)
+        .where(col(colName).isNotNull)
+        .where(size(col(colName)) >= largeIndexLimit)
+        .count() > 0
+    }
+
+    var metadataChanged = false
+    columnsExceedingLimit.foreach { colName =>
+      if (!metadata.auto_bloom_indexes.contains(colName)) {
+        metadata.auto_bloom_indexes.add(colName)
+        metadataChanged = true
+      }
+    }
+    if (metadataChanged) writeMetadata(metadata)
+
+    val autoBloomColumns = metadata.auto_bloom_indexes.asScala.toSet
+      .intersect(eligible)
+      .filter(cachedDf.columns.contains)
+
+    if (autoBloomColumns.isEmpty) {
+      cachedDf.unpersist()
+      return combinedDf
+    }
+
+    logger.warn(s"Building auto-bloom filters for columns: ${autoBloomColumns.mkString(", ")}")
+    val fpr = autoBloomFpr
+    val result = autoBloomColumns.foldLeft(cachedDf) { (df, colName) =>
+      val bloomColumn = autoBloomColumnPrefix + colName
+      val bloomUdf = createBloomFilterUdf(fpr)
+      df.withColumn(bloomColumn, bloomUdf(col(colName)))
+    }
+    result
+  }
+
+  /** Compacts all Delta tables (main index and large index tables) using OPTIMIZE. */
+  protected def compactDeltaTables(): Unit = {
+    delta(indexFilePath).foreach { dt =>
+      logger.warn(s"Compacting main index at $indexFilePath")
+      dt.optimize().executeCompaction()
+    }
+
+    largeIndexColumns.foreach { colName =>
+      val columnPath = new Path(largeIndexesFilePath, colName)
+      delta(columnPath).foreach { dt =>
+        logger.warn(s"Compacting large index for column $colName at $columnPath")
+        dt.optimize().executeCompaction()
+      }
+    }
+  }
+
+  /** Returns true when auto-compaction should run based on the number of Delta log files. */
+  protected def shouldAutoCompact: Boolean = {
+    autoCompactThreshold match {
+      case Some(threshold) =>
+        val logPath = new Path(indexFilePath, "_delta_log")
+        if (exists(logPath)) {
+          val logFileCount = fs.listStatus(logPath).count(_.getPath.getName.endsWith(".json"))
+          logFileCount >= threshold
+        } else false
+      case None => false
+    }
+  }
+
+  /** Runs compaction if auto-compact threshold is met. */
+  protected def maybeAutoCompact(): Unit = {
+    if (shouldAutoCompact) {
+      logger.warn("Auto-compact threshold reached, compacting Delta tables")
+      compactDeltaTables()
+    }
+  }
+
+  /** Vacuums all Delta tables (main index and large index tables) to remove old files.
+    *
+    * @param retentionHours number of hours of history to retain (default 168 = 7 days)
+    */
+  protected def vacuumDeltaTables(retentionHours: Int = 168): Unit = {
+    val previousCheck = spark.conf.getOption("spark.databricks.delta.retentionDurationCheck.enabled")
+    if (retentionHours <= 0) {
+      spark.conf.set("spark.databricks.delta.retentionDurationCheck.enabled", "false")
+    }
+    try {
+      delta(indexFilePath).foreach { dt =>
+        logger.warn(s"Vacuuming main index at $indexFilePath with retention $retentionHours hours")
+        dt.vacuum(retentionHours.toDouble)
+      }
+
+      largeIndexColumns.foreach { colName =>
+        val columnPath = new Path(largeIndexesFilePath, colName)
+        delta(columnPath).foreach { dt =>
+          logger.warn(s"Vacuuming large index for column $colName at $columnPath with retention $retentionHours hours")
+          dt.vacuum(retentionHours.toDouble)
+        }
+      }
+    } finally {
+      previousCheck match {
+        case Some(v) => spark.conf.set("spark.databricks.delta.retentionDurationCheck.enabled", v)
+        case None    => spark.conf.unset("spark.databricks.delta.retentionDurationCheck.enabled")
+      }
+    }
+  }
+
   /** Consolidates staged data into the main index table. */
   protected def consolidateStaging(): Unit = {
     logger.warn("Starting consolidation of staged data")
@@ -325,7 +491,7 @@ trait IndexBuildOperations extends BloomFilterOperations {
       return
     }
     
-    val allStorageColumns = storageColumns ++ bloomStorageColumns
+    val allStorageColumns = storageColumns ++ bloomStorageColumns ++ rangeStorageColumns ++ autoBloomStorageColumns
     val stagingDf = spark.read.format("delta").load(stagingFilePath.toString)
     
     if (allStorageColumns.nonEmpty) {

--- a/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
@@ -234,6 +234,8 @@ trait IndexBuildOperations extends BloomFilterOperations {
     val rangeConfigs = metadata.range_indexes.asScala.toSeq
     if (rangeConfigs.isEmpty) return df.select("filename").distinct()
 
+    logger.warn(s"Building range indexes for ${rangeConfigs.size} columns: ${rangeConfigs.map(_.column).mkString(", ")}")
+
     rangeConfigs.foldLeft(df.select("filename").distinct()) { (accumDf, config) =>
       val rangeCol = s"range_${config.column}"
       val perFile = df
@@ -371,56 +373,62 @@ trait IndexBuildOperations extends BloomFilterOperations {
     // Cache combinedDf to ensure consistent evaluation when checking column sizes
     // and building bloom filters
     val cachedDf = combinedDf.cache()
-
-    val columnsExceedingLimit = eligible.filter { colName =>
-      cachedDf.columns.contains(colName) &&
-      cachedDf
-        .select("filename", colName)
-        .where(col(colName).isNotNull)
-        .where(size(col(colName)) >= largeIndexLimit)
-        .count() > 0
-    }
-
-    var metadataChanged = false
-    columnsExceedingLimit.foreach { colName =>
-      if (!metadata.auto_bloom_indexes.contains(colName)) {
-        metadata.auto_bloom_indexes.add(colName)
-        metadataChanged = true
+    try {
+      val columnsExceedingLimit = eligible.filter { colName =>
+        cachedDf.columns.contains(colName) &&
+        cachedDf
+          .select("filename", colName)
+          .where(col(colName).isNotNull)
+          .where(size(col(colName)) >= largeIndexLimit)
+          .count() > 0
       }
-    }
-    if (metadataChanged) writeMetadata(metadata)
 
-    val autoBloomColumns = metadata.auto_bloom_indexes.asScala.toSet
-      .intersect(eligible)
-      .filter(cachedDf.columns.contains)
+      logger.warn(s"Auto-bloom: checked ${eligible.size} columns, ${columnsExceedingLimit.size} exceed limit")
 
-    if (autoBloomColumns.isEmpty) {
+      columnsExceedingLimit.foreach { colName =>
+        if (!metadata.auto_bloom_indexes.contains(colName)) {
+          metadata.auto_bloom_indexes.add(colName)
+        }
+      }
+
+      val autoBloomColumns = metadata.auto_bloom_indexes.asScala.toSet
+        .intersect(eligible)
+        .filter(cachedDf.columns.contains)
+
+      if (autoBloomColumns.isEmpty) {
+        return combinedDf
+      }
+
+      logger.warn(s"Building auto-bloom filters for columns: ${autoBloomColumns.mkString(", ")}")
+      val fpr = autoBloomFpr
+      val result = autoBloomColumns.foldLeft(cachedDf) { (df, colName) =>
+        logger.warn(s"Auto-bloom: building filter for '$colName' with FPR=$fpr")
+        val bloomColumn = autoBloomColumnPrefix + colName
+        val bloomUdf = createBloomFilterUdf(fpr)
+        df.withColumn(bloomColumn, bloomUdf(col(colName)))
+      }
+      result
+    } finally {
       cachedDf.unpersist()
-      return combinedDf
     }
-
-    logger.warn(s"Building auto-bloom filters for columns: ${autoBloomColumns.mkString(", ")}")
-    val fpr = autoBloomFpr
-    val result = autoBloomColumns.foldLeft(cachedDf) { (df, colName) =>
-      val bloomColumn = autoBloomColumnPrefix + colName
-      val bloomUdf = createBloomFilterUdf(fpr)
-      df.withColumn(bloomColumn, bloomUdf(col(colName)))
-    }
-    result
   }
 
   /** Compacts all Delta tables (main index and large index tables) using OPTIMIZE. */
   protected def compactDeltaTables(): Unit = {
     delta(indexFilePath).foreach { dt =>
+      val compactStart = System.currentTimeMillis()
       logger.warn(s"Compacting main index at $indexFilePath")
       dt.optimize().executeCompaction()
+      logger.warn(s"Compacted main index in ${System.currentTimeMillis() - compactStart}ms")
     }
 
     largeIndexColumns.foreach { colName =>
       val columnPath = new Path(largeIndexesFilePath, colName)
       delta(columnPath).foreach { dt =>
+        val compactStart = System.currentTimeMillis()
         logger.warn(s"Compacting large index for column $colName at $columnPath")
         dt.optimize().executeCompaction()
+        logger.warn(s"Compacted large index '$colName' in ${System.currentTimeMillis() - compactStart}ms")
       }
     }
   }

--- a/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
@@ -594,6 +594,7 @@ trait IndexBuildOperations extends BloomFilterOperations {
     * Checks the [[batchesSinceCompact]] counter against the configured
     * `autoCompactThreshold`. If the threshold is met,
     * compacts all Delta tables and resets the counter to zero.
+    * The counter is persisted to metadata so it survives across Spark jobs.
     */
   protected def maybeAutoCompact(): Unit = {
     autoCompactThreshold.foreach { threshold =>
@@ -601,6 +602,8 @@ trait IndexBuildOperations extends BloomFilterOperations {
         logger.warn(s"Auto-compact threshold reached ($batchesSinceCompact batches), compacting Delta tables")
         compactDeltaTables()
         batchesSinceCompact = 0
+        metadata.batches_since_compact = 0
+        writeMetadata(metadata)
       }
     }
   }

--- a/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
@@ -667,10 +667,10 @@ trait IndexBuildOperations extends BloomFilterOperations {
     val overallStart = System.currentTimeMillis()
     val largeIdxCols = largeIndexColumns
     val previousCheck = spark.conf.getOption("spark.databricks.delta.retentionDurationCheck.enabled")
-    if (retentionHours <= 0) {
-      spark.conf.set("spark.databricks.delta.retentionDurationCheck.enabled", "false")
-    }
     try {
+      if (retentionHours <= 0) {
+        spark.conf.set("spark.databricks.delta.retentionDurationCheck.enabled", "false")
+      }
       delta(indexFilePath).foreach { dt =>
         logger.warn(s"Vacuuming main index at $indexFilePath with retention $retentionHours hours")
         dt.vacuum(retentionHours.toDouble)
@@ -730,7 +730,9 @@ trait IndexBuildOperations extends BloomFilterOperations {
       delta(indexFilePath) match {
         case Some(deltaTable) =>
           logger.warn(s"Merging staging data into main index at ${indexFilePath}")
-          // Enable schema auto-merge so new index columns evolve the target table
+          // Enable schema auto-merge so new index columns evolve the target table.
+          // NOTE: SparkConf mutation is not thread-safe — concurrent Index instances
+          // sharing the same SparkSession could clobber each other's config values.
           val previousAutoMerge = spark.conf.getOption("spark.databricks.delta.schema.autoMerge.enabled")
           spark.conf.set("spark.databricks.delta.schema.autoMerge.enabled", "true")
           try {

--- a/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
@@ -166,6 +166,9 @@ trait IndexBuildOperations extends BloomFilterOperations {
       countDistinct(col(colName)).alias(s"${colName}_distinct")
     }
     
+    if (distinctCountExprs.isEmpty) {
+      files.map(f => FileAnalysis(f, Map.empty, 0L)).toSeq
+    } else {
     val fileAnalysisDf = withFilename
       .groupBy("filename")
       .agg(distinctCountExprs.head, distinctCountExprs.tail: _*)
@@ -184,6 +187,7 @@ trait IndexBuildOperations extends BloomFilterOperations {
 
     logger.warn(s"Pre-flight analysis of ${files.size} files completed in ${System.currentTimeMillis() - startTime}ms")
     results
+      }
       }
     }
   }
@@ -279,6 +283,7 @@ trait IndexBuildOperations extends BloomFilterOperations {
       val regularCols = (regularIndexes + "filename").toList
       val selectedDf = df.select(regularCols.map(col): _*).distinct
       val aggExprs = regularIndexes.toList.map(colName => collect_set(col(colName)).alias(colName))
+      // Safe: regularIndexes.nonEmpty guard above guarantees aggExprs.nonEmpty
       selectedDf.groupBy("filename").agg(aggExprs.head, aggExprs.tail: _*)
     } else {
       df.select("filename").distinct

--- a/src/main/scala/dev/cjfravel/ariadne/IndexCatalog.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexCatalog.scala
@@ -1,0 +1,318 @@
+package dev.cjfravel.ariadne
+
+import dev.cjfravel.ariadne.exceptions.IndexNotFoundException
+import org.apache.hadoop.fs.Path
+import org.apache.logging.log4j.LogManager
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.types._
+import scala.collection.JavaConverters._
+
+/** Summary information for a single Ariadne index.
+  *
+  * Captures the index name, data format, all configured index types, tracked
+  * file count, and cumulative indexed file size. Produced by
+  * [[IndexCatalog.describe]] and [[IndexCatalog.describeAll]].
+  *
+  * @param name                  unique index name
+  * @param format                data file format (e.g., "parquet", "csv", "json")
+  * @param columns               union of all indexed column names across every index type
+  * @param regularIndexes        columns with regular (array-of-values) indexes
+  * @param bloomIndexes          columns with bloom filter indexes
+  * @param computedIndexes       computed index aliases (derived via SQL expressions)
+  * @param temporalIndexes       columns with temporal (version-dedup) indexes
+  * @param rangeIndexes          columns with min/max range indexes
+  * @param explodedFieldIndexes  aliases for exploded array field indexes
+  * @param fileCount             number of files tracked by this index's file list
+  * @param totalIndexedFileSize  cumulative size in bytes of all indexed files, or -1 if unknown
+  */
+case class IndexSummary(
+    name: String,
+    format: String,
+    columns: Set[String],
+    regularIndexes: Set[String],
+    bloomIndexes: Set[String],
+    computedIndexes: Set[String],
+    temporalIndexes: Set[String],
+    rangeIndexes: Set[String],
+    explodedFieldIndexes: Set[String],
+    fileCount: Long,
+    totalIndexedFileSize: Long
+)
+
+/** Catalog for discovering, inspecting, and managing all Ariadne indexes
+  * under the configured `spark.ariadne.storagePath`.
+  *
+  * `IndexCatalog` is stateless — every call scans the filesystem for the
+  * current set of indexes. It complements the per-index API on [[Index]] by
+  * providing a global view of the storage path.
+  *
+  * '''Usage:'''
+  * {{{
+  * import dev.cjfravel.ariadne.IndexCatalog
+  *
+  * // List all index names
+  * val names: Seq[String] = IndexCatalog.list()
+  *
+  * // Get a summary of every index
+  * val summaries: Seq[IndexSummary] = IndexCatalog.describeAll()
+  *
+  * // View all indexes as a DataFrame
+  * IndexCatalog.toDF().show()
+  *
+  * // Fetch a specific Index instance
+  * val index: Index = IndexCatalog.get("myIndex")
+  * }}}
+  */
+object IndexCatalog {
+
+  private val logger = LogManager.getLogger("ariadne")
+
+  /** Lists the names of all indexes in the configured storage path.
+    *
+    * Scans the `{storagePath}/indexes/` directory for subdirectories that
+    * contain a `metadata.json` file — this distinguishes real indexes from
+    * stale or partially deleted directories.
+    *
+    * @param spark implicit SparkSession providing configuration
+    * @return alphabetically sorted sequence of index names, or empty if none exist
+    */
+  def list()(implicit spark: SparkSession): Seq[String] = {
+    val sparkSession = spark
+    val contextUser = new AriadneContextUser {
+      implicit def spark: SparkSession = sparkSession
+    }
+    val indexesDir = IndexPathUtils.storagePath
+    if (!contextUser.exists(indexesDir)) {
+      logger.warn("IndexCatalog: indexes directory does not exist, returning empty list")
+      return Seq.empty
+    }
+
+    val statuses = contextUser.fs.listStatus(indexesDir)
+    statuses
+      .filter(_.isDirectory)
+      .filter { status =>
+        val metadataPath = new Path(status.getPath, "metadata.json")
+        contextUser.fs.exists(metadataPath)
+      }
+      .map(_.getPath.getName)
+      .sorted
+      .toSeq
+  }
+
+  /** Checks whether an index with the given name exists.
+    *
+    * An index is considered to exist if its `metadata.json` file is present
+    * in the indexes storage directory, or if its file list entry exists.
+    *
+    * @param name  the index name to check
+    * @param spark implicit SparkSession
+    * @return true if the index exists
+    */
+  def exists(name: String)(implicit spark: SparkSession): Boolean = {
+    val sparkSession = spark
+    val contextUser = new AriadneContextUser {
+      implicit def spark: SparkSession = sparkSession
+    }
+    val metadataPath = new Path(new Path(IndexPathUtils.storagePath, name), "metadata.json")
+    contextUser.fs.exists(metadataPath) || IndexPathUtils.exists(name)
+  }
+
+  /** Returns a summary of a single index.
+    *
+    * Reads the index's `metadata.json` and file list to populate an
+    * [[IndexSummary]] with all configured index types and tracked file count.
+    *
+    * @param name  the index name
+    * @param spark implicit SparkSession
+    * @return the index summary
+    * @throws IndexNotFoundException if the index does not exist
+    */
+  def describe(name: String)(implicit spark: SparkSession): IndexSummary = {
+    if (!exists(name)) {
+      throw new IndexNotFoundException(name)
+    }
+    buildSummary(name)
+  }
+
+  /** Returns summaries for all indexes in the storage path.
+    *
+    * Equivalent to calling [[describe]] for each name returned by [[list]],
+    * but logs a single message for the batch operation. Indexes whose metadata
+    * cannot be read are skipped with a warning.
+    *
+    * @param spark implicit SparkSession
+    * @return sequence of [[IndexSummary]], one per valid index
+    */
+  def describeAll()(implicit spark: SparkSession): Seq[IndexSummary] = {
+    val names = list()
+    logger.warn(s"IndexCatalog: describing ${names.size} index(es)")
+    names.flatMap { name =>
+      try {
+        Some(buildSummary(name))
+      } catch {
+        case e: Exception =>
+          logger.warn(s"IndexCatalog: skipping index '$name' — ${e.getMessage}")
+          None
+      }
+    }
+  }
+
+  /** Fetches an [[Index]] instance by reconnecting to an existing index.
+    *
+    * This is equivalent to calling `Index(name)` directly; it is provided
+    * here for API completeness so callers can discover and fetch indexes
+    * without importing [[Index]].
+    *
+    * @param name  the index name
+    * @param spark implicit SparkSession
+    * @return a fully initialized Index instance
+    * @throws IndexNotFoundException if the index does not exist
+    */
+  def get(name: String)(implicit spark: SparkSession): Index = {
+    if (!exists(name)) {
+      throw new IndexNotFoundException(name)
+    }
+    Index(name)
+  }
+
+  /** Returns a DataFrame summarizing all indexes.
+    *
+    * The returned DataFrame has one row per index with the following columns:
+    * {{{
+    * name: String
+    * format: String
+    * regular_indexes: String   (comma-separated)
+    * bloom_indexes: String     (comma-separated)
+    * computed_indexes: String   (comma-separated)
+    * temporal_indexes: String   (comma-separated)
+    * range_indexes: String      (comma-separated)
+    * exploded_field_indexes: String (comma-separated)
+    * file_count: Long
+    * total_indexed_file_size: Long
+    * }}}
+    *
+    * @param spark implicit SparkSession
+    * @return DataFrame with one row per index, or an empty DataFrame if no indexes exist
+    */
+  def toDF()(implicit spark: SparkSession): DataFrame = {
+    val summaries = describeAll()
+    val schema = StructType(Seq(
+      StructField("name", StringType, nullable = false),
+      StructField("format", StringType, nullable = false),
+      StructField("regular_indexes", StringType, nullable = false),
+      StructField("bloom_indexes", StringType, nullable = false),
+      StructField("computed_indexes", StringType, nullable = false),
+      StructField("temporal_indexes", StringType, nullable = false),
+      StructField("range_indexes", StringType, nullable = false),
+      StructField("exploded_field_indexes", StringType, nullable = false),
+      StructField("file_count", LongType, nullable = false),
+      StructField("total_indexed_file_size", LongType, nullable = false)
+    ))
+
+    if (summaries.isEmpty) {
+      return spark.createDataFrame(
+        spark.sparkContext.emptyRDD[Row],
+        schema
+      )
+    }
+
+    val rows = summaries.map { s =>
+      Row(
+        s.name,
+        s.format,
+        s.regularIndexes.toSeq.sorted.mkString(", "),
+        s.bloomIndexes.toSeq.sorted.mkString(", "),
+        s.computedIndexes.toSeq.sorted.mkString(", "),
+        s.temporalIndexes.toSeq.sorted.mkString(", "),
+        s.rangeIndexes.toSeq.sorted.mkString(", "),
+        s.explodedFieldIndexes.toSeq.sorted.mkString(", "),
+        s.fileCount,
+        s.totalIndexedFileSize
+      )
+    }
+    spark.createDataFrame(
+      spark.sparkContext.parallelize(rows),
+      schema
+    )
+  }
+
+  /** Removes an index by name.
+    *
+    * Deletes the index storage directory (containing metadata, index tables,
+    * staging, and large indexes) and the associated file list Delta table.
+    *
+    * @param name  the index name
+    * @param spark implicit SparkSession
+    * @return true if any resources were removed
+    * @throws IndexNotFoundException if the index does not exist
+    */
+  def remove(name: String)(implicit spark: SparkSession): Boolean = {
+    if (!exists(name)) {
+      throw new IndexNotFoundException(name)
+    }
+    val sparkSession = spark
+    val contextUser = new AriadneContextUser {
+      implicit def spark: SparkSession = sparkSession
+    }
+
+    logger.warn(s"IndexCatalog: removing index '$name'")
+    val indexDir = new Path(IndexPathUtils.storagePath, name)
+    val indexDeleted = if (contextUser.fs.exists(indexDir)) {
+      contextUser.delete(indexDir)
+    } else false
+
+    val fileListName = IndexPathUtils.fileListName(name)
+    val fileListDeleted = if (FileList.exists(fileListName)) {
+      FileList.remove(fileListName)
+    } else false
+
+    indexDeleted || fileListDeleted
+  }
+
+  // ---- internal helpers ----
+
+  /** Builds an [[IndexSummary]] by reading metadata and file list for the
+    * given index name.
+    */
+  private def buildSummary(
+      name: String
+  )(implicit spark: SparkSession): IndexSummary = {
+    val index = Index(name)
+    val md = index.metadata
+
+    val regularIndexes = md.indexes.asScala.toSet
+    val bloomIndexes = md.bloom_indexes.asScala.map(_.column).toSet
+    val computedIndexes = md.computed_indexes.keySet().asScala.toSet
+    val temporalIndexes = md.temporal_indexes.asScala.map(_.column).toSet
+    val rangeIndexes = md.range_indexes.asScala.map(_.column).toSet
+    val explodedFieldIndexes = md.exploded_field_indexes.asScala.map(_.as_column).toSet
+
+    val allColumns = regularIndexes ++ bloomIndexes ++ computedIndexes ++
+      temporalIndexes ++ rangeIndexes ++ explodedFieldIndexes
+
+    val fileListName = IndexPathUtils.fileListName(name)
+    val fileCount = if (FileList.exists(fileListName)) {
+      FileList(fileListName).files.count()
+    } else {
+      0L
+    }
+
+    val totalSize = Option(md.total_indexed_file_size)
+      .map(_.toLong)
+      .getOrElse(-1L)
+
+    IndexSummary(
+      name = name,
+      format = md.format,
+      columns = allColumns,
+      regularIndexes = regularIndexes,
+      bloomIndexes = bloomIndexes,
+      computedIndexes = computedIndexes,
+      temporalIndexes = temporalIndexes,
+      rangeIndexes = rangeIndexes,
+      explodedFieldIndexes = explodedFieldIndexes,
+      fileCount = fileCount,
+      totalIndexedFileSize = totalSize
+    )
+  }
+}

--- a/src/main/scala/dev/cjfravel/ariadne/IndexCatalog.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexCatalog.scala
@@ -208,12 +208,15 @@ object IndexCatalog {
     */
   def findIndexes(fileName: String)(implicit spark: SparkSession): Seq[String] = {
     require(fileName != null && fileName.trim.nonEmpty, "fileName must not be null or blank")
+    val startTime = System.currentTimeMillis()
     val names = list()
     logger.warn(s"IndexCatalog: searching ${names.size} index(es) for file '$fileName'")
-    names.filter { name =>
+    val result = names.filter { name =>
       val fileListName = IndexPathUtils.fileListName(name)
       FileList.exists(fileListName) && FileList(fileListName).hasFile(fileName)
     }
+    logger.warn(s"IndexCatalog: findIndexes completed for '$fileName' — found ${result.size} match(es) in ${System.currentTimeMillis() - startTime}ms")
+    result
   }
 
   /** Fetches an [[Index]] instance by reconnecting to an existing index.

--- a/src/main/scala/dev/cjfravel/ariadne/IndexCatalog.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexCatalog.scala
@@ -134,6 +134,7 @@ object IndexCatalog {
     * @throws IndexNotFoundException if the index does not exist
     */
   def describe(name: String)(implicit spark: SparkSession): IndexSummary = {
+    require(name != null && name.trim.nonEmpty, "name must not be null or blank")
     if (!exists(name)) {
       throw new IndexNotFoundException(name)
     }
@@ -182,6 +183,7 @@ object IndexCatalog {
     *         or empty if the file is not found in any index
     */
   def findIndexes(fileName: String)(implicit spark: SparkSession): Seq[String] = {
+    require(fileName != null && fileName.trim.nonEmpty, "fileName must not be null or blank")
     val names = list()
     logger.warn(s"IndexCatalog: searching ${names.size} index(es) for file '$fileName'")
     names.filter { name =>
@@ -284,6 +286,7 @@ object IndexCatalog {
     * @throws IndexNotFoundException if the index does not exist
     */
   def remove(name: String)(implicit spark: SparkSession): Boolean = {
+    require(name != null && name.trim.nonEmpty, "name must not be null or blank")
     if (!exists(name)) {
       throw new IndexNotFoundException(name)
     }
@@ -305,7 +308,8 @@ object IndexCatalog {
         FileList.remove(fileListName)
       } else false
     } catch {
-      case _: FileListNotFoundException =>
+      case e: FileListNotFoundException =>
+        logger.debug(s"FileList not found during removal of index '$name' — may have been already removed: ${e.getMessage}")
         false
     }
 

--- a/src/main/scala/dev/cjfravel/ariadne/IndexCatalog.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexCatalog.scala
@@ -1,6 +1,6 @@
 package dev.cjfravel.ariadne
 
-import dev.cjfravel.ariadne.exceptions.IndexNotFoundException
+import dev.cjfravel.ariadne.exceptions.{IndexNotFoundException, FileListNotFoundException}
 import org.apache.hadoop.fs.Path
 import org.apache.logging.log4j.LogManager
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
@@ -84,19 +84,25 @@ object IndexCatalog {
     val indexesDir = IndexPathUtils.storagePath
     if (!contextUser.exists(indexesDir)) {
       logger.warn("IndexCatalog: indexes directory does not exist, returning empty list")
-      return Seq.empty
-    }
-
-    val statuses = contextUser.fs.listStatus(indexesDir)
-    statuses
-      .filter(_.isDirectory)
-      .filter { status =>
-        val metadataPath = new Path(status.getPath, "metadata.json")
-        contextUser.fs.exists(metadataPath)
+      Seq.empty
+    } else {
+      val statuses = contextUser.fs.listStatus(indexesDir)
+      if (statuses == null) {
+        Seq.empty
+      } else {
+        val result = statuses
+          .filter(_.isDirectory)
+          .filter { status =>
+            val metadataPath = new Path(status.getPath, "metadata.json")
+            contextUser.fs.exists(metadataPath)
+          }
+          .map(_.getPath.getName)
+          .sorted
+          .toSeq
+        logger.warn(s"IndexCatalog: found ${result.size} index(es)")
+        result
       }
-      .map(_.getPath.getName)
-      .sorted
-      .toSeq
+    }
   }
 
   /** Checks whether an index with the given name exists.
@@ -199,6 +205,7 @@ object IndexCatalog {
     if (!exists(name)) {
       throw new IndexNotFoundException(name)
     }
+    logger.debug(s"IndexCatalog: fetching index '$name'")
     Index(name)
   }
 
@@ -237,11 +244,11 @@ object IndexCatalog {
     ))
 
     if (summaries.isEmpty) {
-      return spark.createDataFrame(
+      spark.createDataFrame(
         spark.sparkContext.emptyRDD[Row],
         schema
       )
-    }
+    } else {
 
     val rows = summaries.map { s =>
       Row(
@@ -261,12 +268,15 @@ object IndexCatalog {
       spark.sparkContext.parallelize(rows),
       schema
     )
+    }
   }
 
   /** Removes an index by name.
     *
     * Deletes the index storage directory (containing metadata, index tables,
     * staging, and large indexes) and the associated file list Delta table.
+    * If the file list has already been removed by another process, it is
+    * treated as a successful no-op for that resource.
     *
     * @param name  the index name
     * @param spark implicit SparkSession
@@ -282,6 +292,7 @@ object IndexCatalog {
       implicit def spark: SparkSession = sparkSession
     }
 
+    val startTime = System.currentTimeMillis()
     logger.warn(s"IndexCatalog: removing index '$name'")
     val indexDir = new Path(IndexPathUtils.storagePath, name)
     val indexDeleted = if (contextUser.fs.exists(indexDir)) {
@@ -289,10 +300,20 @@ object IndexCatalog {
     } else false
 
     val fileListName = IndexPathUtils.fileListName(name)
-    val fileListDeleted = if (FileList.exists(fileListName)) {
-      FileList.remove(fileListName)
-    } else false
+    val fileListDeleted = try {
+      if (FileList.exists(fileListName)) {
+        FileList.remove(fileListName)
+      } else false
+    } catch {
+      case _: FileListNotFoundException =>
+        false
+    }
 
+    val elapsed = System.currentTimeMillis() - startTime
+    logger.warn(
+      s"IndexCatalog: successfully removed index '$name' in ${elapsed}ms " +
+        s"(indexDir=$indexDeleted, fileList=$fileListDeleted)"
+    )
     indexDeleted || fileListDeleted
   }
 

--- a/src/main/scala/dev/cjfravel/ariadne/IndexCatalog.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexCatalog.scala
@@ -157,6 +157,33 @@ object IndexCatalog {
     }
   }
 
+  /** Returns the names of all indexes that track a given file.
+    *
+    * Scans every index's file list to check whether `fileName` is present.
+    * This is useful for determining which indexes need a `deleteFiles` call
+    * when a source file has been removed from storage.
+    *
+    * {{{
+    * val affected: Seq[String] = IndexCatalog.findIndexes("s3a://bucket/data/file1.parquet")
+    * affected.foreach { name =>
+    *   IndexCatalog.get(name).deleteFiles("s3a://bucket/data/file1.parquet")
+    * }
+    * }}}
+    *
+    * @param fileName the file path to search for across all indexes
+    * @param spark    implicit SparkSession
+    * @return alphabetically sorted names of indexes that track the file,
+    *         or empty if the file is not found in any index
+    */
+  def findIndexes(fileName: String)(implicit spark: SparkSession): Seq[String] = {
+    val names = list()
+    logger.warn(s"IndexCatalog: searching ${names.size} index(es) for file '$fileName'")
+    names.filter { name =>
+      val fileListName = IndexPathUtils.fileListName(name)
+      FileList.exists(fileListName) && FileList(fileListName).hasFile(fileName)
+    }
+  }
+
   /** Fetches an [[Index]] instance by reconnecting to an existing index.
     *
     * This is equivalent to calling `Index(name)` directly; it is provided

--- a/src/main/scala/dev/cjfravel/ariadne/IndexCatalog.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexCatalog.scala
@@ -73,6 +73,12 @@ object IndexCatalog {
     * contain a `metadata.json` file — this distinguishes real indexes from
     * stale or partially deleted directories.
     *
+    * @example
+    * {{{
+    * val catalog = IndexCatalog(spark)
+    * val indexNames: Seq[String] = catalog.list()
+    * }}}
+    *
     * @param spark implicit SparkSession providing configuration
     * @return alphabetically sorted sequence of index names, or empty if none exist
     */
@@ -129,6 +135,12 @@ object IndexCatalog {
     * Reads the index's `metadata.json` and file list to populate an
     * [[IndexSummary]] with all configured index types and tracked file count.
     *
+    * @example
+    * {{{
+    * val summary: IndexSummary = catalog.describe("myIndex")
+    * println(summary.name, summary.fileCount)
+    * }}}
+    *
     * @param name  the index name
     * @param spark implicit SparkSession
     * @return the index summary
@@ -147,6 +159,12 @@ object IndexCatalog {
     * Equivalent to calling [[describe]] for each name returned by [[list]],
     * but logs a single message for the batch operation. Indexes whose metadata
     * cannot be read are skipped with a warning.
+    *
+    * @example
+    * {{{
+    * val summaries: Seq[IndexSummary] = catalog.describeAll()
+    * summaries.foreach(s => println(s.name))
+    * }}}
     *
     * @param spark implicit SparkSession
     * @return sequence of [[IndexSummary]], one per valid index
@@ -170,6 +188,11 @@ object IndexCatalog {
     * Scans every index's file list to check whether `fileName` is present.
     * This is useful for determining which indexes need a `deleteFiles` call
     * when a source file has been removed from storage.
+    *
+    * @example
+    * {{{
+    * val indexes: Seq[String] = catalog.findIndexes("/data/users/part-00000.parquet")
+    * }}}
     *
     * {{{
     * val affected: Seq[String] = IndexCatalog.findIndexes("s3a://bucket/data/file1.parquet")
@@ -199,6 +222,11 @@ object IndexCatalog {
     * here for API completeness so callers can discover and fetch indexes
     * without importing [[Index]].
     *
+    * @example
+    * {{{
+    * val index: Index = catalog.get("myIndex")
+    * }}}
+    *
     * @param name  the index name
     * @param spark implicit SparkSession
     * @return a fully initialized Index instance
@@ -227,6 +255,12 @@ object IndexCatalog {
     * exploded_field_indexes: String (comma-separated)
     * file_count: Long
     * total_indexed_file_size: Long
+    * }}}
+    *
+    * @example
+    * {{{
+    * val df: DataFrame = catalog.toDF()
+    * df.show()
     * }}}
     *
     * @param spark implicit SparkSession
@@ -281,6 +315,11 @@ object IndexCatalog {
     * staging, and large indexes) and the associated file list Delta table.
     * If the file list has already been removed by another process, it is
     * treated as a successful no-op for that resource.
+    *
+    * @example
+    * {{{
+    * catalog.remove("oldIndex")
+    * }}}
     *
     * @param name  the index name
     * @param spark implicit SparkSession

--- a/src/main/scala/dev/cjfravel/ariadne/IndexCatalog.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexCatalog.scala
@@ -115,6 +115,7 @@ object IndexCatalog {
     * @return true if the index exists
     */
   def exists(name: String)(implicit spark: SparkSession): Boolean = {
+    require(name != null && name.trim.nonEmpty, "Index name must not be null or blank")
     val sparkSession = spark
     val contextUser = new AriadneContextUser {
       implicit def spark: SparkSession = sparkSession
@@ -204,6 +205,7 @@ object IndexCatalog {
     * @throws IndexNotFoundException if the index does not exist
     */
   def get(name: String)(implicit spark: SparkSession): Index = {
+    require(name != null && name.trim.nonEmpty, "Index name must not be null or blank")
     if (!exists(name)) {
       throw new IndexNotFoundException(name)
     }

--- a/src/main/scala/dev/cjfravel/ariadne/IndexFileOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexFileOperations.scala
@@ -6,17 +6,30 @@ import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.sql.functions._
 import scala.collection.JavaConverters._
 
-/** Trait providing file operations for Index instances.
+/** Trait providing file I/O operations for Index instances.
+  *
+  * Handles reading data files in supported formats (CSV, Parquet, JSON),
+  * applying computed indexes and exploded field transformations, and
+  * managing column selection for optimized reads.
   */
 trait IndexFileOperations extends IndexMetadataOperations {
   self: Index =>
 
-  /** Returns the stored schema of the index. */
-  def storedSchema: StructType =
+  /** Returns the stored schema of the index.
+    *
+    * @return The StructType schema parsed from metadata
+    * @throws MissingSchemaException if the schema is null in metadata
+    * @throws SchemaParseException if the schema string cannot be parsed as a StructType
+    */
+  def storedSchema: StructType = {
+    if (metadata.schema == null) {
+      throw new dev.cjfravel.ariadne.exceptions.MissingSchemaException()
+    }
     DataType.fromJson(metadata.schema) match {
       case st: StructType => st
       case _ => throw new SchemaParseException()
     }
+  }
 
   /** Reads a set of files into a DataFrame based on the specified format.
     *
@@ -94,8 +107,14 @@ trait IndexFileOperations extends IndexMetadataOperations {
     }
   }
 
-  /** Adds a stable filename column, falling back to the source path for
-    * single-file reads when Spark reports an empty filename.
+  /** Adds a stable filename column to the DataFrame.
+    *
+    * Uses `input_file_name()` to capture the source file path. For single-file
+    * reads where Spark may report an empty filename, falls back to the known file path.
+    *
+    * @param df The DataFrame to add the filename column to
+    * @param files The set of file paths being read
+    * @return DataFrame with a `filename` column added
     */
   protected def addFilenameColumn(df: DataFrame, files: Set[String]): DataFrame = {
     if (files.size == 1) {

--- a/src/main/scala/dev/cjfravel/ariadne/IndexFileOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexFileOperations.scala
@@ -1,5 +1,6 @@
 package dev.cjfravel.ariadne
 
+import dev.cjfravel.ariadne.exceptions.SchemaParseException
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.sql.functions._
@@ -12,7 +13,10 @@ trait IndexFileOperations extends IndexMetadataOperations {
 
   /** Returns the stored schema of the index. */
   def storedSchema: StructType =
-    DataType.fromJson(metadata.schema).asInstanceOf[StructType]
+    DataType.fromJson(metadata.schema) match {
+      case st: StructType => st
+      case _ => throw new SchemaParseException()
+    }
 
   /** Reads a set of files into a DataFrame based on the specified format.
     *

--- a/src/main/scala/dev/cjfravel/ariadne/IndexFileOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexFileOperations.scala
@@ -6,11 +6,28 @@ import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.sql.functions._
 import scala.collection.JavaConverters._
 
-/** Trait providing file I/O operations for Index instances.
+/** Trait providing file I/O operations for [[Index]] instances.
   *
   * Handles reading data files in supported formats (CSV, Parquet, JSON),
   * applying computed indexes and exploded field transformations, and
   * managing column selection for optimized reads.
+  *
+  * '''Read pipeline:''' [[readFiles]] orchestrates the full read path:
+  *  1. [[createBaseDataFrame]] — loads files using the stored schema, format, and read options
+  *  2. [[applyComputedIndexes]] — adds derived columns via Spark SQL expressions
+  *  3. [[applyExplodedFields]] — explodes nested array fields into top-level columns
+  *  4. [[applyColumnSelection]] — prunes to user-selected columns if specified
+  *
+  * '''Format support:''' CSV, Parquet, and JSON. The format is stored in
+  * [[IndexMetadata]] and determines which Spark reader method is used.
+  * Read options (e.g., `header`, `delimiter`) are applied from metadata.
+  *
+  * '''Filename tracking:''' [[addFilenameColumn]] uses `input_file_name()` to
+  * attach the source file path to each row. For single-file reads, a fallback
+  * literal is used because Spark may report an empty filename.
+  *
+  * @see [[IndexMetadataOperations]] for metadata access
+  * @see [[IndexBuildOperations]] for the build pipeline that calls these operations
   */
 trait IndexFileOperations extends IndexMetadataOperations {
   self: Index =>
@@ -35,12 +52,22 @@ trait IndexFileOperations extends IndexMetadataOperations {
 
   /** Reads a set of files into a DataFrame based on the specified format.
     *
+    * Orchestrates the full read pipeline:
+    *  1. [[createBaseDataFrame]] — loads files using stored schema, format, and read options
+    *  2. [[applyComputedIndexes]] — adds derived columns via Spark SQL expressions
+    *  3. [[applyExplodedFields]] — explodes nested array fields into top-level columns
+    *  4. [[applyColumnSelection]] — prunes to user-selected columns if specified
+    *
     * @param files
-    *   A set of file paths to read.
+    *   A set of file paths to read
     * @return
-    *   A DataFrame containing the contents of the specified files.
+    *   A DataFrame containing the contents of the specified files, with computed
+    *   indexes, exploded fields, and column selection applied
+    * @throws IllegalArgumentException
+    *   if the stored format is not csv, parquet, or json (propagated from [[createBaseDataFrame]])
     */
   protected def readFiles(files: Set[String]): DataFrame = {
+    logger.warn(s"Reading ${files.size} files in format '${metadata.format}'")
     if (debugEnabled) {
       logger.warn(s"[debug] readFiles: reading ${files.size} files, format: $format")
     }
@@ -57,6 +84,7 @@ trait IndexFileOperations extends IndexMetadataOperations {
     if (debugEnabled) {
       logger.warn(s"[debug] readFiles: complete setup in ${System.currentTimeMillis() - readStart}ms, columns: ${result.schema.fieldNames.length}")
     }
+    logger.warn(s"readFiles complete for ${files.size} file(s) in ${System.currentTimeMillis() - readStart}ms")
     result
   }
 
@@ -92,25 +120,26 @@ trait IndexFileOperations extends IndexMetadataOperations {
   protected def createBaseDataFrame(files: Set[String]): DataFrame = {
     val normalizedFiles = files.map(_.trim).filter(_.nonEmpty)
     if (normalizedFiles.isEmpty) {
-      return spark.createDataFrame(
+      spark.createDataFrame(
         spark.sparkContext.emptyRDD[org.apache.spark.sql.Row],
         storedSchema
       )
-    }
+    } else {
+      // Apply read options
+      val configuredReader =
+        metadata.read_options.asScala.foldLeft(spark.read.schema(storedSchema)) {
+          case (r, (key, value)) => r.option(key, value)
+        }
 
-    // Apply read options
-    val configuredReader =
-      metadata.read_options.asScala.foldLeft(spark.read.schema(storedSchema)) {
-        case (r, (key, value)) => r.option(key, value)
+      // Load data based on format
+      format match {
+        case "csv"     => configuredReader.csv(normalizedFiles.toList: _*)
+        case "parquet" => configuredReader.parquet(normalizedFiles.toList: _*)
+        case "json"    => configuredReader.json(normalizedFiles.toList: _*)
+        case _ =>
+          logger.warn(s"Unsupported format '${format}' for index — must be csv, parquet, or json")
+          throw new IllegalArgumentException(s"Unsupported format: $format")
       }
-
-    // Load data based on format
-    format match {
-      case "csv"     => configuredReader.csv(normalizedFiles.toList: _*)
-      case "parquet" => configuredReader.parquet(normalizedFiles.toList: _*)
-      case "json"    => configuredReader.json(normalizedFiles.toList: _*)
-      case _ =>
-        throw new IllegalArgumentException(s"Unsupported format: $format")
     }
   }
 
@@ -145,6 +174,7 @@ trait IndexFileOperations extends IndexMetadataOperations {
     *   DataFrame with computed index columns added
     */
   protected def applyComputedIndexes(df: DataFrame): DataFrame = {
+    logger.debug(s"Applying ${metadata.computed_indexes.size()} computed index(es)")
     metadata.computed_indexes.asScala.foldLeft(df) {
       case (tempDf, (colName, exprStr)) =>
         tempDf.withColumn(colName, expr(exprStr))
@@ -153,12 +183,18 @@ trait IndexFileOperations extends IndexMetadataOperations {
 
   /** Applies exploded field transformations to a DataFrame.
     *
+    * For each configured exploded field, extracts the nested field path from the
+    * array column and explodes it into a top-level column. Note that `explode()`
+    * (not `explode_outer()`) is used intentionally — rows with null or empty arrays
+    * are dropped, which is correct for index building since there are no values to index.
+    *
     * @param df
     *   The DataFrame to transform
     * @return
     *   DataFrame with exploded field columns added
     */
   protected def applyExplodedFields(df: DataFrame): DataFrame = {
+    logger.debug(s"Applying ${metadata.exploded_field_indexes.size()} exploded field transform(s)")
     metadata.exploded_field_indexes.asScala.foldLeft(df) {
       case (tempDf, explodedField) =>
         tempDf.withColumn(

--- a/src/main/scala/dev/cjfravel/ariadne/IndexFileOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexFileOperations.scala
@@ -185,14 +185,19 @@ trait IndexFileOperations extends IndexMetadataOperations {
   /** Applies exploded field transformations to a DataFrame.
     *
     * For each configured exploded field, extracts the nested field path from the
-    * array column and explodes it into a top-level column. Note that `explode()`
-    * (not `explode_outer()`) is used intentionally — rows with null or empty arrays
-    * are dropped, which is correct for index building since there are no values to index.
+    * array column and explodes it into a top-level column. This is used on the
+    * read/join path to prepare data for joining on exploded field values.
+    *
+    * Note that `explode()` (not `explode_outer()`) is used intentionally —
+    * rows with null or empty arrays are dropped because they contain no
+    * matchable values for the join. This is consistent with the index build
+    * path which also excludes null/empty arrays.
     *
     * @param df
     *   The DataFrame to transform
     * @return
-    *   DataFrame with exploded field columns added
+    *   DataFrame with exploded field columns added; rows with null/empty
+    *   arrays are excluded
     */
   protected def applyExplodedFields(df: DataFrame): DataFrame = {
     logger.debug(s"Applying ${metadata.exploded_field_indexes.size()} exploded field transform(s)")

--- a/src/main/scala/dev/cjfravel/ariadne/IndexFileOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexFileOperations.scala
@@ -67,6 +67,7 @@ trait IndexFileOperations extends IndexMetadataOperations {
     *   if the stored format is not csv, parquet, or json (propagated from [[createBaseDataFrame]])
     */
   protected def readFiles(files: Set[String]): DataFrame = {
+    require(files != null, "files must not be null")
     logger.warn(s"Reading ${files.size} files in format '${metadata.format}'")
     if (debugEnabled) {
       logger.warn(s"[debug] readFiles: reading ${files.size} files, format: $format")

--- a/src/main/scala/dev/cjfravel/ariadne/IndexFileOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexFileOperations.scala
@@ -17,8 +17,10 @@ trait IndexFileOperations extends IndexMetadataOperations {
 
   /** Returns the stored schema of the index.
     *
+    * Parses the JSON schema string from metadata into a Spark StructType.
+    *
     * @return The StructType schema parsed from metadata
-    * @throws MissingSchemaException if the schema is null in metadata
+    * @throws dev.cjfravel.ariadne.exceptions.MissingSchemaException if the schema is null in metadata
     * @throws SchemaParseException if the schema string cannot be parsed as a StructType
     */
   def storedSchema: StructType = {
@@ -75,12 +77,17 @@ trait IndexFileOperations extends IndexMetadataOperations {
   }
 
   /** Creates a base DataFrame from the provided files using the stored format
-    * and schema.
+    * and schema. Applies any read options configured in the index metadata.
+    *
+    * Returns an empty DataFrame (with the stored schema) if all file paths are
+    * blank after normalization.
     *
     * @param files
     *   Set of file paths to read
     * @return
     *   DataFrame with data from the specified files
+    * @throws IllegalArgumentException
+    *   if the stored format is not csv, parquet, or json
     */
   protected def createBaseDataFrame(files: Set[String]): DataFrame = {
     val normalizedFiles = files.map(_.trim).filter(_.nonEmpty)

--- a/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
@@ -117,6 +117,32 @@ trait IndexJoinOperations extends IndexBuildOperations {
       joinColumnsToUse
     )
     logger.warn(s"Found ${files.size} files in index")
+
+    // Log data pruning metrics using stored file sizes
+    try {
+      val totalIndexedSize = metadata.total_indexed_file_size
+      if (totalIndexedSize > 0 && files.nonEmpty) {
+        delta(indexFilePath).foreach { dt =>
+          val indexDf = dt.toDF
+          if (indexDf.columns.contains("file_size")) {
+            val totalFiles = indexDf.count()
+            val matchedSizeResult = indexDf
+              .where(col("filename").isin(files.toSeq.map(lit(_)): _*))
+              .agg(sum("file_size"))
+              .head()
+            val matchedSize = if (matchedSizeResult.isNullAt(0)) 0L else matchedSizeResult.getLong(0)
+            val totalGB = totalIndexedSize / (1024.0 * 1024.0 * 1024.0)
+            val matchedGB = matchedSize / (1024.0 * 1024.0 * 1024.0)
+            val savedPercent = if (totalIndexedSize > 0) ((totalIndexedSize - matchedSize) * 100.0 / totalIndexedSize).toInt else 0
+            logger.warn(f"Index pruning: loaded ${files.size}%d of $totalFiles%d files ($matchedGB%.2f GB of $totalGB%.2f GB) — $savedPercent%%  data pruned")
+          }
+        }
+      }
+    } catch {
+      case e: Exception =>
+        logger.warn(s"Failed to compute pruning metrics: ${e.getMessage}")
+    }
+
     if (debugEnabled) {
       logger.warn(s"[debug] locateFiles completed in ${elapsed()}, files: ${files.size}")
       try {

--- a/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
@@ -6,17 +6,30 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.expressions.Window
 import scala.collection.JavaConverters._
 
-/** Trait providing join operations for Index instances.
+/** Trait providing join operations between DataFrames and indexed data.
+  *
+  * Orchestrates the join workflow:
+  * 1. Maps join columns to their storage column names
+  * 2. Locates relevant files using the index (via [[IndexQueryOperations]])
+  * 3. Reads the located data files
+  * 4. Applies temporal deduplication if applicable
+  * 5. Performs the final DataFrame join
+  *
+  * Supports inner, left, right, left_semi, left_anti, and other standard join types.
   */
 trait IndexJoinOperations extends IndexBuildOperations {
   self: Index =>
 
   /** Maps join column names to their corresponding storage column names.
     *
+    * Bloom filter columns are prefixed with the bloom prefix, range columns are
+    * prefixed with "range_", exploded field columns are mapped to their backing
+    * array column, and all other columns map to themselves.
+    *
     * @param joinColumns
     *   The column names used in joins
     * @return
-    *   Map from join column to storage column
+    *   Map from each join column name to its storage column name in the index
     */
   protected def mapJoinColumnsToStorage(
       joinColumns: Seq[String]
@@ -231,15 +244,17 @@ trait IndexJoinOperations extends IndexBuildOperations {
     }
   }
 
-  /** Joins a DataFrame with the index.
-    * @param df
-    *   The DataFrame to join.
-    * @param usingColumns
-    *   The columns to use for the join.
-    * @param joinType
-    *   The type of join (default is "inner").
-    * @return
-    *   The resulting joined DataFrame.
+  /** Joins a DataFrame with indexed data files.
+    *
+    * This is the primary public API for index-based joins. The index locates
+    * which files contain matching values, reads only those files, applies
+    * temporal deduplication if applicable, then performs the join.
+    *
+    * @param df The DataFrame to join against indexed data
+    * @param usingColumns The column names to join on (must be indexed)
+    * @param joinType The join type: "inner", "left", "right", "left_semi", "left_anti", etc. (default: "inner")
+    * @return The joined DataFrame
+    * @throws ColumnNotFoundException if join columns are not in the schema or indexes
     */
   def join(
       df: DataFrame,

--- a/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
@@ -182,6 +182,7 @@ trait IndexJoinOperations extends IndexBuildOperations {
     // Default is false — data files keep their natural parquet partitioning.
     // Enable when reading all columns from very large indexes to reduce
     // per-executor memory pressure.
+    logger.warn(s"Reading ${files.size} data files from index '$name'")
     val rawReadIndex = if (repartitionDataFiles) {
       maybeRepartition(readFiles(files))
     } else {
@@ -218,6 +219,7 @@ trait IndexJoinOperations extends IndexBuildOperations {
 
     if (applicableConfigs.isEmpty) return df
 
+    logger.warn(s"Applying temporal deduplication for columns: ${applicableConfigs.map(_.column).mkString(", ")}")
     applicableConfigs.foldLeft(df) { (accumDf, config) =>
       val w = Window
         .partitionBy(config.column)
@@ -244,6 +246,7 @@ trait IndexJoinOperations extends IndexBuildOperations {
       usingColumns: Seq[String],
       joinType: String = "inner"
   ): DataFrame = {
+    logger.warn(s"Index.join: $joinType join on columns ${usingColumns.mkString(", ")}")
     val outerJoinStart = System.currentTimeMillis()
     val indexDf = joinDf(df, usingColumns)
     if (debugEnabled) {

--- a/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
@@ -193,13 +193,15 @@ trait IndexJoinOperations extends IndexBuildOperations {
             val totalGB = totalBytes / (1024.0 * 1024.0 * 1024.0)
             logger.warn(f"[debug] total file size: $totalMB%.1fMB ($totalGB%.2fGB) across ${files.size} files")
             val avgMB = totalMB / files.size
-            val maxFile = fileSizes.head
-            val minFile = fileSizes.last
-            val maxMB = maxFile._2 / (1024.0 * 1024.0)
-            val minMB = minFile._2 / (1024.0 * 1024.0)
-            logger.warn(f"[debug] file sizes: avg=$avgMB%.1fMB, max=$maxMB%.1fMB, min=$minMB%.1fMB")
-            logger.warn(f"[debug] largest file: $maxMB%.1fMB -> ${maxFile._1}")
-            logger.warn(f"[debug] smallest file: $minMB%.1fMB -> ${minFile._1}")
+            if (fileSizes.nonEmpty) {
+              val maxFile = fileSizes.head
+              val minFile = fileSizes.last
+              val maxMB = maxFile._2 / (1024.0 * 1024.0)
+              val minMB = minFile._2 / (1024.0 * 1024.0)
+              logger.warn(f"[debug] file sizes: avg=$avgMB%.1fMB, max=$maxMB%.1fMB, min=$minMB%.1fMB")
+              logger.warn(f"[debug] largest file: $maxMB%.1fMB -> ${maxFile._1}")
+              logger.warn(f"[debug] smallest file: $minMB%.1fMB -> ${minFile._1}")
+            }
             // Log top 5 largest files
             fileSizes.take(5).foreach { case (f, size) =>
               val mb = size / (1024.0 * 1024.0)

--- a/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
@@ -22,11 +22,13 @@ trait IndexJoinOperations extends IndexBuildOperations {
       joinColumns: Seq[String]
   ): Map[String, String] = {
     val bloomColumnSet = bloomColumns
+    val rangeColumnSet = metadata.range_indexes.asScala.map(_.column).toSet
 
     joinColumns.map { joinCol =>
-      // Check if this is a bloom filter column
       if (bloomColumnSet.contains(joinCol)) {
         joinCol -> (bloomColumnPrefix + joinCol)
+      } else if (rangeColumnSet.contains(joinCol)) {
+        joinCol -> (s"range_${joinCol}")
       } else {
         // Check if this is an exploded field column
         val explodedMapping =
@@ -92,8 +94,8 @@ trait IndexJoinOperations extends IndexBuildOperations {
     // Map join columns to storage columns
     val columnMappings = mapJoinColumnsToStorage(usingColumns)
 
-    // Include both regular storage columns and bloom storage columns
-    val allStorageColumns = this.storageColumns ++ this.bloomStorageColumns
+    // Include both regular storage columns and bloom/range storage columns
+    val allStorageColumns = this.storageColumns ++ this.bloomStorageColumns ++ this.rangeStorageColumns
     val storageColumnsToUse =
       columnMappings.values.toSet.intersect(allStorageColumns)
     logger.warn(s"Found indexes for ${storageColumnsToUse.mkString(",")}")

--- a/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
@@ -77,6 +77,8 @@ trait IndexJoinOperations extends IndexBuildOperations {
     *   if join columns are not in the selected columns, schema, or indexes
     */
   protected def joinDf(df: DataFrame, usingColumns: Seq[String]): DataFrame = {
+    require(df != null, "DataFrame must not be null")
+    require(usingColumns != null && usingColumns.nonEmpty, "usingColumns must not be null or empty")
     val joinStart = System.currentTimeMillis()
     def elapsed(): String = {
       val ms = System.currentTimeMillis() - joinStart
@@ -293,19 +295,25 @@ trait IndexJoinOperations extends IndexBuildOperations {
       joinType: String = "inner"
   ): DataFrame = {
     logger.warn(s"Index.join on index '$name': $joinType join on columns ${usingColumns.mkString(", ")}")
-    val outerJoinStart = System.currentTimeMillis()
-    val indexDf = joinDf(df, usingColumns)
-    if (debugEnabled) {
-      logger.warn(s"[debug] joinDf returned in ${System.currentTimeMillis() - outerJoinStart}ms, now performing $joinType join")
+    try {
+      val outerJoinStart = System.currentTimeMillis()
+      val indexDf = joinDf(df, usingColumns)
+      if (debugEnabled) {
+        logger.warn(s"[debug] joinDf returned in ${System.currentTimeMillis() - outerJoinStart}ms, now performing $joinType join")
+      }
+      val result = indexDf.join(df, usingColumns, joinType)
+      logger.warn(s"Index.join on index '$name': $joinType join setup completed in ${System.currentTimeMillis() - outerJoinStart}ms")
+      if (debugEnabled) {
+        logger.warn(s"[debug] Index.join complete in ${System.currentTimeMillis() - outerJoinStart}ms")
+        logger.warn(s"[debug] result physical plan:")
+        result.queryExecution.executedPlan.toString().split("\n").foreach(line =>
+          logger.warn(s"[debug]   $line"))
+      }
+      result
+    } catch {
+      case e: Exception =>
+        logger.warn(s"Join failed for index '$name' with columns [${usingColumns.mkString(", ")}]: ${e.getMessage}")
+        throw e
     }
-    val result = indexDf.join(df, usingColumns, joinType)
-    logger.warn(s"Index.join on index '$name': $joinType join setup completed in ${System.currentTimeMillis() - outerJoinStart}ms")
-    if (debugEnabled) {
-      logger.warn(s"[debug] Index.join complete in ${System.currentTimeMillis() - outerJoinStart}ms")
-      logger.warn(s"[debug] result physical plan:")
-      result.queryExecution.executedPlan.toString().split("\n").foreach(line =>
-        logger.warn(s"[debug]   $line"))
-    }
-    result
   }
 }

--- a/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
@@ -126,8 +126,10 @@ trait IndexJoinOperations extends IndexBuildOperations {
           val indexDf = dt.toDF
           if (indexDf.columns.contains("file_size")) {
             val totalFiles = indexDf.count()
+            import spark.implicits._
+            val filesDf = files.toSeq.toDF("filename")
             val matchedSizeResult = indexDf
-              .where(col("filename").isin(files.toSeq.map(lit(_)): _*))
+              .join(filesDf, Seq("filename"), "inner")
               .agg(sum("file_size"))
               .head()
             val matchedSize = if (matchedSizeResult.isNullAt(0)) 0L else matchedSizeResult.getLong(0)

--- a/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
@@ -268,6 +268,7 @@ trait IndexJoinOperations extends IndexBuildOperations {
       logger.warn(s"[debug] joinDf returned in ${System.currentTimeMillis() - outerJoinStart}ms, now performing $joinType join")
     }
     val result = indexDf.join(df, usingColumns, joinType)
+    logger.warn(s"Index.join: $joinType join setup completed in ${System.currentTimeMillis() - outerJoinStart}ms")
     if (debugEnabled) {
       logger.warn(s"[debug] Index.join complete in ${System.currentTimeMillis() - outerJoinStart}ms")
       logger.warn(s"[debug] result physical plan:")

--- a/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
@@ -9,13 +9,15 @@ import scala.collection.JavaConverters._
 /** Trait providing join operations between DataFrames and indexed data.
   *
   * Orchestrates the join workflow:
-  * 1. Maps join columns to their storage column names
-  * 2. Locates relevant files using the index (via [[IndexQueryOperations]])
-  * 3. Reads the located data files
-  * 4. Applies temporal deduplication if applicable
-  * 5. Performs the final DataFrame join
+  * 1. Maps join columns to their storage column names (regular, bloom, range, exploded)
+  * 2. Locates relevant files using the index (via [[IndexQueryOperations.locateFilesFromDataFrame]])
+  * 3. Reads only the located data files (file-level pruning)
+  * 4. Applies temporal deduplication if applicable (keeps latest version per value)
+  * 5. Performs the final Spark DataFrame join
   *
-  * Supports inner, left, right, left_semi, left_anti, and other standard join types.
+  * Supports inner, left, right, left_semi, left_anti, and other standard Spark join types.
+  *
+  * Mixed into [[Index]] via `self: Index =>`.
   */
 trait IndexJoinOperations extends IndexBuildOperations {
   self: Index =>
@@ -57,15 +59,22 @@ trait IndexJoinOperations extends IndexBuildOperations {
   /** Locates and reads indexed data files relevant to the given DataFrame.
     *
     * Uses the index to identify which files contain matching values, then
-    * reads those files into a lazy DataFrame. The actual row-level filtering
-    * happens in the subsequent join in [[join]].
+    * reads those files into a lazy DataFrame. If no matching files are found,
+    * returns an empty DataFrame with the stored schema. The actual row-level
+    * filtering happens in the subsequent join in [[join]].
+    *
+    * Logs data pruning metrics (file count, data size saved) when available,
+    * and includes detailed file-level debug information when debug mode is enabled.
     *
     * @param df
     *   The DataFrame to match against the index.
     * @param usingColumns
     *   The columns used for the join.
     * @return
-    *   A lazy DataFrame containing data from indexed files.
+    *   A lazy DataFrame containing data from indexed files, or an empty
+    *   DataFrame if no files match.
+    * @throws dev.cjfravel.ariadne.exceptions.ColumnNotFoundException
+    *   if join columns are not in the selected columns, schema, or indexes
     */
   protected def joinDf(df: DataFrame, usingColumns: Seq[String]): DataFrame = {
     val joinStart = System.currentTimeMillis()
@@ -131,86 +140,99 @@ trait IndexJoinOperations extends IndexBuildOperations {
     )
     logger.warn(s"Found ${files.size} files in index")
 
-    // Log data pruning metrics using stored file sizes
-    try {
-      val totalIndexedSize = metadata.total_indexed_file_size
-      if (totalIndexedSize > 0 && files.nonEmpty) {
-        delta(indexFilePath).foreach { dt =>
-          val indexDf = dt.toDF
-          if (indexDf.columns.contains("file_size")) {
-            val totalFiles = indexDf.count()
-            import spark.implicits._
-            val filesDf = files.toSeq.toDF("filename")
-            val matchedSizeResult = indexDf
-              .join(filesDf, Seq("filename"), "inner")
-              .agg(sum("file_size"))
-              .head()
-            val matchedSize = if (matchedSizeResult.isNullAt(0)) 0L else matchedSizeResult.getLong(0)
-            val totalGB = totalIndexedSize / (1024.0 * 1024.0 * 1024.0)
-            val matchedGB = matchedSize / (1024.0 * 1024.0 * 1024.0)
-            val savedPercent = if (totalIndexedSize > 0) ((totalIndexedSize - matchedSize) * 100.0 / totalIndexedSize).toInt else 0
-            logger.warn(f"Index pruning: loaded ${files.size}%d of $totalFiles%d files ($matchedGB%.2f GB of $totalGB%.2f GB) — $savedPercent%%  data pruned")
-          }
-        }
-      }
-    } catch {
-      case e: Exception =>
-        logger.warn(s"Failed to compute pruning metrics: ${e.getMessage}")
-    }
+    if (files.isEmpty) {
+      logger.warn(s"No matching files found in index '$name', returning empty DataFrame")
+      import org.apache.spark.sql.Row
+      spark.createDataFrame(spark.sparkContext.emptyRDD[Row], storedSchema)
+    } else {
 
-    if (debugEnabled) {
-      logger.warn(s"[debug] locateFiles completed in ${elapsed()}, files: ${files.size}")
+      // Log data pruning metrics using stored file sizes
       try {
-        val fileSizes = files.toSeq.map { f =>
-          val path = new org.apache.hadoop.fs.Path(f)
-          val fileFs = path.getFileSystem(spark.sparkContext.hadoopConfiguration)
-          val size = fileFs.getFileStatus(path).getLen
-          (f, size)
-        }.sortBy(-_._2)
-        val totalBytes = fileSizes.map(_._2).sum
-        val totalMB = totalBytes / (1024.0 * 1024.0)
-        val totalGB = totalBytes / (1024.0 * 1024.0 * 1024.0)
-        logger.warn(f"[debug] total file size: $totalMB%.1fMB ($totalGB%.2fGB) across ${files.size} files")
-        val avgMB = totalMB / files.size
-        val maxFile = fileSizes.head
-        val minFile = fileSizes.last
-        val maxMB = maxFile._2 / (1024.0 * 1024.0)
-        val minMB = minFile._2 / (1024.0 * 1024.0)
-        logger.warn(f"[debug] file sizes: avg=$avgMB%.1fMB, max=$maxMB%.1fMB, min=$minMB%.1fMB")
-        logger.warn(f"[debug] largest file: $maxMB%.1fMB -> ${maxFile._1}")
-        logger.warn(f"[debug] smallest file: $minMB%.1fMB -> ${minFile._1}")
-        // Log top 5 largest files
-        fileSizes.take(5).foreach { case (f, size) =>
-          val mb = size / (1024.0 * 1024.0)
-          logger.warn(f"[debug]   $mb%.1fMB -> $f")
+        val totalIndexedSize = metadata.total_indexed_file_size
+        if (totalIndexedSize > 0 && files.nonEmpty) {
+          delta(indexFilePath).foreach { dt =>
+            val indexDf = dt.toDF
+            if (indexDf.columns.contains("file_size")) {
+              val totalFiles = indexDf.count()
+              import spark.implicits._
+              val filesDf = files.toSeq.toDF("filename")
+              val matchedSizeRows = indexDf
+                .join(filesDf, Seq("filename"), "inner")
+                .agg(sum("file_size"))
+                .take(1)
+              if (matchedSizeRows.nonEmpty) {
+                val matchedSizeResult = matchedSizeRows(0)
+                val matchedSize = if (matchedSizeResult.isNullAt(0)) 0L else matchedSizeResult.getLong(0)
+                val totalGB = totalIndexedSize / (1024.0 * 1024.0 * 1024.0)
+                val matchedGB = matchedSize / (1024.0 * 1024.0 * 1024.0)
+                val savedPercent = if (totalIndexedSize > 0) ((totalIndexedSize - matchedSize) * 100.0 / totalIndexedSize).toInt else 0
+                logger.warn(f"Index pruning: loaded ${files.size}%d of $totalFiles%d files ($matchedGB%.2f GB of $totalGB%.2f GB) — $savedPercent%%  data pruned")
+              }
+            }
+          }
         }
       } catch {
         case e: Exception =>
-          logger.warn(s"[debug] failed to get file sizes: ${e.getMessage}")
+          logger.warn(s"Failed to compute pruning metrics for index '$name': ${e.getClass.getSimpleName}: ${e.getMessage}")
       }
-    }
 
-    // Read the data files located by the index.
-    // repartitionDataFiles controls whether the data files are repartitioned.
-    // Default is false — data files keep their natural parquet partitioning.
-    // Enable when reading all columns from very large indexes to reduce
-    // per-executor memory pressure.
-    logger.warn(s"Reading ${files.size} data files from index '$name'")
-    val rawReadIndex = if (repartitionDataFiles) {
-      maybeRepartition(readFiles(files))
-    } else {
-      readFiles(files)
-    }
-    // Apply temporal deduplication if any temporal indexes are being used in this join
-    val readIndex = applyTemporalDeduplication(rawReadIndex, usingColumns)
-    if (debugEnabled) {
-      logger.warn(s"[debug] readFiles setup in ${elapsed()}, repartitionDataFiles=$repartitionDataFiles, schema columns: ${readIndex.schema.fieldNames.length}")
-      logger.warn(s"[debug] readFiles physical plan:")
-      readIndex.queryExecution.executedPlan.toString().split("\n").foreach(line =>
-        logger.warn(s"[debug]   $line"))
-    }
+      if (debugEnabled) {
+        logger.warn(s"[debug] locateFiles completed in ${elapsed()}, files: ${files.size}")
+        if (files.nonEmpty) {
+          try {
+            val fileSizes = files.toSeq.map { f =>
+              val path = new org.apache.hadoop.fs.Path(f)
+              val fileFs = path.getFileSystem(spark.sparkContext.hadoopConfiguration)
+              val size = fileFs.getFileStatus(path).getLen
+              (f, size)
+            }.sortBy(-_._2)
+            val totalBytes = fileSizes.map(_._2).sum
+            val totalMB = totalBytes / (1024.0 * 1024.0)
+            val totalGB = totalBytes / (1024.0 * 1024.0 * 1024.0)
+            logger.warn(f"[debug] total file size: $totalMB%.1fMB ($totalGB%.2fGB) across ${files.size} files")
+            val avgMB = totalMB / files.size
+            val maxFile = fileSizes.head
+            val minFile = fileSizes.last
+            val maxMB = maxFile._2 / (1024.0 * 1024.0)
+            val minMB = minFile._2 / (1024.0 * 1024.0)
+            logger.warn(f"[debug] file sizes: avg=$avgMB%.1fMB, max=$maxMB%.1fMB, min=$minMB%.1fMB")
+            logger.warn(f"[debug] largest file: $maxMB%.1fMB -> ${maxFile._1}")
+            logger.warn(f"[debug] smallest file: $minMB%.1fMB -> ${minFile._1}")
+            // Log top 5 largest files
+            fileSizes.take(5).foreach { case (f, size) =>
+              val mb = size / (1024.0 * 1024.0)
+              logger.warn(f"[debug]   $mb%.1fMB -> $f")
+            }
+          } catch {
+            case e: Exception =>
+              logger.warn(s"[debug] failed to get file sizes: ${e.getMessage}")
+          }
+        }
+      }
 
-    readIndex
+      // Read the data files located by the index.
+      // repartitionDataFiles controls whether the data files are repartitioned.
+      // Default is false — data files keep their natural parquet partitioning.
+      // Enable when reading all columns from very large indexes to reduce
+      // per-executor memory pressure.
+      logger.warn(s"Reading ${files.size} data files from index '$name'")
+      val rawReadIndex = if (repartitionDataFiles) {
+        maybeRepartition(readFiles(files))
+      } else {
+        readFiles(files)
+      }
+      // Apply temporal deduplication if any temporal indexes are being used in this join
+      val readIndex = applyTemporalDeduplication(rawReadIndex, usingColumns)
+      if (debugEnabled) {
+        logger.warn(s"[debug] readFiles setup in ${elapsed()}, repartitionDataFiles=$repartitionDataFiles, schema columns: ${readIndex.schema.fieldNames.length}")
+        logger.warn(s"[debug] readFiles physical plan:")
+        readIndex.queryExecution.executedPlan.toString().split("\n").foreach(line =>
+          logger.warn(s"[debug]   $line"))
+      }
+
+      logger.warn(s"joinDf completed for index '$name' in ${elapsed()}")
+      readIndex
+    }
   }
 
   /** Applies temporal deduplication to keep only the latest version of each
@@ -230,17 +252,21 @@ trait IndexJoinOperations extends IndexBuildOperations {
     val temporalConfigs = metadata.temporal_indexes.asScala.toSeq
     val applicableConfigs = temporalConfigs.filter(tc => joinColumns.contains(tc.column))
 
-    if (applicableConfigs.isEmpty) return df
-
-    logger.warn(s"Applying temporal deduplication for columns: ${applicableConfigs.map(_.column).mkString(", ")}")
-    applicableConfigs.foldLeft(df) { (accumDf, config) =>
-      val w = Window
-        .partitionBy(config.column)
-        .orderBy(col(config.timestamp_column).desc_nulls_last)
-      accumDf
-        .withColumn("_ariadne_temporal_rank", row_number().over(w))
-        .filter(col("_ariadne_temporal_rank") === 1)
-        .drop("_ariadne_temporal_rank")
+    if (applicableConfigs.isEmpty) {
+      df
+    } else {
+      logger.warn(s"Applying temporal deduplication for columns: ${applicableConfigs.map(_.column).mkString(", ")}")
+      val result = applicableConfigs.foldLeft(df) { (accumDf, config) =>
+        val w = Window
+          .partitionBy(config.column)
+          .orderBy(col(config.timestamp_column).desc_nulls_last)
+        accumDf
+          .withColumn("_ariadne_temporal_rank", row_number().over(w))
+          .filter(col("_ariadne_temporal_rank") === 1)
+          .drop("_ariadne_temporal_rank")
+      }
+      logger.debug(s"Temporal deduplication applied for ${applicableConfigs.size} column(s)")
+      result
     }
   }
 
@@ -248,27 +274,32 @@ trait IndexJoinOperations extends IndexBuildOperations {
     *
     * This is the primary public API for index-based joins. The index locates
     * which files contain matching values, reads only those files, applies
-    * temporal deduplication if applicable, then performs the join.
+    * temporal deduplication if applicable, then performs the Spark DataFrame join.
+    *
+    * The join direction is `indexedData.join(df)` — the index-located data is
+    * on the left. For the reverse direction, use [[Index.DataFrameOps.join]].
     *
     * @param df The DataFrame to join against indexed data
-    * @param usingColumns The column names to join on (must be indexed)
-    * @param joinType The join type: "inner", "left", "right", "left_semi", "left_anti", etc. (default: "inner")
+    * @param usingColumns The column names to join on (must be indexed columns)
+    * @param joinType The Spark join type: "inner", "left", "right", "left_semi",
+    *   "left_anti", etc. (default: "inner")
     * @return The joined DataFrame
-    * @throws ColumnNotFoundException if join columns are not in the schema or indexes
+    * @throws dev.cjfravel.ariadne.exceptions.ColumnNotFoundException
+    *   if join columns are not in the schema or indexes
     */
   def join(
       df: DataFrame,
       usingColumns: Seq[String],
       joinType: String = "inner"
   ): DataFrame = {
-    logger.warn(s"Index.join: $joinType join on columns ${usingColumns.mkString(", ")}")
+    logger.warn(s"Index.join on index '$name': $joinType join on columns ${usingColumns.mkString(", ")}")
     val outerJoinStart = System.currentTimeMillis()
     val indexDf = joinDf(df, usingColumns)
     if (debugEnabled) {
       logger.warn(s"[debug] joinDf returned in ${System.currentTimeMillis() - outerJoinStart}ms, now performing $joinType join")
     }
     val result = indexDf.join(df, usingColumns, joinType)
-    logger.warn(s"Index.join: $joinType join setup completed in ${System.currentTimeMillis() - outerJoinStart}ms")
+    logger.warn(s"Index.join on index '$name': $joinType join setup completed in ${System.currentTimeMillis() - outerJoinStart}ms")
     if (debugEnabled) {
       logger.warn(s"[debug] Index.join complete in ${System.currentTimeMillis() - outerJoinStart}ms")
       logger.warn(s"[debug] result physical plan:")

--- a/src/main/scala/dev/cjfravel/ariadne/IndexLock.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexLock.scala
@@ -81,7 +81,11 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
     try {
       spark.sparkContext.applicationId
     } catch {
-      case _: Exception => InetAddress.getLocalHost.getHostName
+      case e: Exception =>
+        logger.debug(
+          s"Could not get Spark application ID, falling back to hostname: ${e.getMessage}"
+        )
+        InetAddress.getLocalHost.getHostName
     }
   }
 
@@ -98,7 +102,12 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
     *   max retry attempts
     */
   def acquire(correlationId: String): Unit = {
+    logger.debug(s"Acquiring lock for index '$indexName' (correlationId='$correlationId')")
+    val acquireStart = System.currentTimeMillis()
     doAcquire(correlationId, depth = 0)
+    logger.debug(
+      s"Lock acquire completed for index '$indexName' in ${System.currentTimeMillis() - acquireStart}ms"
+    )
   }
 
   /** Internal acquire implementation with a recursion depth guard.
@@ -117,7 +126,6 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
     }
 
     val startTime = System.currentTimeMillis()
-    val attempt = 0
 
     try {
       val now = Instant.now().toString
@@ -131,7 +139,7 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
     } catch {
       case _: org.apache.hadoop.fs.FileAlreadyExistsException |
           _: java.io.IOException =>
-        handleExistingLock(correlationId, startTime, attempt, depth)
+        handleExistingLock(correlationId, startTime, 0, depth)
     }
   }
 
@@ -140,6 +148,12 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
     * Reads the existing lock to determine whether it is stale (auto-heal),
     * active (enter retry loop), or corrupt/unreadable (delete and retry with
     * depth guard).
+    *
+    * '''TOCTOU note:''' There is an inherent race between reading the lock,
+    * determining it is stale, deleting it, and re-creating it. A third process
+    * could create a new lock between the delete and the re-acquire. The
+    * `depth` guard limits recursion, and the filesystem's atomic-create
+    * semantics (`overwrite = false`) ensure at most one writer succeeds.
     *
     * @param correlationId
     *   unique identifier for the new lock request
@@ -177,6 +191,24 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
     }
   }
 
+  /** Retry loop implementing exponential back-off for lock acquisition.
+    *
+    * Sleeps with exponential back-off (capped at 60 s) between attempts.
+    * On each iteration the lock file is re-read to check for staleness or
+    * release. The loop terminates when the lock is successfully acquired,
+    * the caller is interrupted, or `lockMaxWait` is exceeded.
+    *
+    * @param correlationId
+    *   unique identifier for the new lock request
+    * @param startTime
+    *   epoch millis when the acquire attempt started
+    * @param attempt
+    *   initial retry attempt number (for back-off calculation)
+    * @param lastLock
+    *   the most recently observed [[LockInfo]] from the lock file
+    * @throws IndexLockException
+    *   if the lock cannot be acquired within `lockMaxWait` seconds
+    */
   private def retryLoop(
       correlationId: String,
       startTime: Long,
@@ -185,8 +217,9 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
   ): Unit = {
     var currentAttempt = attempt
     var currentLock = lastLock
+    var acquired = false
 
-    while (true) {
+    while (!acquired) {
       val elapsed = (System.currentTimeMillis() - startTime) / 1000
       if (elapsed >= lockMaxWait) {
         throw new IndexLockException(
@@ -202,6 +235,11 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
           60.0
         )
         .toLong
+      logger.warn(
+        s"Lock retry for index '$indexName': attempt=$currentAttempt, " +
+          s"elapsed=${elapsed}s, sleeping=${sleepSeconds}s, " +
+          s"holder=${currentLock.owner} (correlationId='${currentLock.correlationId}')"
+      )
       try {
         Thread.sleep(sleepSeconds * 1000)
       } catch {
@@ -229,7 +267,7 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
             logger.warn(
               s"Lock acquired for index '$indexName' (correlationId='$correlationId')"
             )
-            return
+            acquired = true
           } catch {
             case _: org.apache.hadoop.fs.FileAlreadyExistsException |
                 _: java.io.IOException =>
@@ -247,7 +285,7 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
             logger.warn(
               s"Lock acquired for index '$indexName' (correlationId='$correlationId')"
             )
-            return
+            acquired = true
           } catch {
             case _: org.apache.hadoop.fs.FileAlreadyExistsException |
                 _: java.io.IOException =>
@@ -266,6 +304,8 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
     *   the correlation ID that should currently hold the lock
     */
   def release(correlationId: String): Unit = {
+    logger.debug(s"Releasing lock for index '$indexName' (correlationId='$correlationId')")
+    val releaseStart = System.currentTimeMillis()
     readLock() match {
       case Some(lockInfo) if lockInfo.correlationId == correlationId =>
         delete(lockPath)
@@ -282,6 +322,9 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
           s"Cannot release lock for index '$indexName': lock file does not exist"
         )
     }
+    logger.debug(
+      s"Lock release completed for index '$indexName' in ${System.currentTimeMillis() - releaseStart}ms"
+    )
   }
 
   /** Refreshes the lock's `lastRefreshedAt` timestamp to prevent stale-lock
@@ -294,6 +337,8 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
     *   the correlation ID that should currently hold the lock
     */
   def refresh(correlationId: String): Unit = {
+    logger.debug(s"Refreshing lock for index '$indexName' (correlationId='$correlationId')")
+    val refreshStart = System.currentTimeMillis()
     readLock() match {
       case Some(lockInfo) if lockInfo.correlationId == correlationId =>
         val updated = lockInfo.copy(lastRefreshedAt = Instant.now().toString)
@@ -311,13 +356,16 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
           s"Cannot refresh lock for index '$indexName': lock file does not exist"
         )
     }
+    logger.debug(
+      s"Lock refresh completed for index '$indexName' in ${System.currentTimeMillis() - refreshStart}ms"
+    )
   }
 
   /** Determines whether the lock is stale based on `lastRefreshedAt`.
     *
     * A lock is stale when the time elapsed since its last refresh exceeds the
     * configured `lockTimeout`. If the timestamp cannot be parsed, the lock is
-    * considered stale.
+    * considered stale and a warning is logged.
     *
     * @param lockInfo
     *   the lock metadata to evaluate
@@ -329,7 +377,12 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
       val lastRefreshed = Instant.parse(lockInfo.lastRefreshedAt)
       Duration.between(lastRefreshed, Instant.now()).getSeconds > lockTimeout
     } catch {
-      case _: Exception => true
+      case e: Exception =>
+        logger.warn(
+          s"Could not parse lastRefreshedAt='${lockInfo.lastRefreshedAt}' for index " +
+            s"'$indexName', treating lock as stale: ${e.getMessage}"
+        )
+        true
     }
   }
 
@@ -344,9 +397,14 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
       if (exists(lockPath)) {
         val inputStream = open(lockPath)
         try {
-          val jsonString =
-            Source.fromInputStream(inputStream)(StandardCharsets.UTF_8).mkString
-          Some(gson.fromJson(jsonString, classOf[LockInfo]))
+          val source =
+            Source.fromInputStream(inputStream)(StandardCharsets.UTF_8)
+          try {
+            val jsonString = source.mkString
+            Some(gson.fromJson(jsonString, classOf[LockInfo]))
+          } finally {
+            source.close()
+          }
         } finally {
           inputStream.close()
         }
@@ -354,8 +412,10 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
         None
       }
     } catch {
-      case _: java.io.FileNotFoundException       => None
-      case _: com.google.gson.JsonSyntaxException => None
+      case _: java.io.FileNotFoundException => None
+      case e: com.google.gson.JsonSyntaxException =>
+        logger.warn(s"Corrupt lock file at $lockPath: ${e.getMessage}")
+        None
     }
   }
 
@@ -368,8 +428,9 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
     *   file already exists (atomic create)
     */
   private def writeLockFile(lockInfo: LockInfo, overwrite: Boolean): Unit = {
-    val outputStream = fs.create(lockPath, overwrite)
+    var outputStream: org.apache.hadoop.fs.FSDataOutputStream = null
     try {
+      outputStream = fs.create(lockPath, overwrite)
       outputStream.write(gson.toJson(lockInfo).getBytes(StandardCharsets.UTF_8))
       outputStream.flush()
     } catch {
@@ -379,7 +440,9 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
         )
         throw e
     } finally {
-      outputStream.close()
+      if (outputStream != null) {
+        outputStream.close()
+      }
     }
   }
 }

--- a/src/main/scala/dev/cjfravel/ariadne/IndexLock.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexLock.scala
@@ -10,6 +10,13 @@ import java.nio.charset.StandardCharsets
 import java.time.{Duration, Instant}
 import scala.io.Source
 
+/** Metadata stored in lock files to track lock ownership and freshness.
+  *
+  * @param correlationId Unique identifier for the lock holder's operation
+  * @param acquiredAt ISO-8601 timestamp when the lock was first acquired
+  * @param lastRefreshedAt ISO-8601 timestamp of the last lock refresh
+  * @param owner Spark application ID or hostname of the lock holder
+  */
 case class LockInfo(
     correlationId: String,
     acquiredAt: String,
@@ -17,6 +24,16 @@ case class LockInfo(
     owner: String
 )
 
+/** File-based distributed lock for index operations.
+  *
+  * Provides mutual exclusion for index operations (update, compact, vacuum)
+  * using lock files on HDFS/cloud storage. Supports automatic stale lock
+  * detection and healing based on configurable timeouts.
+  *
+  * @param lockPath Path to the lock file on the filesystem
+  * @param indexName Name of the index being locked (for logging)
+  * @param spark Implicit SparkSession for filesystem access
+  */
 case class IndexLock(lockPath: Path, indexName: String)(implicit val spark: SparkSession)
     extends AriadneContextUser {
 
@@ -84,7 +101,13 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit val spark: Spar
       }
 
       val sleepSeconds = math.min(lockRetryInterval.toDouble * math.pow(2, math.min(currentAttempt, 6)), 60.0).toLong
-      Thread.sleep(sleepSeconds * 1000)
+      try {
+        Thread.sleep(sleepSeconds * 1000)
+      } catch {
+        case _: InterruptedException =>
+          Thread.currentThread().interrupt()
+          throw new IndexLockException(s"Lock acquisition interrupted for index '$indexName'")
+      }
       currentAttempt += 1
 
       readLock() match {

--- a/src/main/scala/dev/cjfravel/ariadne/IndexLock.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexLock.scala
@@ -41,14 +41,8 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit val spark: Spar
     def tryAcquire(): Unit = {
       try {
         val now = Instant.now().toString
-        val lockInfo = LockInfo(correlationId, now, now, getOwner)
-        val outputStream = fs.create(lockPath, false)
-        try {
-          outputStream.write(gson.toJson(lockInfo).getBytes(StandardCharsets.UTF_8))
-          outputStream.flush()
-        } finally {
-          outputStream.close()
-        }
+        writeLockFile(LockInfo(correlationId, now, now, getOwner), overwrite = false)
+        logger.warn(s"Lock acquired for index '$indexName' (correlationId='$correlationId')")
       } catch {
         case _: org.apache.hadoop.fs.FileAlreadyExistsException | _: java.io.IOException =>
           handleExistingLock(correlationId, startTime, attempt)
@@ -89,7 +83,7 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit val spark: Spar
         throw new IndexLockException(indexName, currentLock.correlationId, currentLock.owner)
       }
 
-      val sleepSeconds = Math.min(lockRetryInterval * Math.pow(2, currentAttempt).toLong, 60)
+      val sleepSeconds = math.min(lockRetryInterval.toDouble * math.pow(2, math.min(currentAttempt, 6)), 60.0).toLong
       Thread.sleep(sleepSeconds * 1000)
       currentAttempt += 1
 
@@ -102,14 +96,8 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit val spark: Spar
           delete(lockPath)
           try {
             val now = Instant.now().toString
-            val lockInfo = LockInfo(correlationId, now, now, getOwner)
-            val outputStream = fs.create(lockPath, false)
-            try {
-              outputStream.write(gson.toJson(lockInfo).getBytes(StandardCharsets.UTF_8))
-              outputStream.flush()
-            } finally {
-              outputStream.close()
-            }
+            writeLockFile(LockInfo(correlationId, now, now, getOwner), overwrite = false)
+            logger.warn(s"Lock acquired for index '$indexName' (correlationId='$correlationId')")
             return
           } catch {
             case _: org.apache.hadoop.fs.FileAlreadyExistsException | _: java.io.IOException =>
@@ -120,14 +108,8 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit val spark: Spar
         case None =>
           try {
             val now = Instant.now().toString
-            val lockInfo = LockInfo(correlationId, now, now, getOwner)
-            val outputStream = fs.create(lockPath, false)
-            try {
-              outputStream.write(gson.toJson(lockInfo).getBytes(StandardCharsets.UTF_8))
-              outputStream.flush()
-            } finally {
-              outputStream.close()
-            }
+            writeLockFile(LockInfo(correlationId, now, now, getOwner), overwrite = false)
+            logger.warn(s"Lock acquired for index '$indexName' (correlationId='$correlationId')")
             return
           } catch {
             case _: org.apache.hadoop.fs.FileAlreadyExistsException | _: java.io.IOException =>
@@ -145,6 +127,7 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit val spark: Spar
     readLock() match {
       case Some(lockInfo) if lockInfo.correlationId == correlationId =>
         delete(lockPath)
+        logger.warn(s"Lock released for index '$indexName' (correlationId='$correlationId')")
       case Some(lockInfo) =>
         logger.warn(
           s"Cannot release lock for index '$indexName': " +
@@ -163,7 +146,8 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit val spark: Spar
     readLock() match {
       case Some(lockInfo) if lockInfo.correlationId == correlationId =>
         val updated = lockInfo.copy(lastRefreshedAt = Instant.now().toString)
-        writeLock(updated)
+        writeLockFile(updated, overwrite = true)
+        logger.warn(s"Lock refreshed for index '$indexName' (correlationId='$correlationId')")
       case Some(lockInfo) =>
         logger.warn(
           s"Cannot refresh lock for index '$indexName': " +
@@ -197,15 +181,20 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit val spark: Spar
         None
       }
     } catch {
-      case _: Exception => None
+      case _: java.io.FileNotFoundException => None
+      case _: com.google.gson.JsonSyntaxException => None
     }
   }
 
-  private def writeLock(lockInfo: LockInfo): Unit = {
-    val outputStream = fs.create(lockPath, true)
+  private def writeLockFile(lockInfo: LockInfo, overwrite: Boolean): Unit = {
+    val outputStream = fs.create(lockPath, overwrite)
     try {
       outputStream.write(gson.toJson(lockInfo).getBytes(StandardCharsets.UTF_8))
       outputStream.flush()
+    } catch {
+      case e: Exception =>
+        logger.warn(s"Failed to write lock file for index '$indexName': ${e.getMessage}")
+        throw e
     } finally {
       outputStream.close()
     }

--- a/src/main/scala/dev/cjfravel/ariadne/IndexLock.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexLock.scala
@@ -12,10 +12,18 @@ import scala.io.Source
 
 /** Metadata stored in lock files to track lock ownership and freshness.
   *
-  * @param correlationId Unique identifier for the lock holder's operation
-  * @param acquiredAt ISO-8601 timestamp when the lock was first acquired
-  * @param lastRefreshedAt ISO-8601 timestamp of the last lock refresh
-  * @param owner Spark application ID or hostname of the lock holder
+  * Each lock file is a JSON document containing these fields, serialized via
+  * Gson. The [[IndexLock]] reads and writes [[LockInfo]] instances to
+  * coordinate distributed access to an index.
+  *
+  * @param correlationId
+  *   Unique identifier for the lock holder's operation
+  * @param acquiredAt
+  *   ISO-8601 timestamp when the lock was first acquired
+  * @param lastRefreshedAt
+  *   ISO-8601 timestamp of the most recent lock refresh
+  * @param owner
+  *   Spark application ID, or the hostname if the application ID is unavailable
   */
 case class LockInfo(
     correlationId: String,
@@ -27,18 +35,48 @@ case class LockInfo(
 /** File-based distributed lock for index operations.
   *
   * Provides mutual exclusion for index operations (update, compact, vacuum)
-  * using lock files on HDFS/cloud storage. Supports automatic stale lock
-  * detection and healing based on configurable timeouts.
+  * using lock files on HDFS or cloud-compatible filesystems. Lock files are
+  * JSON documents containing a [[LockInfo]] payload.
   *
-  * @param lockPath Path to the lock file on the filesystem
-  * @param indexName Name of the index being locked (for logging)
-  * @param spark Implicit SparkSession for filesystem access
+  * ==Concurrency semantics==
+  * Lock acquisition is atomic at the filesystem level: the lock file is created
+  * with `overwrite = false`, so only one writer can succeed. If another process
+  * already holds the lock, acquisition enters a retry loop with exponential
+  * back-off (capped at 60 s) up to `lockMaxWait` seconds.
+  *
+  * ==Stale lock healing==
+  * If the `lastRefreshedAt` timestamp is older than `lockTimeout` seconds, the
+  * lock is considered stale. A stale lock is automatically deleted and
+  * re-acquired, with a warning logged identifying the previous holder.
+  *
+  * ==Corrupt lock file handling==
+  * If the lock file exists but cannot be parsed (empty or invalid JSON), it is
+  * treated as corrupt: the file is deleted and acquisition is retried, up to
+  * `MaxCorruptLockRetries` times to prevent infinite recursion.
+  *
+  * @param lockPath
+  *   Path to the lock file on the filesystem
+  * @param indexName
+  *   Name of the index being locked (used in log messages)
+  * @param spark
+  *   Implicit SparkSession for filesystem access and configuration
   */
-case class IndexLock(lockPath: Path, indexName: String)(implicit val spark: SparkSession)
-    extends AriadneContextUser {
+case class IndexLock(lockPath: Path, indexName: String)(implicit
+    val spark: SparkSession
+) extends AriadneContextUser {
 
   private val gson = new Gson()
 
+  /** Maximum number of recursive acquire attempts when encountering corrupt or
+    * transient lock files, to prevent stack overflow.
+    */
+  private val MaxCorruptLockRetries = 3
+
+  /** Returns the Spark application ID, falling back to the local hostname.
+    *
+    * @return
+    *   an owner identifier string for the lock file
+    */
   private def getOwner: String = {
     try {
       spark.sparkContext.applicationId
@@ -48,28 +86,76 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit val spark: Spar
   }
 
   /** Acquires the lock for the given correlation ID.
+    *
+    * If the lock file already exists, this method will either heal a stale or
+    * corrupt lock, or enter a retry loop until the lock becomes available or
+    * `lockMaxWait` is exceeded.
+    *
     * @param correlationId
-    *   The correlation ID to associate with the lock.
+    *   unique identifier to associate with this lock hold
+    * @throws IndexLockException
+    *   if the lock cannot be acquired within the configured timeout or after
+    *   max retry attempts
     */
   def acquire(correlationId: String): Unit = {
-    val startTime = System.currentTimeMillis()
-    var attempt = 0
-
-    def tryAcquire(): Unit = {
-      try {
-        val now = Instant.now().toString
-        writeLockFile(LockInfo(correlationId, now, now, getOwner), overwrite = false)
-        logger.warn(s"Lock acquired for index '$indexName' (correlationId='$correlationId')")
-      } catch {
-        case _: org.apache.hadoop.fs.FileAlreadyExistsException | _: java.io.IOException =>
-          handleExistingLock(correlationId, startTime, attempt)
-      }
-    }
-
-    tryAcquire()
+    doAcquire(correlationId, depth = 0)
   }
 
-  private def handleExistingLock(correlationId: String, startTime: Long, attempt: Int): Unit = {
+  /** Internal acquire implementation with a recursion depth guard.
+    *
+    * @param correlationId
+    *   unique identifier to associate with this lock hold
+    * @param depth
+    *   current recursion depth (0-based)
+    */
+  private def doAcquire(correlationId: String, depth: Int): Unit = {
+    if (depth >= MaxCorruptLockRetries) {
+      throw new IndexLockException(
+        s"Failed to acquire lock for index '$indexName' after $MaxCorruptLockRetries attempts " +
+          s"(possible persistent corrupt lock file at $lockPath)"
+      )
+    }
+
+    val startTime = System.currentTimeMillis()
+    val attempt = 0
+
+    try {
+      val now = Instant.now().toString
+      writeLockFile(
+        LockInfo(correlationId, now, now, getOwner),
+        overwrite = false
+      )
+      logger.warn(
+        s"Lock acquired for index '$indexName' (correlationId='$correlationId')"
+      )
+    } catch {
+      case _: org.apache.hadoop.fs.FileAlreadyExistsException |
+          _: java.io.IOException =>
+        handleExistingLock(correlationId, startTime, attempt, depth)
+    }
+  }
+
+  /** Handles the case where a lock file already exists during acquisition.
+    *
+    * Reads the existing lock to determine whether it is stale (auto-heal),
+    * active (enter retry loop), or corrupt/unreadable (delete and retry with
+    * depth guard).
+    *
+    * @param correlationId
+    *   unique identifier for the new lock request
+    * @param startTime
+    *   epoch millis when the acquire attempt started
+    * @param attempt
+    *   current retry attempt number (for back-off)
+    * @param depth
+    *   current recursion depth to prevent infinite recursion
+    */
+  private def handleExistingLock(
+      correlationId: String,
+      startTime: Long,
+      attempt: Int,
+      depth: Int
+  ): Unit = {
     readLock() match {
       case Some(existingLock) if isStale(existingLock) =>
         logger.warn(
@@ -77,11 +163,17 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit val spark: Spar
             s"(held by correlationId='${existingLock.correlationId}', owner='${existingLock.owner}')"
         )
         delete(lockPath)
-        acquire(correlationId)
+        doAcquire(correlationId, depth + 1)
       case Some(existingLock) =>
         retryLoop(correlationId, startTime, attempt, existingLock)
       case None =>
-        acquire(correlationId)
+        if (exists(lockPath)) {
+          logger.warn(
+            s"Detected corrupt lock file for index '$indexName' at $lockPath, deleting"
+          )
+          delete(lockPath)
+        }
+        doAcquire(correlationId, depth + 1)
     }
   }
 
@@ -97,16 +189,27 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit val spark: Spar
     while (true) {
       val elapsed = (System.currentTimeMillis() - startTime) / 1000
       if (elapsed >= lockMaxWait) {
-        throw new IndexLockException(indexName, currentLock.correlationId, currentLock.owner)
+        throw new IndexLockException(
+          indexName,
+          currentLock.correlationId,
+          currentLock.owner
+        )
       }
 
-      val sleepSeconds = math.min(lockRetryInterval.toDouble * math.pow(2, math.min(currentAttempt, 6)), 60.0).toLong
+      val sleepSeconds = math
+        .min(
+          lockRetryInterval.toDouble * math.pow(2, math.min(currentAttempt, 6)),
+          60.0
+        )
+        .toLong
       try {
         Thread.sleep(sleepSeconds * 1000)
       } catch {
         case _: InterruptedException =>
           Thread.currentThread().interrupt()
-          throw new IndexLockException(s"Lock acquisition interrupted for index '$indexName'")
+          throw new IndexLockException(
+            s"Lock acquisition interrupted for index '$indexName'"
+          )
       }
       currentAttempt += 1
 
@@ -119,11 +222,17 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit val spark: Spar
           delete(lockPath)
           try {
             val now = Instant.now().toString
-            writeLockFile(LockInfo(correlationId, now, now, getOwner), overwrite = false)
-            logger.warn(s"Lock acquired for index '$indexName' (correlationId='$correlationId')")
+            writeLockFile(
+              LockInfo(correlationId, now, now, getOwner),
+              overwrite = false
+            )
+            logger.warn(
+              s"Lock acquired for index '$indexName' (correlationId='$correlationId')"
+            )
             return
           } catch {
-            case _: org.apache.hadoop.fs.FileAlreadyExistsException | _: java.io.IOException =>
+            case _: org.apache.hadoop.fs.FileAlreadyExistsException |
+                _: java.io.IOException =>
               currentLock = readLock().getOrElse(currentLock)
           }
         case Some(lock) =>
@@ -131,56 +240,90 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit val spark: Spar
         case None =>
           try {
             val now = Instant.now().toString
-            writeLockFile(LockInfo(correlationId, now, now, getOwner), overwrite = false)
-            logger.warn(s"Lock acquired for index '$indexName' (correlationId='$correlationId')")
+            writeLockFile(
+              LockInfo(correlationId, now, now, getOwner),
+              overwrite = false
+            )
+            logger.warn(
+              s"Lock acquired for index '$indexName' (correlationId='$correlationId')"
+            )
             return
           } catch {
-            case _: org.apache.hadoop.fs.FileAlreadyExistsException | _: java.io.IOException =>
+            case _: org.apache.hadoop.fs.FileAlreadyExistsException |
+                _: java.io.IOException =>
               currentLock = readLock().getOrElse(currentLock)
           }
       }
     }
   }
 
-  /** Releases the lock for the given correlation ID.
+  /** Releases the lock if it is held by the given correlation ID.
+    *
+    * If the lock file does not exist or belongs to a different correlation ID,
+    * a warning is logged and no action is taken.
+    *
     * @param correlationId
-    *   The correlation ID that holds the lock.
+    *   the correlation ID that should currently hold the lock
     */
   def release(correlationId: String): Unit = {
     readLock() match {
       case Some(lockInfo) if lockInfo.correlationId == correlationId =>
         delete(lockPath)
-        logger.warn(s"Lock released for index '$indexName' (correlationId='$correlationId')")
+        logger.warn(
+          s"Lock released for index '$indexName' (correlationId='$correlationId')"
+        )
       case Some(lockInfo) =>
         logger.warn(
           s"Cannot release lock for index '$indexName': " +
             s"correlationId mismatch (expected='$correlationId', actual='${lockInfo.correlationId}')"
         )
       case None =>
-        logger.warn(s"Cannot release lock for index '$indexName': lock file does not exist")
+        logger.warn(
+          s"Cannot release lock for index '$indexName': lock file does not exist"
+        )
     }
   }
 
-  /** Refreshes the lock timestamp for the given correlation ID.
+  /** Refreshes the lock's `lastRefreshedAt` timestamp to prevent stale-lock
+    * healing.
+    *
+    * Long-running operations should call this periodically (more frequently
+    * than `lockTimeout`) to signal that the lock holder is still active.
+    *
     * @param correlationId
-    *   The correlation ID that holds the lock.
+    *   the correlation ID that should currently hold the lock
     */
   def refresh(correlationId: String): Unit = {
     readLock() match {
       case Some(lockInfo) if lockInfo.correlationId == correlationId =>
         val updated = lockInfo.copy(lastRefreshedAt = Instant.now().toString)
         writeLockFile(updated, overwrite = true)
-        logger.warn(s"Lock refreshed for index '$indexName' (correlationId='$correlationId')")
+        logger.warn(
+          s"Lock refreshed for index '$indexName' (correlationId='$correlationId')"
+        )
       case Some(lockInfo) =>
         logger.warn(
           s"Cannot refresh lock for index '$indexName': " +
             s"correlationId mismatch (expected='$correlationId', actual='${lockInfo.correlationId}')"
         )
       case None =>
-        logger.warn(s"Cannot refresh lock for index '$indexName': lock file does not exist")
+        logger.warn(
+          s"Cannot refresh lock for index '$indexName': lock file does not exist"
+        )
     }
   }
 
+  /** Determines whether the lock is stale based on `lastRefreshedAt`.
+    *
+    * A lock is stale when the time elapsed since its last refresh exceeds the
+    * configured `lockTimeout`. If the timestamp cannot be parsed, the lock is
+    * considered stale.
+    *
+    * @param lockInfo
+    *   the lock metadata to evaluate
+    * @return
+    *   true if the lock should be considered stale
+    */
   private def isStale(lockInfo: LockInfo): Boolean = {
     try {
       val lastRefreshed = Instant.parse(lockInfo.lastRefreshedAt)
@@ -190,12 +333,19 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit val spark: Spar
     }
   }
 
+  /** Reads and deserializes the lock file.
+    *
+    * @return
+    *   `Some(lockInfo)` if the file exists and contains valid JSON, `None` if
+    *   the file does not exist or cannot be parsed
+    */
   private def readLock(): Option[LockInfo] = {
     try {
       if (exists(lockPath)) {
         val inputStream = open(lockPath)
         try {
-          val jsonString = Source.fromInputStream(inputStream)(StandardCharsets.UTF_8).mkString
+          val jsonString =
+            Source.fromInputStream(inputStream)(StandardCharsets.UTF_8).mkString
           Some(gson.fromJson(jsonString, classOf[LockInfo]))
         } finally {
           inputStream.close()
@@ -204,11 +354,19 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit val spark: Spar
         None
       }
     } catch {
-      case _: java.io.FileNotFoundException => None
+      case _: java.io.FileNotFoundException       => None
       case _: com.google.gson.JsonSyntaxException => None
     }
   }
 
+  /** Writes lock metadata to the lock file.
+    *
+    * @param lockInfo
+    *   the metadata to serialize as JSON
+    * @param overwrite
+    *   if false, the write fails with `FileAlreadyExistsException` when the
+    *   file already exists (atomic create)
+    */
   private def writeLockFile(lockInfo: LockInfo, overwrite: Boolean): Unit = {
     val outputStream = fs.create(lockPath, overwrite)
     try {
@@ -216,7 +374,9 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit val spark: Spar
       outputStream.flush()
     } catch {
       case e: Exception =>
-        logger.warn(s"Failed to write lock file for index '$indexName': ${e.getMessage}")
+        logger.warn(
+          s"Failed to write lock file for index '$indexName': ${e.getMessage}"
+        )
         throw e
     } finally {
       outputStream.close()

--- a/src/main/scala/dev/cjfravel/ariadne/IndexLock.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexLock.scala
@@ -102,6 +102,7 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
     *   max retry attempts
     */
   def acquire(correlationId: String): Unit = {
+    require(correlationId != null && correlationId.trim.nonEmpty, "correlationId must not be null or blank")
     logger.debug(s"Acquiring lock for index '$indexName' (correlationId='$correlationId')")
     val acquireStart = System.currentTimeMillis()
     doAcquire(correlationId, depth = 0)
@@ -304,6 +305,7 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
     *   the correlation ID that should currently hold the lock
     */
   def release(correlationId: String): Unit = {
+    require(correlationId != null && correlationId.trim.nonEmpty, "correlationId must not be null or blank")
     logger.debug(s"Releasing lock for index '$indexName' (correlationId='$correlationId')")
     val releaseStart = System.currentTimeMillis()
     readLock() match {
@@ -337,6 +339,7 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
     *   the correlation ID that should currently hold the lock
     */
   def refresh(correlationId: String): Unit = {
+    require(correlationId != null && correlationId.trim.nonEmpty, "correlationId must not be null or blank")
     logger.debug(s"Refreshing lock for index '$indexName' (correlationId='$correlationId')")
     val refreshStart = System.currentTimeMillis()
     readLock() match {

--- a/src/main/scala/dev/cjfravel/ariadne/IndexMetadata.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexMetadata.scala
@@ -33,6 +33,18 @@ case class TemporalIndexConfig(
     var timestamp_column: String
 )
 
+/** Configuration for a range index.
+  *
+  * Range indexes store min/max values per file for a column, enabling
+  * file pruning at query time. Files whose [min, max] range does not
+  * overlap with the queried values are skipped.
+  *
+  * @param column The column name to create a range index for
+  */
+case class RangeIndexConfig(
+    var column: String
+)
+
 /** Represents a mapping for exploded field index configuration.
   *
   * This case class defines how to extract and index fields from array elements.
@@ -84,7 +96,9 @@ case class IndexMetadata(
     var exploded_field_indexes: util.List[ExplodedFieldMapping],
     var bloom_indexes: util.List[BloomIndexConfig],
     var temporal_indexes: util.List[TemporalIndexConfig],
-    var read_options: util.Map[String, String]
+    var read_options: util.Map[String, String],
+    var range_indexes: util.List[RangeIndexConfig],
+    var auto_bloom_indexes: util.List[String]
 )
 
 /** Factory object for creating IndexMetadata instances from JSON.
@@ -134,6 +148,14 @@ object IndexMetadata {
     // v5 -> v6
     if (indexMetadata.temporal_indexes == null) {
       indexMetadata.temporal_indexes = new util.ArrayList[TemporalIndexConfig]()
+    }
+    // v6 -> v7
+    if (indexMetadata.range_indexes == null) {
+      indexMetadata.range_indexes = new util.ArrayList[RangeIndexConfig]()
+    }
+    // v7 -> v8
+    if (indexMetadata.auto_bloom_indexes == null) {
+      indexMetadata.auto_bloom_indexes = new util.ArrayList[String]()
     }
     indexMetadata
   }

--- a/src/main/scala/dev/cjfravel/ariadne/IndexMetadata.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexMetadata.scala
@@ -147,7 +147,12 @@ object IndexMetadata {
     if (jsonString == null || jsonString.trim.isEmpty) {
       throw new MetadataMissingOrCorruptException()
     }
-    val indexMetadata = new Gson().fromJson(jsonString, classOf[IndexMetadata])
+    val indexMetadata = try {
+      new Gson().fromJson(jsonString, classOf[IndexMetadata])
+    } catch {
+      case e: com.google.gson.JsonSyntaxException =>
+        throw new MetadataMissingOrCorruptException(e)
+    }
     if (indexMetadata == null) {
       throw new MetadataMissingOrCorruptException()
     }

--- a/src/main/scala/dev/cjfravel/ariadne/IndexMetadata.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexMetadata.scala
@@ -84,6 +84,9 @@ case class ExplodedFieldMapping(
   * @param temporal_indexes List of temporal index configurations for version-aware deduplication
   * @param read_options Map of read options for format-specific configuration (e.g., "multiLine" -> "true" for JSON)
   * @param total_indexed_file_size Total size in bytes of all indexed files, or -1 if not yet computed (nullable for Gson compatibility)
+  * @param batches_since_compact Number of update batches processed since the last auto-compaction,
+  *                              persisted across Spark jobs so that `autoCompactThreshold` works
+  *                              correctly even when updates happen in separate runs (v10+, nullable for Gson)
   *
   * @note The field names use underscore notation to match JSON serialization format
   */
@@ -101,7 +104,8 @@ case class IndexMetadata(
     var read_options: util.Map[String, String],
     var range_indexes: util.List[RangeIndexConfig],
     var auto_bloom_indexes: util.List[String],
-    var total_indexed_file_size: java.lang.Long
+    var total_indexed_file_size: java.lang.Long,
+    var batches_since_compact: java.lang.Integer
 )
 
 /** Factory object for creating IndexMetadata instances from JSON.
@@ -123,6 +127,7 @@ object IndexMetadata {
     * - v6 → v7: Adds range_indexes field if missing
     * - v7 → v8: Adds auto_bloom_indexes field if missing
     * - v8 → v9: Adds total_indexed_file_size field if missing
+    * - v9 → v10: Adds batches_since_compact field if missing
     *
     * @param jsonString The JSON representation of the metadata
     * @return A fully initialized IndexMetadata instance
@@ -171,6 +176,10 @@ object IndexMetadata {
     // v8 -> v9
     if (indexMetadata.total_indexed_file_size == null) {
       indexMetadata.total_indexed_file_size = -1L
+    }
+    // v9 -> v10
+    if (indexMetadata.batches_since_compact == null) {
+      indexMetadata.batches_since_compact = 0
     }
     indexMetadata
   }

--- a/src/main/scala/dev/cjfravel/ariadne/IndexMetadata.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexMetadata.scala
@@ -117,6 +117,10 @@ object IndexMetadata {
     * - v1 → v2: Adds computed_indexes field if missing
     * - v2 → v3: Adds exploded_field_indexes field if missing
     * - v3 → v4: Adds read_options field if missing
+    * - v4 → v5: Adds bloom_indexes field if missing
+    * - v5 → v6: Adds temporal_indexes field if missing
+    * - v6 → v7: Adds range_indexes field if missing
+    * - v7 → v8: Adds auto_bloom_indexes field if missing
     * - v8 → v9: Adds total_indexed_file_size field if missing
     *
     * @param jsonString The JSON representation of the metadata

--- a/src/main/scala/dev/cjfravel/ariadne/IndexMetadata.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexMetadata.scala
@@ -18,7 +18,9 @@ import dev.cjfravel.ariadne.exceptions.MetadataMissingOrCorruptException
 case class BloomIndexConfig(
     var column: String,
     var fpr: Double = 0.01
-)
+) {
+  require(fpr > 0 && fpr < 1, s"fpr must be between 0 and 1 (exclusive), got $fpr")
+}
 
 /** Configuration for a temporal index.
   *
@@ -131,6 +133,8 @@ object IndexMetadata {
     *
     * @param jsonString The JSON representation of the metadata
     * @return A fully initialized IndexMetadata instance
+    * @throws MetadataMissingOrCorruptException
+    *   if `jsonString` is null, empty, or cannot be deserialized
     *
     * @example
     * {{{
@@ -144,6 +148,9 @@ object IndexMetadata {
       throw new MetadataMissingOrCorruptException()
     }
     val indexMetadata = new Gson().fromJson(jsonString, classOf[IndexMetadata])
+    if (indexMetadata == null) {
+      throw new MetadataMissingOrCorruptException()
+    }
     // v1 -> v2
     if (indexMetadata.computed_indexes == null) {
       indexMetadata.computed_indexes =

--- a/src/main/scala/dev/cjfravel/ariadne/IndexMetadata.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexMetadata.scala
@@ -82,6 +82,7 @@ case class ExplodedFieldMapping(
   * @param bloom_indexes List of bloom filter index configurations for probabilistic indexing
   * @param temporal_indexes List of temporal index configurations for version-aware deduplication
   * @param read_options Map of read options for format-specific configuration (e.g., "multiLine" -> "true" for JSON)
+  * @param total_indexed_file_size Total size in bytes of all indexed files, or -1 if not yet computed (nullable for Gson compatibility)
   *
   * @note The field names use underscore notation to match JSON serialization format
   */
@@ -98,7 +99,8 @@ case class IndexMetadata(
     var temporal_indexes: util.List[TemporalIndexConfig],
     var read_options: util.Map[String, String],
     var range_indexes: util.List[RangeIndexConfig],
-    var auto_bloom_indexes: util.List[String]
+    var auto_bloom_indexes: util.List[String],
+    var total_indexed_file_size: java.lang.Long
 )
 
 /** Factory object for creating IndexMetadata instances from JSON.
@@ -115,6 +117,7 @@ object IndexMetadata {
     * - v1 → v2: Adds computed_indexes field if missing
     * - v2 → v3: Adds exploded_field_indexes field if missing
     * - v3 → v4: Adds read_options field if missing
+    * - v8 → v9: Adds total_indexed_file_size field if missing
     *
     * @param jsonString The JSON representation of the metadata
     * @return A fully initialized IndexMetadata instance
@@ -156,6 +159,10 @@ object IndexMetadata {
     // v7 -> v8
     if (indexMetadata.auto_bloom_indexes == null) {
       indexMetadata.auto_bloom_indexes = new util.ArrayList[String]()
+    }
+    // v8 -> v9
+    if (indexMetadata.total_indexed_file_size == null) {
+      indexMetadata.total_indexed_file_size = -1L
     }
     indexMetadata
   }

--- a/src/main/scala/dev/cjfravel/ariadne/IndexMetadata.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexMetadata.scala
@@ -3,6 +3,7 @@ package dev.cjfravel.ariadne
 import com.google.gson.annotations.SerializedName
 import java.util
 import com.google.gson.Gson
+import dev.cjfravel.ariadne.exceptions.MetadataMissingOrCorruptException
 
 /** Configuration for a bloom filter index.
   *
@@ -134,6 +135,9 @@ object IndexMetadata {
     * }}}
     */
   def apply(jsonString: String): IndexMetadata = {
+    if (jsonString == null || jsonString.trim.isEmpty) {
+      throw new MetadataMissingOrCorruptException()
+    }
     val indexMetadata = new Gson().fromJson(jsonString, classOf[IndexMetadata])
     // v1 -> v2
     if (indexMetadata.computed_indexes == null) {

--- a/src/main/scala/dev/cjfravel/ariadne/IndexMetadataOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexMetadataOperations.scala
@@ -25,7 +25,7 @@ import com.google.gson.Gson
 trait IndexMetadataOperations extends AriadneContextUser {
   self: Index =>
 
-  override val logger: Logger = LogManager.getLogger("ariadne")
+  override lazy val logger: Logger = LogManager.getLogger("ariadne")
 
   /** Hadoop path for the metadata file.
     * @return

--- a/src/main/scala/dev/cjfravel/ariadne/IndexMetadataOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexMetadataOperations.scala
@@ -7,14 +7,30 @@ import scala.io.Source
 import java.nio.charset.StandardCharsets
 import com.google.gson.Gson
 
-/** Trait providing metadata operations for Index instances.
+/** Trait providing metadata read/write operations for [[Index]] instances.
+  *
+  * Manages the lifecycle of [[IndexMetadata]] — reading from and writing to the
+  * `metadata.json` file on the Hadoop-compatible filesystem. Metadata is cached
+  * in memory after the first load; call [[refreshMetadata]] to force a reload.
+  *
+  * '''Storage:''' Metadata is persisted as a single JSON file at
+  * `{storagePath}/metadata.json`, serialized and deserialized via Gson.
+  *
+  * '''Error handling:''' If the metadata file is missing or corrupt,
+  * [[dev.cjfravel.ariadne.exceptions.MetadataMissingOrCorruptException]] is
+  * thrown. Write failures are logged before the exception propagates.
+  *
+  * @see [[IndexMetadata]] for the metadata schema and version migration logic
   */
 trait IndexMetadataOperations extends AriadneContextUser {
   self: Index =>
 
   override val logger: Logger = LogManager.getLogger("ariadne")
 
-  /** Hadoop path for the metadata file */
+  /** Hadoop path for the metadata file.
+    * @return
+    *   the path to `metadata.json` under the index storage directory
+    */
   protected def metadataFilePath: Path = new Path(storagePath, "metadata.json")
 
   /** Checks if metadata exists in the storage location.
@@ -26,27 +42,46 @@ trait IndexMetadataOperations extends AriadneContextUser {
 
   private var _metadata: IndexMetadata = _
 
-  /** Forces a reload of metadata from disk. */
+  /** Forces a reload of metadata from the `metadata.json` file on disk.
+    *
+    * Replaces the in-memory cached metadata with a freshly deserialized copy.
+    * This is called automatically by [[metadata]] on first access; callers may
+    * invoke it explicitly to pick up external changes.
+    *
+    * @throws MetadataMissingOrCorruptException
+    *   if the metadata file does not exist, cannot be read, or contains
+    *   invalid JSON
+    */
   def refreshMetadata(): Unit = {
+    logger.debug(s"Entering refreshMetadata for index '${name}'")
     _metadata = if (metadataExists) {
       try {
         val inputStream = open(metadataFilePath)
         try {
-          val jsonString =
-            Source.fromInputStream(inputStream)(StandardCharsets.UTF_8).mkString
-          IndexMetadata(jsonString)
+          val source =
+            Source.fromInputStream(inputStream)(StandardCharsets.UTF_8)
+          try {
+            val jsonString = source.mkString
+            IndexMetadata(jsonString)
+          } finally {
+            source.close()
+          }
         } finally {
           inputStream.close()
         }
       } catch {
         case e: Exception =>
-          logger.warn(s"Failed to read metadata from ${metadataFilePath.toString}: ${e.getMessage}")
+          logger.warn(
+            s"Failed to read metadata from ${metadataFilePath.toString}: " +
+              s"${e.getClass.getSimpleName}: ${e.getMessage}"
+          )
           throw new MetadataMissingOrCorruptException(e)
       }
     } else {
       throw new MetadataMissingOrCorruptException()
     }
     logger.warn(s"Read metadata from ${metadataFilePath.toString}")
+    logger.debug(s"Completed refreshMetadata for index '${name}'")
   }
 
   /** Retrieves the stored metadata for the index.
@@ -63,34 +98,61 @@ trait IndexMetadataOperations extends AriadneContextUser {
     _metadata
   }
 
-  /** Writes metadata to the storage location.
+  /** Writes metadata to the `metadata.json` file and updates the in-memory cache.
+    *
+    * Creates the parent directory if it does not exist. The write is ''not''
+    * atomic — a crash mid-write may leave a corrupt file that triggers
+    * [[dev.cjfravel.ariadne.exceptions.MetadataMissingOrCorruptException]] on
+    * the next read.
+    *
     * @param metadata
-    *   The metadata to write.
+    *   the metadata instance to serialize and persist
+    * @throws java.io.IOException
+    *   if the write fails (the error is logged before propagating)
     */
   protected def writeMetadata(metadata: IndexMetadata): Unit = {
+    logger.debug(s"Entering writeMetadata for index '${name}'")
     val directoryPath = metadataFilePath.getParent
     if (!exists(directoryPath)) fs.mkdirs(directoryPath)
 
     val jsonString = new Gson().toJson(metadata)
-    val outputStream = fs.create(metadataFilePath)
+    var outputStream: org.apache.hadoop.fs.FSDataOutputStream = null
     try {
+      outputStream = fs.create(metadataFilePath)
       outputStream.write(jsonString.getBytes(StandardCharsets.UTF_8))
       outputStream.flush()
+    } catch {
+      case e: Exception =>
+        logger.warn(
+          s"Failed to write metadata to ${metadataFilePath.toString}: ${e.getMessage}"
+        )
+        throw e
     } finally {
-      outputStream.close()
+      if (outputStream != null) outputStream.close()
     }
     _metadata = metadata // Update in-memory cache
     logger.warn(s"Wrote metadata to ${metadataFilePath.toString}")
+    logger.debug(s"Completed writeMetadata for index '${name}'")
   }
 
-  /** Returns the format of the stored data. */
+  /** Returns the file format of the indexed data (e.g., "parquet", "csv", "json").
+    * @return
+    *   the format string from the stored metadata
+    */
   def format: String = metadata.format
 
-  /** Updates the format of the stored data.
+  /** Updates the file format recorded in the stored metadata.
+    *
     * @param newFormat
-    *   The new format to set.
+    *   the new format string to persist (e.g., "parquet")
+    * @throws IllegalArgumentException
+    *   if `newFormat` is null or empty
     */
   private def format_=(newFormat: String): Unit = {
+    require(
+      newFormat != null && newFormat.nonEmpty,
+      "format must not be null or empty"
+    )
     val currentMetadata = metadata
     currentMetadata.format = newFormat
     writeMetadata(currentMetadata)

--- a/src/main/scala/dev/cjfravel/ariadne/IndexMetadataOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexMetadataOperations.scala
@@ -111,6 +111,7 @@ trait IndexMetadataOperations extends AriadneContextUser {
     *   if the write fails (the error is logged before propagating)
     */
   protected def writeMetadata(metadata: IndexMetadata): Unit = {
+    require(metadata != null, "metadata must not be null")
     logger.debug(s"Entering writeMetadata for index '${name}'")
     val directoryPath = metadataFilePath.getParent
     if (!exists(directoryPath)) fs.mkdirs(directoryPath)

--- a/src/main/scala/dev/cjfravel/ariadne/IndexMetadataOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexMetadataOperations.scala
@@ -56,7 +56,7 @@ trait IndexMetadataOperations extends AriadneContextUser {
     * @throws MetadataMissingOrCorruptException
     *   if metadata is missing or cannot be parsed.
     */
-  protected def metadata: IndexMetadata = {
+  private[ariadne] def metadata: IndexMetadata = {
     if (_metadata == null) {
       refreshMetadata()
     }

--- a/src/main/scala/dev/cjfravel/ariadne/IndexMetadataOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexMetadataOperations.scala
@@ -31,11 +31,17 @@ trait IndexMetadataOperations extends AriadneContextUser {
     _metadata = if (metadataExists) {
       try {
         val inputStream = open(metadataFilePath)
-        val jsonString =
-          Source.fromInputStream(inputStream)(StandardCharsets.UTF_8).mkString
-        IndexMetadata(jsonString)
+        try {
+          val jsonString =
+            Source.fromInputStream(inputStream)(StandardCharsets.UTF_8).mkString
+          IndexMetadata(jsonString)
+        } finally {
+          inputStream.close()
+        }
       } catch {
-        case _: Exception => throw new MetadataMissingOrCorruptException()
+        case e: Exception =>
+          logger.warn(s"Failed to read metadata from ${metadataFilePath.toString}: ${e.getMessage}")
+          throw new MetadataMissingOrCorruptException(e)
       }
     } else {
       throw new MetadataMissingOrCorruptException()
@@ -67,9 +73,12 @@ trait IndexMetadataOperations extends AriadneContextUser {
 
     val jsonString = new Gson().toJson(metadata)
     val outputStream = fs.create(metadataFilePath)
-    outputStream.write(jsonString.getBytes(StandardCharsets.UTF_8))
-    outputStream.flush()
-    outputStream.close()
+    try {
+      outputStream.write(jsonString.getBytes(StandardCharsets.UTF_8))
+      outputStream.flush()
+    } finally {
+      outputStream.close()
+    }
     _metadata = metadata // Update in-memory cache
     logger.warn(s"Wrote metadata to ${metadataFilePath.toString}")
   }

--- a/src/main/scala/dev/cjfravel/ariadne/IndexPathUtils.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexPathUtils.scala
@@ -39,7 +39,10 @@ object IndexPathUtils {
     * @return
     *   The prefixed file list identifier
     */
-  def fileListName(name: String): String = s"[ariadne_index] $name"
+  def fileListName(name: String): String = {
+    require(name != null && name.trim.nonEmpty, "name must not be null or blank")
+    s"[ariadne_index] $name"
+  }
 
   /** Checks whether an index with the given name exists.
     *
@@ -59,6 +62,7 @@ object IndexPathUtils {
     *   true if the index exists
     */
   def exists(name: String)(implicit sparkSession: SparkSession): Boolean = {
+    require(name != null && name.trim.nonEmpty, "name must not be null or blank")
     val contextUser = new AriadneContextUser {
       implicit def spark: SparkSession = sparkSession
     }
@@ -89,6 +93,7 @@ object IndexPathUtils {
     *   if the index does not exist
     */
   def remove(name: String)(implicit sparkSession: SparkSession): Boolean = {
+    require(name != null && name.trim.nonEmpty, "name must not be null or blank")
     if (!exists(name)(sparkSession)) {
       throw new IndexNotFoundException(name)
     }

--- a/src/main/scala/dev/cjfravel/ariadne/IndexPathUtils.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexPathUtils.scala
@@ -2,16 +2,28 @@ package dev.cjfravel.ariadne
 
 import dev.cjfravel.ariadne.exceptions.IndexNotFoundException
 import org.apache.hadoop.fs.Path
+import org.apache.logging.log4j.LogManager
 import org.apache.spark.sql.SparkSession
 
-/** Utility object providing path and utility functions for Index operations.
+/** Utility object providing path resolution and lifecycle operations for
+  * indexes.
+  *
+  * All paths are resolved relative to the configured
+  * `spark.ariadne.storagePath`. This object is stateless; filesystem access is
+  * performed through temporary [[AriadneContextUser]] instances created from
+  * the implicit `SparkSession`.
   */
 object IndexPathUtils {
 
-  /** Returns the base storage path for indexes under the configured Ariadne storage path.
+  private val logger = LogManager.getLogger("ariadne")
+
+  /** Returns the base storage path for indexes under the configured Ariadne
+    * storage path.
     *
-    * @param sparkSession The implicit SparkSession providing configuration
-    * @return The Hadoop Path to the indexes directory
+    * @param sparkSession
+    *   the implicit SparkSession providing configuration
+    * @return
+    *   the Hadoop Path to the `indexes` directory
     */
   def storagePath(implicit sparkSession: SparkSession): Path = {
     val contextUser = new AriadneContextUser {
@@ -22,8 +34,10 @@ object IndexPathUtils {
 
   /** Returns the file list name for a given index name.
     *
-    * @param name The index name
-    * @return The prefixed file list identifier
+    * @param name
+    *   The index name
+    * @return
+    *   The prefixed file list identifier
     */
   def fileListName(name: String): String = s"[ariadne_index] $name"
 
@@ -32,9 +46,12 @@ object IndexPathUtils {
     * An index is considered to exist if either its file list entry or its
     * storage directory is present.
     *
-    * @param name The index name to check
-    * @param sparkSession The implicit SparkSession
-    * @return true if the index exists
+    * @param name
+    *   The index name to check
+    * @param sparkSession
+    *   The implicit SparkSession
+    * @return
+    *   true if the index exists
     */
   def exists(name: String)(implicit sparkSession: SparkSession): Boolean = {
     val contextUser = new AriadneContextUser {
@@ -47,16 +64,25 @@ object IndexPathUtils {
 
   /** Removes an index by deleting its file list entry and storage directory.
     *
-    * @param name The index name to remove
-    * @param sparkSession The implicit SparkSession
-    * @return true if any resources were successfully removed
-    * @throws IndexNotFoundException if the index does not exist
+    * Both the file list Delta table and the index storage directory are
+    * removed. The method returns `true` if at least one resource was
+    * successfully deleted.
+    *
+    * @param name
+    *   the index name to remove
+    * @param sparkSession
+    *   the implicit SparkSession
+    * @return
+    *   true if any resources were successfully removed
+    * @throws IndexNotFoundException
+    *   if the index does not exist
     */
   def remove(name: String)(implicit sparkSession: SparkSession): Boolean = {
     if (!exists(name)(sparkSession)) {
       throw new IndexNotFoundException(name)
     }
 
+    logger.warn(s"Removing index '${name}' (file list and storage directory)")
     val contextUser = new AriadneContextUser {
       implicit def spark: SparkSession = sparkSession
     }
@@ -66,12 +92,14 @@ object IndexPathUtils {
     ) || fileListRemoved
   }
 
-  /** Cleans a filename for safe storage by replacing special characters.
+  /** Cleans a filename for safe storage by replacing non-alphanumeric
+    * characters with underscores, collapsing consecutive underscores, and
+    * trimming leading/trailing underscores.
     *
     * @param fileName
-    *   The filename to clean
+    *   the raw filename to clean
     * @return
-    *   The cleaned filename
+    *   the sanitized filename, or an empty string if input is null/empty
     */
   def cleanFileName(fileName: String): String = {
     if (fileName == null || fileName.isEmpty) return ""
@@ -81,12 +109,15 @@ object IndexPathUtils {
       .replaceAll("^_+|_+$", "")
   }
 
-  /** Creates a temp path for query staging operations.
+  /** Returns a temporary directory path for query staging operations.
+    *
+    * The `_temp` directory is located under the Ariadne storage path and is
+    * used for transient data during query execution.
     *
     * @param sparkSession
-    *   The SparkSession
+    *   the implicit SparkSession
     * @return
-    *   Path to temp directory
+    *   Hadoop Path to the `_temp` directory
     */
   def tempPath(implicit sparkSession: SparkSession): Path = {
     val contextUser = new AriadneContextUser {

--- a/src/main/scala/dev/cjfravel/ariadne/IndexPathUtils.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexPathUtils.scala
@@ -7,6 +7,12 @@ import org.apache.spark.sql.SparkSession
 /** Utility object providing path and utility functions for Index operations.
   */
 object IndexPathUtils {
+
+  /** Returns the base storage path for indexes under the configured Ariadne storage path.
+    *
+    * @param sparkSession The implicit SparkSession providing configuration
+    * @return The Hadoop Path to the indexes directory
+    */
   def storagePath(implicit sparkSession: SparkSession): Path = {
     val contextUser = new AriadneContextUser {
       implicit def spark: SparkSession = sparkSession
@@ -14,8 +20,22 @@ object IndexPathUtils {
     new Path(contextUser.storagePath, "indexes")
   }
 
+  /** Returns the file list name for a given index name.
+    *
+    * @param name The index name
+    * @return The prefixed file list identifier
+    */
   def fileListName(name: String): String = s"[ariadne_index] $name"
 
+  /** Checks whether an index with the given name exists.
+    *
+    * An index is considered to exist if either its file list entry or its
+    * storage directory is present.
+    *
+    * @param name The index name to check
+    * @param sparkSession The implicit SparkSession
+    * @return true if the index exists
+    */
   def exists(name: String)(implicit sparkSession: SparkSession): Boolean = {
     val contextUser = new AriadneContextUser {
       implicit def spark: SparkSession = sparkSession
@@ -25,6 +45,13 @@ object IndexPathUtils {
     )
   }
 
+  /** Removes an index by deleting its file list entry and storage directory.
+    *
+    * @param name The index name to remove
+    * @param sparkSession The implicit SparkSession
+    * @return true if any resources were successfully removed
+    * @throws IndexNotFoundException if the index does not exist
+    */
   def remove(name: String)(implicit sparkSession: SparkSession): Boolean = {
     if (!exists(name)(sparkSession)) {
       throw new IndexNotFoundException(name)
@@ -47,10 +74,11 @@ object IndexPathUtils {
     *   The cleaned filename
     */
   def cleanFileName(fileName: String): String = {
+    if (fileName == null || fileName.isEmpty) return ""
     fileName
       .replaceAll("[^a-zA-Z0-9]", "_")
-      .replaceAll("__+", "_")
-      .replaceAll("^_|_$", "")
+      .replaceAll("_+", "_")
+      .replaceAll("^_+|_+$", "")
   }
 
   /** Creates a temp path for query staging operations.

--- a/src/main/scala/dev/cjfravel/ariadne/IndexPathUtils.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexPathUtils.scala
@@ -46,6 +46,11 @@ object IndexPathUtils {
     * An index is considered to exist if either its file list entry or its
     * storage directory is present.
     *
+    * '''Note:''' This check is subject to a TOCTOU (time-of-check/time-of-use)
+    * race condition — the index may be created or removed between this call and
+    * a subsequent operation. Callers should not rely on this result for
+    * correctness in concurrent environments.
+    *
     * @param name
     *   The index name to check
     * @param sparkSession
@@ -68,6 +73,12 @@ object IndexPathUtils {
     * removed. The method returns `true` if at least one resource was
     * successfully deleted.
     *
+    * '''Note:''' The [[exists]] guard is subject to a TOCTOU
+    * (time-of-check/time-of-use) race — another process may remove the index
+    * between the existence check and the actual deletion, or create a new index
+    * with the same name concurrently. External locking is required to prevent
+    * this in multi-process environments.
+    *
     * @param name
     *   the index name to remove
     * @param sparkSession
@@ -83,13 +94,17 @@ object IndexPathUtils {
     }
 
     logger.warn(s"Removing index '${name}' (file list and storage directory)")
+    val startTime = System.currentTimeMillis()
     val contextUser = new AriadneContextUser {
       implicit def spark: SparkSession = sparkSession
     }
     val fileListRemoved = FileList.remove(fileListName(name))(sparkSession)
-    contextUser.delete(
+    val result = contextUser.delete(
       new Path(contextUser.storagePath, name)
     ) || fileListRemoved
+    val elapsed = System.currentTimeMillis() - startTime
+    logger.warn(s"Successfully removed index '$name' in ${elapsed}ms")
+    result
   }
 
   /** Cleans a filename for safe storage by replacing non-alphanumeric
@@ -97,16 +112,26 @@ object IndexPathUtils {
     * trimming leading/trailing underscores.
     *
     * @param fileName
-    *   the raw filename to clean
+    *   the raw filename to clean; must not be null
     * @return
-    *   the sanitized filename, or an empty string if input is null/empty
+    *   the sanitized filename, or an empty string if input is empty
+    * @throws IllegalArgumentException
+    *   if `fileName` is null
     */
   def cleanFileName(fileName: String): String = {
-    if (fileName == null || fileName.isEmpty) return ""
-    fileName
-      .replaceAll("[^a-zA-Z0-9]", "_")
-      .replaceAll("_+", "_")
-      .replaceAll("^_+|_+$", "")
+    if (fileName == null) {
+      throw new IllegalArgumentException(
+        "fileName must not be null"
+      )
+    }
+    if (fileName.isEmpty) {
+      ""
+    } else {
+      fileName
+        .replaceAll("[^a-zA-Z0-9]", "_")
+        .replaceAll("_+", "_")
+        .replaceAll("^_+|_+$", "")
+    }
   }
 
   /** Returns a temporary directory path for query staging operations.

--- a/src/main/scala/dev/cjfravel/ariadne/IndexQueryOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexQueryOperations.scala
@@ -1,7 +1,7 @@
 package dev.cjfravel.ariadne
 
 import org.apache.spark.sql.{DataFrame, Row}
-import org.apache.spark.sql.types.{StructType, StructField, StringType}
+
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.expressions.Window
 import io.delta.tables.DeltaTable
@@ -177,6 +177,7 @@ trait IndexQueryOperations extends IndexJoinOperations {
     *   if no matches are found or no index exists
     */
   def locateFiles(indexes: Map[String, Array[Any]]): Set[String] = {
+    val locateStart = System.currentTimeMillis()
     logger.warn(s"locateFiles: querying columns ${indexes.keys.mkString(", ")} with ${indexes.values.map(_.length).sum} total values")
     index match {
       case Some(df) =>
@@ -195,6 +196,7 @@ trait IndexQueryOperations extends IndexJoinOperations {
         }
 
         // Get files from bloom filters
+        val bloomStart = System.currentTimeMillis()
         val bloomFiles = if (bloomQueries.nonEmpty) {
           bloomQueries.map { case (col, values) =>
             locateFilesWithBloom(col, values, df)
@@ -202,8 +204,10 @@ trait IndexQueryOperations extends IndexJoinOperations {
         } else {
           Set.empty[String]
         }
+        val bloomMs = System.currentTimeMillis() - bloomStart
 
         // Get files from temporal indexes (pruned to latest timestamp per value)
+        val temporalStart = System.currentTimeMillis()
         val temporalFiles = if (temporalQueries.nonEmpty) {
           temporalQueries.map { case (column, values) =>
             locateFilesWithTemporal(column, values, df)
@@ -211,8 +215,10 @@ trait IndexQueryOperations extends IndexJoinOperations {
         } else {
           Set.empty[String]
         }
+        val temporalMs = System.currentTimeMillis() - temporalStart
 
         // Get files from range indexes
+        val rangeStart = System.currentTimeMillis()
         val rangeFiles = if (rangeQueries.nonEmpty) {
           rangeQueries.map { case (column, values) =>
             locateFilesWithRange(column, values, df)
@@ -220,13 +226,16 @@ trait IndexQueryOperations extends IndexJoinOperations {
         } else {
           Set.empty[String]
         }
+        val rangeMs = System.currentTimeMillis() - rangeStart
 
         // Get files from regular indexes
+        val regularStart = System.currentTimeMillis()
         val regularFiles = if (regularQueries.nonEmpty) {
           locateFilesRegular(regularQueries, df)
         } else {
           Set.empty[String]
         }
+        val regularMs = System.currentTimeMillis() - regularStart
 
         // Combine results - intersect across types that returned results (AND semantics)
         // Track which categories were queried (had input), not just which returned results
@@ -248,7 +257,11 @@ trait IndexQueryOperations extends IndexJoinOperations {
               s"range=${rangeFiles.size}, regular=${regularFiles.size} -> final=${allFiles.size}"
           )
         }
-        logger.warn(s"locateFiles: ${allFiles.size} files matched")
+        val totalMs = System.currentTimeMillis() - locateStart
+        logger.warn(
+          s"locateFiles: ${allFiles.size} files matched in ${totalMs}ms " +
+            s"(bloom=${bloomMs}ms, temporal=${temporalMs}ms, range=${rangeMs}ms, regular=${regularMs}ms)"
+        )
         if (allFiles.isEmpty) Set.empty else allFiles
       case None => Set()
     }
@@ -298,12 +311,11 @@ trait IndexQueryOperations extends IndexJoinOperations {
         .csv(tempPath.toString)
         .select("filename")
 
-      // Get count before collect for debugging
-      val fileCount = stagedFiles.count()
+      val collectedFiles = stagedFiles.collect()
+      val fileCount = collectedFiles.length
       logger.warn(s"Collecting $fileCount distinct filenames from staging")
 
-      val files = stagedFiles
-        .collect()
+      val files = collectedFiles
         .map(_.getString(0))
         .toSet
 
@@ -326,9 +338,22 @@ trait IndexQueryOperations extends IndexJoinOperations {
     }
   }
 
-  /** Gets candidate files from auto-bloom filter for a column.
-    * Returns None if no auto-bloom is available for the column.
-    * Files with null bloom filters are included as candidates (backward compat).
+  /** Gets candidate files from the auto-bloom filter for a specific column.
+    *
+    * Collects all bloom filter byte arrays from the index to the driver and
+    * tests each value against them. Files whose bloom filter is null are
+    * included as candidates for backward compatibility with indexes built
+    * before auto-bloom was added.
+    *
+    * @param column
+    *   The storage column name to check for auto-bloom filtering
+    * @param values
+    *   Array of values to probe against each file's bloom filter
+    * @param indexDf
+    *   The main index DataFrame containing auto-bloom binary columns
+    * @return
+    *   Some(set of candidate filenames) if an auto-bloom index exists for the
+    *   column, None otherwise
     */
   protected def getAutoBloomCandidates(
       column: String,
@@ -358,7 +383,24 @@ trait IndexQueryOperations extends IndexJoinOperations {
     Some(candidates)
   }
 
-  /** Gets candidate files from auto-bloom filter using values from a DataFrame. */
+  /** Gets candidate files from the auto-bloom filter using values extracted
+    * from a DataFrame.
+    *
+    * Collects distinct non-null values from the given DataFrame column, then
+    * delegates to [[getAutoBloomCandidates]] for the actual bloom filter probing.
+    *
+    * @param storageColumn
+    *   The storage column name in the index (used to look up the auto-bloom)
+    * @param joinColumn
+    *   The column name in `valuesDf` containing the query values
+    * @param valuesDf
+    *   DataFrame containing the values to probe against bloom filters
+    * @param indexDf
+    *   The main index DataFrame containing auto-bloom binary columns
+    * @return
+    *   Some(set of candidate filenames) if an auto-bloom index exists,
+    *   None otherwise
+    */
   protected def getAutoBloomCandidatesFromDf(
       storageColumn: String,
       joinColumn: String,
@@ -399,7 +441,17 @@ trait IndexQueryOperations extends IndexJoinOperations {
   ): Set[String] = {
     if (indexes.isEmpty) return Set.empty
 
-    val perColumnFiles = indexes.map { case (column, values) =>
+    // Filter null values from each column — isin() throws on an empty array
+    val filteredIndexes = indexes.map { case (column, values) =>
+      column -> values.filter(_ != null)
+    }
+    if (filteredIndexes.exists(_._2.isEmpty)) {
+      val emptyColumns = filteredIndexes.filter(_._2.isEmpty).keys.mkString(", ")
+      logger.debug(s"locateFilesRegular: columns [$emptyColumns] have no non-null values, returning empty result")
+      return Set.empty[String]
+    }
+
+    val perColumnFiles = filteredIndexes.map { case (column, values) =>
       val bloomCandidates = getAutoBloomCandidates(column, values, df)
       loadColumnIndex(df, column, bloomCandidates)
         .where(col(column).isin(values: _*))

--- a/src/main/scala/dev/cjfravel/ariadne/IndexQueryOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexQueryOperations.scala
@@ -636,27 +636,57 @@ trait IndexQueryOperations extends IndexJoinOperations {
     val rangeCol = s"range_${column}"
     if (!indexDf.columns.contains(rangeCol)) return Set.empty
 
-    // Get query range (min/max of incoming values)
-    val queryStats = valuesDf.select(
-      min(col(column)).alias("q_min"),
-      max(col(column)).alias("q_max")
-    ).collect()(0)
-
-    val qMin = queryStats.get(0)
-    val qMax = queryStats.get(1)
-    if (qMin == null || qMax == null) return Set.empty
-
-    logger.warn(s"Range query on column '$column': query range [$qMin, $qMax]")
-
-    // Filter files where range overlaps
-    val matchingFiles = indexDf
-      .select(col("filename"), col(s"$rangeCol.min").alias("file_min"), col(s"$rangeCol.max").alias("file_max"))
-      .where(col("file_min").isNotNull && col("file_max").isNotNull)
-      .where(col("file_max") >= lit(qMin) && col("file_min") <= lit(qMax))
-      .select("filename")
+    // Collect distinct query values (bounded to avoid driver OOM)
+    val distinctValues = valuesDf
+      .select(col(column))
       .distinct()
+      .limit(10000)
+      .collect()
+      .map(_.get(0))
+      .filter(_ != null)
 
-    collectFilenamesViaStaging(matchingFiles)
+    if (distinctValues.isEmpty) return Set.empty
+
+    logger.warn(s"Range query on column '$column' with ${distinctValues.length} distinct values")
+
+    if (distinctValues.length > 1000) {
+      logger.warn(s"Range query: large value set (${distinctValues.length}), using bounding box optimization")
+      val minMaxRow = valuesDf.agg(
+        min(col(column)).alias("q_min"),
+        max(col(column)).alias("q_max")
+      ).head()
+
+      val matchingFiles = indexDf
+        .select(
+          col("filename"),
+          col(s"$rangeCol.min").alias("file_min"),
+          col(s"$rangeCol.max").alias("file_max")
+        )
+        .where(col("file_min").isNotNull && col("file_max").isNotNull)
+        .where(col("file_max") >= lit(minMaxRow.get(0)) && col("file_min") <= lit(minMaxRow.get(1)))
+        .select("filename")
+        .distinct()
+
+      collectFilenamesViaStaging(matchingFiles)
+    } else {
+      // For reasonable value sets, check per-value containment (precise pruning)
+      val valueConditions = distinctValues.map { v =>
+        col("file_min") <= lit(v) && col("file_max") >= lit(v)
+      }
+
+      val matchingFiles = indexDf
+        .select(
+          col("filename"),
+          col(s"$rangeCol.min").alias("file_min"),
+          col(s"$rangeCol.max").alias("file_max")
+        )
+        .where(col("file_min").isNotNull && col("file_max").isNotNull)
+        .where(valueConditions.reduce(_ || _))
+        .select("filename")
+        .distinct()
+
+      collectFilenamesViaStaging(matchingFiles)
+    }
   }
 
   /** Returns a DataFrame of statistics for each indexed column (based on array

--- a/src/main/scala/dev/cjfravel/ariadne/IndexQueryOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexQueryOperations.scala
@@ -89,7 +89,9 @@ trait IndexQueryOperations extends IndexJoinOperations {
         Some(spark.read.format("delta").load(columnPath.toString))
       else None
     } catch {
-      case _: Exception => None
+      case e: Exception =>
+        logger.warn(s"Failed to load large index for column '$colName' in index '$name': ${e.getMessage}")
+        None
     }
   }
 
@@ -179,6 +181,7 @@ trait IndexQueryOperations extends IndexJoinOperations {
     *   if no matches are found or no index exists
     */
   def locateFiles(indexes: Map[String, Array[Any]]): Set[String] = {
+    require(indexes != null, "columnValues must not be null")
     val locateStart = System.currentTimeMillis()
     logger.warn(s"locateFiles: querying columns ${indexes.keys.mkString(", ")} with ${indexes.values.map(_.length).sum} total values")
     index match {
@@ -596,6 +599,8 @@ trait IndexQueryOperations extends IndexJoinOperations {
       columnMappings: Map[String, String],
       joinColumns: Seq[String]
   ): Set[String] = {
+    require(valuesDf != null, "DataFrame must not be null")
+    require(columnMappings != null && columnMappings.nonEmpty, "columnMappings must not be null or empty")
     val locateStart = System.currentTimeMillis()
     logger.warn(s"locateFilesFromDataFrame: querying columns ${joinColumns.mkString(", ")}")
     index match {

--- a/src/main/scala/dev/cjfravel/ariadne/IndexQueryOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexQueryOperations.scala
@@ -325,6 +325,7 @@ trait IndexQueryOperations extends IndexJoinOperations {
 
       val files = collectedFiles
         .map(_.getString(0))
+        .filter(_ != null)
         .toSet
 
       if (debugEnabled) {

--- a/src/main/scala/dev/cjfravel/ariadne/IndexQueryOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexQueryOperations.scala
@@ -89,18 +89,30 @@ trait IndexQueryOperations extends IndexJoinOperations {
     *   The main index DataFrame (may be repartitioned)
     * @param colName
     *   The storage column name
+    * @param bloomCandidateFiles
+    *   Optional set of files that passed auto-bloom pre-filtering.
+    *   When provided, only large index rows for these files are included.
     * @return
     *   DataFrame with (filename, colName) scalar rows
     */
   protected def loadColumnIndex(
       indexDf: DataFrame,
-      colName: String
+      colName: String,
+      bloomCandidateFiles: Option[Set[String]] = None
   ): DataFrame = {
     val mainRows = indexDf
       .select(col("filename"), explode(col(colName)).alias(colName))
     loadLargeIndex(colName) match {
-      case Some(largeDf) => mainRows.union(largeDf)
-      case None          => mainRows
+      case Some(largeDf) =>
+        bloomCandidateFiles match {
+          case Some(candidates) if candidates.nonEmpty =>
+            logger.warn(s"Filtering large index for $colName to ${candidates.size} bloom-candidate files")
+            val filteredLarge = largeDf.where(col("filename").isin(candidates.toSeq: _*))
+            mainRows.union(filteredLarge)
+          case _ =>
+            mainRows.union(largeDf)
+        }
+      case None => mainRows
     }
   }
 
@@ -150,14 +162,18 @@ trait IndexQueryOperations extends IndexJoinOperations {
   def locateFiles(indexes: Map[String, Array[Any]]): Set[String] = {
     index match {
       case Some(df) =>
-        // Separate bloom, temporal, and regular index queries
+        // Separate bloom, temporal, range, and regular index queries
         val bloomColumnSet = bloomColumns
         val temporalColumnSet = metadata.temporal_indexes.asScala.map(_.column).toSet
+        val rangeColumnSet = metadata.range_indexes.asScala.map(_.column).toSet
         val (bloomQueries, nonBloomQueries) = indexes.partition {
           case (col, _) => bloomColumnSet.contains(col)
         }
-        val (temporalQueries, regularQueries) = nonBloomQueries.partition {
+        val (temporalQueries, nonTemporalQueries) = nonBloomQueries.partition {
           case (col, _) => temporalColumnSet.contains(col)
+        }
+        val (rangeQueries, regularQueries) = nonTemporalQueries.partition {
+          case (col, _) => rangeColumnSet.contains(col)
         }
 
         // Get files from bloom filters
@@ -178,6 +194,15 @@ trait IndexQueryOperations extends IndexJoinOperations {
           Set.empty[String]
         }
 
+        // Get files from range indexes
+        val rangeFiles = if (rangeQueries.nonEmpty) {
+          rangeQueries.map { case (column, values) =>
+            locateFilesWithRange(column, values, df)
+          }.reduce(_ intersect _)
+        } else {
+          Set.empty[String]
+        }
+
         // Get files from regular indexes
         val regularFiles = if (regularQueries.nonEmpty) {
           locateFilesRegular(regularQueries, df)
@@ -185,8 +210,13 @@ trait IndexQueryOperations extends IndexJoinOperations {
           Set.empty[String]
         }
 
-        // Combine results (union / OR semantics)
-        val allFiles = bloomFiles.union(temporalFiles).union(regularFiles)
+        // Combine results - intersect across types that returned results (AND semantics)
+        val nonEmptyResults = Seq(bloomFiles, temporalFiles, rangeFiles, regularFiles).filter(_.nonEmpty)
+        val allFiles = if (nonEmptyResults.isEmpty) {
+          Set.empty[String]
+        } else {
+          nonEmptyResults.reduce(_ intersect _)
+        }
         if (allFiles.isEmpty) Set.empty else allFiles
       case None => Set()
     }
@@ -261,6 +291,56 @@ trait IndexQueryOperations extends IndexJoinOperations {
     }
   }
 
+  /** Gets candidate files from auto-bloom filter for a column.
+    * Returns None if no auto-bloom is available for the column.
+    * Files with null bloom filters are included as candidates (backward compat).
+    */
+  protected def getAutoBloomCandidates(
+      column: String,
+      values: Array[Any],
+      indexDf: DataFrame
+  ): Option[Set[String]] = {
+    if (!metadata.auto_bloom_indexes.asScala.contains(column)) return None
+    val autoBloomCol = s"auto_bloom_${column}"
+    if (!indexDf.columns.contains(autoBloomCol)) return None
+
+    val candidates = indexDf
+      .select("filename", autoBloomCol)
+      .collect()
+      .filter { row =>
+        val bloomBytes = row.getAs[Array[Byte]](autoBloomCol)
+        if (bloomBytes == null) true
+        else values.exists(v => bloomMightContain(bloomBytes, v))
+      }
+      .map(_.getString(0))
+      .toSet
+
+    logger.warn(s"Auto-bloom filter for $column: ${candidates.size} candidate files")
+    Some(candidates)
+  }
+
+  /** Gets candidate files from auto-bloom filter using values from a DataFrame. */
+  protected def getAutoBloomCandidatesFromDf(
+      storageColumn: String,
+      joinColumn: String,
+      valuesDf: DataFrame,
+      indexDf: DataFrame
+  ): Option[Set[String]] = {
+    if (!metadata.auto_bloom_indexes.asScala.contains(storageColumn)) return None
+    val autoBloomCol = s"auto_bloom_${storageColumn}"
+    if (!indexDf.columns.contains(autoBloomCol)) return None
+
+    val values = valuesDf
+      .select(joinColumn)
+      .distinct()
+      .collect()
+      .map(_.get(0))
+      .filter(_ != null)
+
+    if (values.isEmpty) return None
+    getAutoBloomCandidates(storageColumn, values, indexDf)
+  }
+
   /** Locates files using regular (non-bloom) indexes.
     *
     * @param indexes
@@ -274,26 +354,23 @@ trait IndexQueryOperations extends IndexJoinOperations {
       indexes: Map[String, Array[Any]],
       df: DataFrame
   ): Set[String] = {
-    val schema = StructType(
-      Array(StructField("filename", StringType, nullable = false))
-    )
-    val emptyDF =
-      spark.createDataFrame(
-        spark.sparkContext.emptyRDD[Row],
-        schema
-      )
+    if (indexes.isEmpty) return Set.empty
 
-    val resultDF = indexes.foldLeft(emptyDF) {
-      case (accumDF, (column, values)) =>
-        val filteredDF = loadColumnIndex(df, column)
-          .where(col(column).isin(values: _*))
-          .select("filename")
-          .distinct
+    val perColumnFiles = indexes.map { case (column, values) =>
+      val bloomCandidates = getAutoBloomCandidates(column, values, df)
+      loadColumnIndex(df, column, bloomCandidates)
+        .where(col(column).isin(values: _*))
+        .select("filename")
+        .distinct
+    }.toSeq
 
-        accumDF.union(filteredDF)
+    val intersectedDF = if (perColumnFiles.size == 1) {
+      perColumnFiles.head
+    } else {
+      perColumnFiles.reduce((a, b) => a.join(b, Seq("filename"), "inner"))
     }
 
-    collectFilenamesViaStaging(resultDF)
+    collectFilenamesViaStaging(intersectedDF)
   }
 
   /** Locates files using temporal indexes, pruning to only files containing
@@ -325,6 +402,40 @@ trait IndexQueryOperations extends IndexJoinOperations {
     collectFilenamesViaStaging(pruned)
   }
 
+  /** Locates files using range indexes by checking if any query value falls
+    * within the file's [min, max] range.
+    *
+    * @param column The range index column name
+    * @param values Values to search for
+    * @param df The index DataFrame
+    * @return Set of filenames whose range overlaps with query values
+    */
+  private def locateFilesWithRange(
+      column: String,
+      values: Array[Any],
+      df: DataFrame
+  ): Set[String] = {
+    val rangeCol = s"range_${column}"
+    if (!df.columns.contains(rangeCol)) return Set.empty
+
+    df.select("filename", rangeCol)
+      .where(col(rangeCol).isNotNull)
+      .collect()
+      .filter { row =>
+        val rangeStruct = row.getStruct(1)
+        if (rangeStruct == null || rangeStruct.isNullAt(0) || rangeStruct.isNullAt(1)) false
+        else {
+          val fileMin = rangeStruct.get(0).asInstanceOf[Comparable[Any]]
+          val fileMax = rangeStruct.get(1).asInstanceOf[Comparable[Any]]
+          values.exists { v =>
+            fileMin.compareTo(v) <= 0 && fileMax.compareTo(v) >= 0
+          }
+        }
+      }
+      .map(_.getString(0))
+      .toSet
+  }
+
   /** Locates files based on a DataFrame containing join column values. Handles
     * both regular indexes and bloom filter indexes.
     *
@@ -350,13 +461,17 @@ trait IndexQueryOperations extends IndexJoinOperations {
         }
         val bloomColumnSet = bloomColumns
         val temporalColumnSet = metadata.temporal_indexes.asScala.map(_.column).toSet
+        val rangeColumnSet = metadata.range_indexes.asScala.map(_.column).toSet
 
-        // Separate bloom, temporal, and regular columns
+        // Separate bloom, temporal, range, and regular columns
         val (bloomJoinColumns, nonBloomColumns) = joinColumns.partition {
           joinColumn => bloomColumnSet.contains(joinColumn)
         }
-        val (temporalJoinColumns, regularJoinColumns) = nonBloomColumns.partition {
+        val (temporalJoinColumns, nonTemporalColumns) = nonBloomColumns.partition {
           joinColumn => temporalColumnSet.contains(joinColumn)
+        }
+        val (rangeJoinColumns, regularJoinColumns) = nonTemporalColumns.partition {
+          joinColumn => rangeColumnSet.contains(joinColumn)
         }
 
         // Get files from bloom filters
@@ -378,17 +493,17 @@ trait IndexQueryOperations extends IndexJoinOperations {
           Set.empty[String]
         }
 
+        // Get files from range indexes
+        val rangeFiles = if (rangeJoinColumns.nonEmpty) {
+          rangeJoinColumns.map { joinColumn =>
+            locateFilesWithRangeFromDataFrame(joinColumn, valuesDf, indexDf)
+          }.reduce(_ intersect _)
+        } else {
+          Set.empty[String]
+        }
+
         // Get files from regular indexes
         val regularFiles = if (regularJoinColumns.nonEmpty) {
-          val schema = StructType(
-            Array(StructField("filename", StringType, nullable = false))
-          )
-          val emptyDF =
-            spark.createDataFrame(
-              spark.sparkContext.emptyRDD[Row],
-              schema
-            )
-
           // Repartition the index DataFrame before explode to reduce
           // per-executor memory pressure on large indexes
           val repartitionedIndex = maybeRepartition(indexDf)
@@ -396,35 +511,41 @@ trait IndexQueryOperations extends IndexJoinOperations {
             logger.warn(s"[debug] locateFiles: index repartitioned")
           }
 
-          val resultDF = regularJoinColumns.foldLeft(emptyDF) {
-            (accumDF, joinColumn) =>
-              val storageColumn = columnMappings(joinColumn)
+          val perColumnDFs = regularJoinColumns.map { joinColumn =>
+            val storageColumn = columnMappings(joinColumn)
+            val distinctValues = valuesDf.select(col(joinColumn)).distinct()
+            val bloomCandidates = getAutoBloomCandidatesFromDf(storageColumn, joinColumn, valuesDf, indexDf)
+            loadColumnIndex(repartitionedIndex, storageColumn, bloomCandidates)
+              .join(
+                distinctValues.withColumnRenamed(joinColumn, storageColumn),
+                Seq(storageColumn),
+                "leftsemi"
+              )
+              .select("filename")
+              .distinct()
+          }
 
-              // Create a DataFrame with distinct values for this column
-              val distinctValues = valuesDf.select(col(joinColumn)).distinct()
-
-              val filteredDF = loadColumnIndex(repartitionedIndex, storageColumn)
-                .join(
-                  distinctValues.withColumnRenamed(joinColumn, storageColumn),
-                  Seq(storageColumn),
-                  "leftsemi"
-                )
-                .select("filename")
-                .distinct()
-
-              accumDF.union(filteredDF)
+          val intersectedDF = if (perColumnDFs.size == 1) {
+            perColumnDFs.head
+          } else {
+            perColumnDFs.reduce((a, b) => a.join(b, Seq("filename"), "inner"))
           }
 
           if (debugEnabled) {
             logger.warn(s"[debug] locateFiles: about to collectFilenamesViaStaging at ${System.currentTimeMillis() - locateStart}ms")
           }
-          collectFilenamesViaStaging(resultDF)
+          collectFilenamesViaStaging(intersectedDF)
         } else {
           Set.empty[String]
         }
 
-        // Combine results (union / OR semantics)
-        val allFiles = bloomFiles.union(temporalFiles).union(regularFiles)
+        // Combine results - intersect across types that returned results (AND semantics)
+        val nonEmptyResults = Seq(bloomFiles, temporalFiles, rangeFiles, regularFiles).filter(_.nonEmpty)
+        val allFiles = if (nonEmptyResults.isEmpty) {
+          Set.empty[String]
+        } else {
+          nonEmptyResults.reduce(_ intersect _)
+        }
         if (allFiles.isEmpty) Set.empty else allFiles
       case None => Set()
     }
@@ -459,6 +580,45 @@ trait IndexQueryOperations extends IndexJoinOperations {
       .distinct()
 
     collectFilenamesViaStaging(pruned)
+  }
+
+  /** Locates files using range indexes from a DataFrame of values.
+    *
+    * Computes the min/max of the incoming query values and filters index rows
+    * where the file's stored range overlaps: file_max >= query_min AND file_min <= query_max.
+    *
+    * @param column The range index column name
+    * @param valuesDf DataFrame containing values to search for
+    * @param indexDf The index DataFrame
+    * @return Set of filenames whose range overlaps with query values
+    */
+  private def locateFilesWithRangeFromDataFrame(
+      column: String,
+      valuesDf: DataFrame,
+      indexDf: DataFrame
+  ): Set[String] = {
+    val rangeCol = s"range_${column}"
+    if (!indexDf.columns.contains(rangeCol)) return Set.empty
+
+    // Get query range (min/max of incoming values)
+    val queryStats = valuesDf.select(
+      min(col(column)).alias("q_min"),
+      max(col(column)).alias("q_max")
+    ).collect()(0)
+
+    val qMin = queryStats.get(0)
+    val qMax = queryStats.get(1)
+    if (qMin == null || qMax == null) return Set.empty
+
+    // Filter files where range overlaps
+    val matchingFiles = indexDf
+      .select(col("filename"), col(s"$rangeCol.min").alias("file_min"), col(s"$rangeCol.max").alias("file_max"))
+      .where(col("file_min").isNotNull && col("file_max").isNotNull)
+      .where(col("file_max") >= lit(qMin) && col("file_min") <= lit(qMax))
+      .select("filename")
+      .distinct()
+
+    collectFilenamesViaStaging(matchingFiles)
   }
 
   /** Returns a DataFrame of statistics for each indexed column (based on array

--- a/src/main/scala/dev/cjfravel/ariadne/IndexQueryOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexQueryOperations.scala
@@ -179,6 +179,14 @@ trait IndexQueryOperations extends IndexJoinOperations {
     * @return
     *   A set of file paths matching all query criteria, or an empty set
     *   if no matches are found or no index exists
+    *
+    * @note If a staging table exists, its contents are collected to the driver
+    *       for merging. This may cause driver OOM for very large staging tables.
+    *
+    * @example
+    * {{{
+    * val matchingFiles = index.locateFiles(Map("userId" -> Set("u1", "u2")))
+    * }}}
     */
   def locateFiles(indexes: Map[String, Array[Any]]): Set[String] = {
     require(indexes != null, "columnValues must not be null")
@@ -268,7 +276,9 @@ trait IndexQueryOperations extends IndexJoinOperations {
             s"(bloom=${bloomMs}ms, temporal=${temporalMs}ms, range=${rangeMs}ms, regular=${regularMs}ms)"
         )
         if (allFiles.isEmpty) Set.empty else allFiles
-      case None => Set.empty
+      case None =>
+        logger.warn(s"Index table not found for index '$name'; returning empty file set")
+        Set.empty
     }
   }
 
@@ -594,6 +604,11 @@ trait IndexQueryOperations extends IndexJoinOperations {
     *   The columns to use for filtering
     * @return
     *   A set of file names matching the criteria.
+    *
+    * @example
+    * {{{
+    * val files = index.locateFilesFromDataFrame(lookupDf, Seq("userId"))
+    * }}}
     */
   def locateFilesFromDataFrame(
       valuesDf: DataFrame,
@@ -861,6 +876,11 @@ trait IndexQueryOperations extends IndexJoinOperations {
     *
     * @return Single-row DataFrame with FileCount and per-column stat structs,
     *         or an empty DataFrame if no index exists
+    *
+    * @example
+    * {{{
+    * index.stats()  // prints index statistics to console
+    * }}}
     */
   def stats(): DataFrame = {
     logger.warn(s"Computing stats for index '$name'")

--- a/src/main/scala/dev/cjfravel/ariadne/IndexQueryOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexQueryOperations.scala
@@ -8,7 +8,17 @@ import io.delta.tables.DeltaTable
 import org.apache.hadoop.fs.Path
 import scala.collection.JavaConverters._
 
-/** Trait providing query operations for Index instances.
+/** Trait providing query and file location operations for Index instances.
+  *
+  * This is the top-level trait in the Index trait hierarchy, providing:
+  * - File location via regular, bloom, temporal, range, and auto-bloom indexes
+  * - Multi-column intersection with AND semantics across index types
+  * - Index statistics and diagnostics
+  * - Delta table management (repartitioning, large index loading)
+  *
+  * File location uses a staged collection strategy: distinct filenames are
+  * written to temporary CSV storage before collection to avoid executor
+  * memory pressure on large result sets.
   */
 trait IndexQueryOperations extends IndexJoinOperations {
   self: Index =>
@@ -151,13 +161,20 @@ trait IndexQueryOperations extends IndexJoinOperations {
     }
   }
 
-  /** Locates files based on index values. Handles both regular indexes (using
-    * explode) and bloom filter indexes (using probabilistic matching).
+  /** Locates files matching the given index values across all index types.
+    *
+    * Queries regular, bloom, temporal, range, and auto-bloom indexes in
+    * parallel and intersects results with AND semantics. Each index type
+    * independently returns candidate files, and only files present in all
+    * queried categories are included in the final result.
     *
     * @param indexes
-    *   A map of index column names to their values.
+    *   A map of index column names to arrays of values to search for.
+    *   Columns are automatically routed to the appropriate index type
+    *   (bloom, temporal, range, or regular).
     * @return
-    *   A set of file names matching the criteria.
+    *   A set of file paths matching all query criteria, or an empty set
+    *   if no matches are found or no index exists
     */
   def locateFiles(indexes: Map[String, Array[Any]]): Set[String] = {
     logger.warn(s"locateFiles: querying columns ${indexes.keys.mkString(", ")} with ${indexes.values.map(_.length).sum} total values")
@@ -237,14 +254,17 @@ trait IndexQueryOperations extends IndexJoinOperations {
     }
   }
 
-  /** Collects filenames via staging through temp storage. This separates the
-    * distinct operation from collect to avoid executor failures on large result
-    * sets.
+  /** Collects filenames via staging through temporary CSV storage.
+    *
+    * Separates the distributed distinct operation from the driver-side collect
+    * to avoid executor memory pressure on large result sets. Writes distinct
+    * filenames to a temporary CSV path, then reads them back and collects.
+    * The temporary path is cleaned up in a finally block.
     *
     * @param resultDF
-    *   DataFrame containing filename column to collect
+    *   DataFrame containing a "filename" column to collect
     * @return
-    *   Set of distinct filenames
+    *   Set of distinct filenames collected from the staged CSV
     */
   private def collectFilenamesViaStaging(resultDF: DataFrame): Set[String] = {
     val stagingStart = System.currentTimeMillis()
@@ -360,14 +380,18 @@ trait IndexQueryOperations extends IndexJoinOperations {
     getAutoBloomCandidates(storageColumn, values, indexDf)
   }
 
-  /** Locates files using regular (non-bloom) indexes.
+  /** Locates files using regular (non-bloom, non-temporal, non-range) indexes.
+    *
+    * For each column, explodes the index arrays and filters to matching values,
+    * optionally using auto-bloom pre-filtering. When multiple columns are queried,
+    * results are intersected (AND semantics) via inner joins on filename.
     *
     * @param indexes
-    *   A map of index column names to their values.
+    *   A map of storage column names to arrays of values to match
     * @param df
-    *   The index DataFrame.
+    *   The main index DataFrame
     * @return
-    *   A set of file names matching the criteria.
+    *   Set of filenames matching all specified column values
     */
   private def locateFilesRegular(
       indexes: Map[String, Array[Any]],
@@ -399,10 +423,13 @@ trait IndexQueryOperations extends IndexJoinOperations {
   /** Locates files using temporal indexes, pruning to only files containing
     * the latest version of each value (by max timestamp).
     *
+    * Uses a window function partitioned by value, ordered by max_ts descending,
+    * keeping only rank 1 to ensure only the most recent file per value is returned.
+    *
     * @param column The temporal index value column name
-    * @param values Values to search for
-    * @param df The index DataFrame
-    * @return Set of filenames containing the latest versions
+    * @param values Array of values to search for in the temporal index
+    * @param df The main index DataFrame containing temporal struct arrays
+    * @return Set of filenames containing the latest version of any matching value
     */
   private def locateFilesWithTemporal(
       column: String,
@@ -428,10 +455,13 @@ trait IndexQueryOperations extends IndexJoinOperations {
   /** Locates files using range indexes by checking if any query value falls
     * within the file's [min, max] range.
     *
+    * Builds an OR condition across all values, checking file_min <= value AND
+    * file_max >= value for each. Logs a warning when value count exceeds 1000.
+    *
     * @param column The range index column name
-    * @param values Values to search for
-    * @param df The index DataFrame
-    * @return Set of filenames whose range overlaps with query values
+    * @param values Array of values to check against per-file min/max ranges
+    * @param indexDf The main index DataFrame containing range struct columns
+    * @return Set of filenames whose stored range contains at least one query value
     */
   private def locateFilesWithRange(
       column: String,
@@ -594,10 +624,13 @@ trait IndexQueryOperations extends IndexJoinOperations {
   /** Locates files using temporal indexes from a DataFrame of values, pruning
     * to only files containing the latest version of each value.
     *
+    * Joins the exploded temporal index with distinct query values, then applies
+    * a window function to keep only the file with the highest max_ts per value.
+    *
     * @param column The temporal index value column name
-    * @param valuesDf DataFrame containing values to search for
-    * @param indexDf The index DataFrame
-    * @return Set of filenames containing the latest versions
+    * @param valuesDf DataFrame containing a column named `column` with values to search for
+    * @param indexDf The main index DataFrame (should already be repartitioned if needed)
+    * @return Set of filenames containing the latest version of any matching value
     */
   private def locateFilesWithTemporalFromDataFrame(
       column: String,
@@ -624,13 +657,14 @@ trait IndexQueryOperations extends IndexJoinOperations {
 
   /** Locates files using range indexes from a DataFrame of values.
     *
-    * Computes the min/max of the incoming query values and filters index rows
-    * where the file's stored range overlaps: file_max >= query_min AND file_min <= query_max.
+    * Collects up to 10,000 distinct query values. For sets exceeding 1,000 values,
+    * falls back to a bounding-box optimization (query min/max vs file min/max).
+    * For smaller sets, checks per-value containment for precise pruning.
     *
     * @param column The range index column name
-    * @param valuesDf DataFrame containing values to search for
-    * @param indexDf The index DataFrame
-    * @return Set of filenames whose range overlaps with query values
+    * @param valuesDf DataFrame containing a column named `column` with values to search for
+    * @param indexDf The main index DataFrame containing range struct columns
+    * @return Set of filenames whose stored range overlaps with the query values
     */
   private def locateFilesWithRangeFromDataFrame(
       column: String,
@@ -641,6 +675,10 @@ trait IndexQueryOperations extends IndexJoinOperations {
     if (!indexDf.columns.contains(rangeCol)) return Set.empty
 
     // Collect distinct query values (bounded to avoid driver OOM)
+    val rawCount = valuesDf.select(col(column)).distinct().count()
+    if (rawCount > 10000) {
+      logger.warn(s"Range query on '$column': truncating $rawCount distinct values to 10000 for per-value pruning")
+    }
     val distinctValues = valuesDf
       .select(col(column))
       .distinct()
@@ -693,8 +731,14 @@ trait IndexQueryOperations extends IndexJoinOperations {
     }
   }
 
-  /** Returns a DataFrame of statistics for each indexed column (based on array
-    * length per file) and file count.
+  /** Returns a DataFrame of per-column index statistics and total file count.
+    *
+    * For each indexed column, computes statistics on the array length (number of
+    * distinct values per file): min, max, avg, median, and standard deviation.
+    * Also includes the total number of indexed files.
+    *
+    * @return Single-row DataFrame with FileCount and per-column stat structs,
+    *         or an empty DataFrame if no index exists
     */
   def stats(): DataFrame = {
     index match {
@@ -724,10 +768,12 @@ trait IndexQueryOperations extends IndexJoinOperations {
     }
   }
 
-  /** Prints the index DataFrame to the console, including its schema.
+  /** Prints the index DataFrame to the console for debugging.
     *
-    * This method retrieves the latest version of the index stored in Delta
-    * Lake, displays its contents, and prints its schema.
+    * Displays the contents and schema of the main index Delta table.
+    * This is an internal/diagnostic method.
+    *
+    * @param truncate Whether to truncate long values in the display (default: false)
     */
   private[ariadne] def printIndex(truncate: Boolean = false): Unit = {
     index match {
@@ -735,6 +781,7 @@ trait IndexQueryOperations extends IndexJoinOperations {
         df.show(truncate)
         df.printSchema()
       case None =>
+        logger.warn(s"No index data found for index '$name'")
     }
   }
 

--- a/src/main/scala/dev/cjfravel/ariadne/IndexQueryOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexQueryOperations.scala
@@ -42,10 +42,11 @@ trait IndexQueryOperations extends IndexJoinOperations {
     }
   }
 
-  /** Helper function to load the index
+  /** Helper function to load the index.
     *
     * @return
-    *   DataFrame containing latest version of the index
+    *   `Some(DataFrame)` containing the latest version of the index,
+    *   or `None` if the index Delta table does not yet exist
     */
   protected def index: Option[DataFrame] = {
     delta(indexFilePath).map(_.toDF)
@@ -883,6 +884,7 @@ trait IndexQueryOperations extends IndexJoinOperations {
     * }}}
     */
   def stats(): DataFrame = {
+    val startTime = System.currentTimeMillis()
     logger.warn(s"Computing stats for index '$name'")
     index match {
       case Some(df) =>
@@ -896,7 +898,7 @@ trait IndexQueryOperations extends IndexJoinOperations {
             min(lenCol).as("min"),
             max(lenCol).as("max"),
             avg(lenCol).as("avg"),
-            expr("percentile_approx(size(" + colName + "), 0.5)").as("median"),
+            expr(s"percentile_approx(size(`$colName`), 0.5)").as("median"),
             stddev(lenCol).as("stddev")
           ).as(colName)
         }
@@ -904,9 +906,12 @@ trait IndexQueryOperations extends IndexJoinOperations {
         // Build a single-row DataFrame with all stats
         val aggExprs =
           Seq(countDistinct("filename").as("FileCount")) ++ statCols
-        df.agg(aggExprs.head, aggExprs.tail: _*)
+        val result = df.agg(aggExprs.head, aggExprs.tail: _*)
+        logger.warn(s"Stats computation for index '$name' completed in ${System.currentTimeMillis() - startTime}ms")
+        result
 
       case None =>
+        logger.warn(s"No index data found for stats on '$name' (${System.currentTimeMillis() - startTime}ms)")
         spark.emptyDataFrame
     }
   }
@@ -930,8 +935,11 @@ trait IndexQueryOperations extends IndexJoinOperations {
 
   /** Prints the metadata associated with the index to the console.
     *
-    * This metadata contains details about the index, including its schema,
-    * format, and tracked files.
+    * Outputs the string representation of [[IndexMetadata]], which includes
+    * the index schema, format, read options, and all configured index types
+    * (regular, bloom, temporal, range, computed, exploded).
+    *
+    * @see [[IndexMetadataOperations.metadata]]
     */
   private[ariadne] def printMetadata: Unit = println(metadata)
 }

--- a/src/main/scala/dev/cjfravel/ariadne/IndexQueryOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexQueryOperations.scala
@@ -178,18 +178,18 @@ trait IndexQueryOperations extends IndexJoinOperations {
 
         // Get files from bloom filters
         val bloomFiles = if (bloomQueries.nonEmpty) {
-          bloomQueries.flatMap { case (col, values) =>
+          bloomQueries.map { case (col, values) =>
             locateFilesWithBloom(col, values, df)
-          }.toSet
+          }.reduce(_ intersect _)
         } else {
           Set.empty[String]
         }
 
         // Get files from temporal indexes (pruned to latest timestamp per value)
         val temporalFiles = if (temporalQueries.nonEmpty) {
-          temporalQueries.flatMap { case (column, values) =>
+          temporalQueries.map { case (column, values) =>
             locateFilesWithTemporal(column, values, df)
-          }.toSet
+          }.reduce(_ intersect _)
         } else {
           Set.empty[String]
         }
@@ -211,11 +211,24 @@ trait IndexQueryOperations extends IndexJoinOperations {
         }
 
         // Combine results - intersect across types that returned results (AND semantics)
-        val nonEmptyResults = Seq(bloomFiles, temporalFiles, rangeFiles, regularFiles).filter(_.nonEmpty)
-        val allFiles = if (nonEmptyResults.isEmpty) {
+        // Track which categories were queried (had input), not just which returned results
+        val queriedResults: Seq[Set[String]] = Seq(
+          if (bloomQueries.nonEmpty) Some(bloomFiles) else None,
+          if (temporalQueries.nonEmpty) Some(temporalFiles) else None,
+          if (rangeQueries.nonEmpty) Some(rangeFiles) else None,
+          if (regularQueries.nonEmpty) Some(regularFiles) else None
+        ).flatten
+
+        val allFiles = if (queriedResults.isEmpty) {
           Set.empty[String]
         } else {
-          nonEmptyResults.reduce(_ intersect _)
+          queriedResults.reduce(_ intersect _)
+        }
+        if (debugEnabled) {
+          logger.warn(
+            s"[debug] Cross-type combination: bloom=${bloomFiles.size}, temporal=${temporalFiles.size}, " +
+              s"range=${rangeFiles.size}, regular=${regularFiles.size} -> final=${allFiles.size}"
+          )
         }
         if (allFiles.isEmpty) Set.empty else allFiles
       case None => Set()
@@ -304,9 +317,11 @@ trait IndexQueryOperations extends IndexJoinOperations {
     val autoBloomCol = s"auto_bloom_${column}"
     if (!indexDf.columns.contains(autoBloomCol)) return None
 
-    val candidates = indexDf
+    val allRows = indexDf
       .select("filename", autoBloomCol)
       .collect()
+
+    val candidates = allRows
       .filter { row =>
         val bloomBytes = row.getAs[Array[Byte]](autoBloomCol)
         if (bloomBytes == null) true
@@ -315,7 +330,9 @@ trait IndexQueryOperations extends IndexJoinOperations {
       .map(_.getString(0))
       .toSet
 
-    logger.warn(s"Auto-bloom filter for $column: ${candidates.size} candidate files")
+    val totalFiles = allRows.length
+    val reduction = if (totalFiles > 0) 100 - (candidates.size * 100 / totalFiles) else 0
+    logger.warn(s"Auto-bloom filter for '$column': $totalFiles total files -> ${candidates.size} candidates ($reduction% reduction)")
     Some(candidates)
   }
 
@@ -370,7 +387,11 @@ trait IndexQueryOperations extends IndexJoinOperations {
       perColumnFiles.reduce((a, b) => a.join(b, Seq("filename"), "inner"))
     }
 
-    collectFilenamesViaStaging(intersectedDF)
+    val result = collectFilenamesViaStaging(intersectedDF)
+    if (debugEnabled && indexes.size > 1) {
+      logger.warn(s"[debug] Multi-column intersection: ${indexes.size} columns, result: ${result.size} files")
+    }
+    result
   }
 
   /** Locates files using temporal indexes, pruning to only files containing
@@ -413,27 +434,35 @@ trait IndexQueryOperations extends IndexJoinOperations {
   private def locateFilesWithRange(
       column: String,
       values: Array[Any],
-      df: DataFrame
+      indexDf: DataFrame
   ): Set[String] = {
     val rangeCol = s"range_${column}"
-    if (!df.columns.contains(rangeCol)) return Set.empty
+    if (!indexDf.columns.contains(rangeCol)) return Set.empty
+    if (values.isEmpty) return Set.empty
 
-    df.select("filename", rangeCol)
-      .where(col(rangeCol).isNotNull)
-      .collect()
-      .filter { row =>
-        val rangeStruct = row.getStruct(1)
-        if (rangeStruct == null || rangeStruct.isNullAt(0) || rangeStruct.isNullAt(1)) false
-        else {
-          val fileMin = rangeStruct.get(0).asInstanceOf[Comparable[Any]]
-          val fileMax = rangeStruct.get(1).asInstanceOf[Comparable[Any]]
-          values.exists { v =>
-            fileMin.compareTo(v) <= 0 && fileMax.compareTo(v) >= 0
-          }
-        }
-      }
-      .map(_.getString(0))
-      .toSet
+    logger.warn(s"Range query on column '$column' with ${values.length} values")
+    if (values.length > 1000) {
+      logger.warn(s"Range query has ${values.length} values; large OR expression may be slow")
+    }
+
+    // Use Spark lit() for type-safe comparisons instead of Comparable casts.
+    // This handles type coercion (e.g. Long vs Int) and NaN correctly.
+    val valueConditions = values.map { v =>
+      col("file_min") <= lit(v) && col("file_max") >= lit(v)
+    }
+
+    val matchingFiles = indexDf
+      .select(
+        col("filename"),
+        col(s"$rangeCol.min").alias("file_min"),
+        col(s"$rangeCol.max").alias("file_max")
+      )
+      .where(col("file_min").isNotNull && col("file_max").isNotNull)
+      .where(valueConditions.reduce(_ || _))
+      .select("filename")
+      .distinct()
+
+    collectFilenamesViaStaging(matchingFiles)
   }
 
   /** Locates files based on a DataFrame containing join column values. Handles
@@ -476,9 +505,9 @@ trait IndexQueryOperations extends IndexJoinOperations {
 
         // Get files from bloom filters
         val bloomFiles = if (bloomJoinColumns.nonEmpty) {
-          bloomJoinColumns.flatMap { joinColumn =>
+          bloomJoinColumns.map { joinColumn =>
             locateFilesWithBloomFromDataFrame(joinColumn, valuesDf, indexDf)
-          }.toSet
+          }.reduce(_ intersect _)
         } else {
           Set.empty[String]
         }
@@ -486,9 +515,9 @@ trait IndexQueryOperations extends IndexJoinOperations {
         // Get files from temporal indexes (pruned to latest timestamp per value)
         val temporalFiles = if (temporalJoinColumns.nonEmpty) {
           val repartitionedIndex = maybeRepartition(indexDf)
-          temporalJoinColumns.flatMap { joinColumn =>
+          temporalJoinColumns.map { joinColumn =>
             locateFilesWithTemporalFromDataFrame(joinColumn, valuesDf, repartitionedIndex)
-          }.toSet
+          }.reduce(_ intersect _)
         } else {
           Set.empty[String]
         }
@@ -540,11 +569,18 @@ trait IndexQueryOperations extends IndexJoinOperations {
         }
 
         // Combine results - intersect across types that returned results (AND semantics)
-        val nonEmptyResults = Seq(bloomFiles, temporalFiles, rangeFiles, regularFiles).filter(_.nonEmpty)
-        val allFiles = if (nonEmptyResults.isEmpty) {
+        // Track which categories were queried (had input), not just which returned results
+        val queriedResults: Seq[Set[String]] = Seq(
+          if (bloomJoinColumns.nonEmpty) Some(bloomFiles) else None,
+          if (temporalJoinColumns.nonEmpty) Some(temporalFiles) else None,
+          if (rangeJoinColumns.nonEmpty) Some(rangeFiles) else None,
+          if (regularJoinColumns.nonEmpty) Some(regularFiles) else None
+        ).flatten
+
+        val allFiles = if (queriedResults.isEmpty) {
           Set.empty[String]
         } else {
-          nonEmptyResults.reduce(_ intersect _)
+          queriedResults.reduce(_ intersect _)
         }
         if (allFiles.isEmpty) Set.empty else allFiles
       case None => Set()
@@ -609,6 +645,8 @@ trait IndexQueryOperations extends IndexJoinOperations {
     val qMin = queryStats.get(0)
     val qMax = queryStats.get(1)
     if (qMin == null || qMax == null) return Set.empty
+
+    logger.warn(s"Range query on column '$column': query range [$qMin, $qMax]")
 
     // Filter files where range overlaps
     val matchingFiles = indexDf

--- a/src/main/scala/dev/cjfravel/ariadne/IndexQueryOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexQueryOperations.scala
@@ -57,15 +57,17 @@ trait IndexQueryOperations extends IndexJoinOperations {
     *   Set of column names with large index storage
     */
   protected def largeIndexColumns: Set[String] = {
-    if (!exists(largeIndexesFilePath)) return Set.empty
-    fs.listStatus(largeIndexesFilePath)
-      .filter(_.isDirectory)
-      .map(_.getPath)
-      .filter(path =>
-        exists(path) && DeltaTable.isDeltaTable(spark, path.toString)
-      )
-      .map(_.getName)
-      .toSet
+    if (!exists(largeIndexesFilePath)) Set.empty
+    else {
+      fs.listStatus(largeIndexesFilePath)
+        .filter(_.isDirectory)
+        .map(_.getPath)
+        .filter(path =>
+          exists(path) && DeltaTable.isDeltaTable(spark, path.toString)
+        )
+        .map(_.getName)
+        .toSet
+    }
   }
 
   /** Loads a large index Delta table for a specific column. Large indexes
@@ -263,7 +265,7 @@ trait IndexQueryOperations extends IndexJoinOperations {
             s"(bloom=${bloomMs}ms, temporal=${temporalMs}ms, range=${rangeMs}ms, regular=${regularMs}ms)"
         )
         if (allFiles.isEmpty) Set.empty else allFiles
-      case None => Set()
+      case None => Set.empty
     }
   }
 
@@ -273,6 +275,9 @@ trait IndexQueryOperations extends IndexJoinOperations {
     * to avoid executor memory pressure on large result sets. Writes distinct
     * filenames to a temporary CSV path, then reads them back and collects.
     * The temporary path is cleaned up in a finally block.
+    *
+    * @note All distinct filenames are collected to the driver. For indexes with
+    *   millions of files, this can cause driver OOM.
     *
     * @param resultDF
     *   DataFrame containing a "filename" column to collect
@@ -345,6 +350,10 @@ trait IndexQueryOperations extends IndexJoinOperations {
     * included as candidates for backward compatibility with indexes built
     * before auto-bloom was added.
     *
+    * @note This method collects all (filename, bloom_filter_bytes) rows to the
+    *   driver. For very large indexes (100k+ files), this can cause driver OOM.
+    *   Monitor driver memory when using auto-bloom on large indexes.
+    *
     * @param column
     *   The storage column name to check for auto-bloom filtering
     * @param values
@@ -360,27 +369,35 @@ trait IndexQueryOperations extends IndexJoinOperations {
       values: Array[Any],
       indexDf: DataFrame
   ): Option[Set[String]] = {
-    if (!metadata.auto_bloom_indexes.asScala.contains(column)) return None
-    val autoBloomCol = s"auto_bloom_${column}"
-    if (!indexDf.columns.contains(autoBloomCol)) return None
+    if (!metadata.auto_bloom_indexes.asScala.contains(column)) None
+    else {
+      val autoBloomCol = s"auto_bloom_${column}"
+      if (!indexDf.columns.contains(autoBloomCol)) None
+      else {
+        val rowCount = indexDf.count()
+        if (rowCount > 100000) {
+          logger.warn(s"getAutoBloomCandidates: collecting $rowCount rows to driver for column '$column' — risk of driver OOM on very large indexes")
+        }
 
-    val allRows = indexDf
-      .select("filename", autoBloomCol)
-      .collect()
+        val allRows = indexDf
+          .select("filename", autoBloomCol)
+          .collect()
 
-    val candidates = allRows
-      .filter { row =>
-        val bloomBytes = row.getAs[Array[Byte]](autoBloomCol)
-        if (bloomBytes == null) true
-        else values.exists(v => bloomMightContain(bloomBytes, v))
+        val candidates = allRows
+          .filter { row =>
+            val bloomBytes = row.getAs[Array[Byte]](autoBloomCol)
+            if (bloomBytes == null) true
+            else values.exists(v => bloomMightContain(bloomBytes, v))
+          }
+          .map(_.getString(0))
+          .toSet
+
+        val totalFiles = allRows.length
+        val reduction = if (totalFiles > 0) 100 - (candidates.size * 100 / totalFiles) else 0
+        logger.warn(s"Auto-bloom filter for '$column': $totalFiles total files -> ${candidates.size} candidates ($reduction% reduction)")
+        Some(candidates)
       }
-      .map(_.getString(0))
-      .toSet
-
-    val totalFiles = allRows.length
-    val reduction = if (totalFiles > 0) 100 - (candidates.size * 100 / totalFiles) else 0
-    logger.warn(s"Auto-bloom filter for '$column': $totalFiles total files -> ${candidates.size} candidates ($reduction% reduction)")
-    Some(candidates)
+    }
   }
 
   /** Gets candidate files from the auto-bloom filter using values extracted
@@ -388,6 +405,10 @@ trait IndexQueryOperations extends IndexJoinOperations {
     *
     * Collects distinct non-null values from the given DataFrame column, then
     * delegates to [[getAutoBloomCandidates]] for the actual bloom filter probing.
+    *
+    * @note This method collects distinct values from `valuesDf` to the driver
+    *   and then delegates to [[getAutoBloomCandidates]], which collects all
+    *   bloom filter rows. Both collections can cause driver OOM on large indexes.
     *
     * @param storageColumn
     *   The storage column name in the index (used to look up the auto-bloom)
@@ -407,19 +428,22 @@ trait IndexQueryOperations extends IndexJoinOperations {
       valuesDf: DataFrame,
       indexDf: DataFrame
   ): Option[Set[String]] = {
-    if (!metadata.auto_bloom_indexes.asScala.contains(storageColumn)) return None
-    val autoBloomCol = s"auto_bloom_${storageColumn}"
-    if (!indexDf.columns.contains(autoBloomCol)) return None
+    if (!metadata.auto_bloom_indexes.asScala.contains(storageColumn)) None
+    else {
+      val autoBloomCol = s"auto_bloom_${storageColumn}"
+      if (!indexDf.columns.contains(autoBloomCol)) None
+      else {
+        val values = valuesDf
+          .select(joinColumn)
+          .distinct()
+          .collect()
+          .map(_.get(0))
+          .filter(_ != null)
 
-    val values = valuesDf
-      .select(joinColumn)
-      .distinct()
-      .collect()
-      .map(_.get(0))
-      .filter(_ != null)
-
-    if (values.isEmpty) return None
-    getAutoBloomCandidates(storageColumn, values, indexDf)
+        if (values.isEmpty) None
+        else getAutoBloomCandidates(storageColumn, values, indexDf)
+      }
+    }
   }
 
   /** Locates files using regular (non-bloom, non-temporal, non-range) indexes.
@@ -439,37 +463,39 @@ trait IndexQueryOperations extends IndexJoinOperations {
       indexes: Map[String, Array[Any]],
       df: DataFrame
   ): Set[String] = {
-    if (indexes.isEmpty) return Set.empty
-
-    // Filter null values from each column — isin() throws on an empty array
-    val filteredIndexes = indexes.map { case (column, values) =>
-      column -> values.filter(_ != null)
-    }
-    if (filteredIndexes.exists(_._2.isEmpty)) {
-      val emptyColumns = filteredIndexes.filter(_._2.isEmpty).keys.mkString(", ")
-      logger.debug(s"locateFilesRegular: columns [$emptyColumns] have no non-null values, returning empty result")
-      return Set.empty[String]
-    }
-
-    val perColumnFiles = filteredIndexes.map { case (column, values) =>
-      val bloomCandidates = getAutoBloomCandidates(column, values, df)
-      loadColumnIndex(df, column, bloomCandidates)
-        .where(col(column).isin(values: _*))
-        .select("filename")
-        .distinct
-    }.toSeq
-
-    val intersectedDF = if (perColumnFiles.size == 1) {
-      perColumnFiles.head
+    if (indexes.isEmpty) {
+      Set.empty
     } else {
-      perColumnFiles.reduce((a, b) => a.join(b, Seq("filename"), "inner"))
-    }
+      // Filter null values from each column — isin() throws on an empty array
+      val filteredIndexes = indexes.map { case (column, values) =>
+        column -> values.filter(_ != null)
+      }
+      if (filteredIndexes.exists(_._2.isEmpty)) {
+        val emptyColumns = filteredIndexes.filter(_._2.isEmpty).keys.mkString(", ")
+        logger.debug(s"locateFilesRegular: columns [$emptyColumns] have no non-null values, returning empty result")
+        Set.empty[String]
+      } else {
+        val perColumnFiles = filteredIndexes.map { case (column, values) =>
+          val bloomCandidates = getAutoBloomCandidates(column, values, df)
+          loadColumnIndex(df, column, bloomCandidates)
+            .where(col(column).isin(values: _*))
+            .select("filename")
+            .distinct
+        }.toSeq
 
-    val result = collectFilenamesViaStaging(intersectedDF)
-    if (debugEnabled && indexes.size > 1) {
-      logger.warn(s"[debug] Multi-column intersection: ${indexes.size} columns, result: ${result.size} files")
+        val intersectedDF = if (perColumnFiles.size == 1) {
+          perColumnFiles.head
+        } else {
+          perColumnFiles.reduce((a, b) => a.join(b, Seq("filename"), "inner"))
+        }
+
+        val result = collectFilenamesViaStaging(intersectedDF)
+        if (debugEnabled && indexes.size > 1) {
+          logger.warn(s"[debug] Multi-column intersection: ${indexes.size} columns, result: ${result.size} files")
+        }
+        result
+      }
     }
-    result
   }
 
   /** Locates files using temporal indexes, pruning to only files containing
@@ -521,32 +547,36 @@ trait IndexQueryOperations extends IndexJoinOperations {
       indexDf: DataFrame
   ): Set[String] = {
     val rangeCol = s"range_${column}"
-    if (!indexDf.columns.contains(rangeCol)) return Set.empty
-    if (values.isEmpty) return Set.empty
+    if (!indexDf.columns.contains(rangeCol)) {
+      logger.warn(s"Range column $rangeCol not found in index, returning empty result")
+      Set.empty
+    } else if (values.isEmpty) {
+      Set.empty
+    } else {
+      logger.warn(s"Range query on column '$column' with ${values.length} values")
+      if (values.length > 1000) {
+        logger.warn(s"Range query has ${values.length} values; large OR expression may be slow")
+      }
 
-    logger.warn(s"Range query on column '$column' with ${values.length} values")
-    if (values.length > 1000) {
-      logger.warn(s"Range query has ${values.length} values; large OR expression may be slow")
+      // Use Spark lit() for type-safe comparisons instead of Comparable casts.
+      // This handles type coercion (e.g. Long vs Int) and NaN correctly.
+      val valueConditions = values.map { v =>
+        col("file_min") <= lit(v) && col("file_max") >= lit(v)
+      }
+
+      val matchingFiles = indexDf
+        .select(
+          col("filename"),
+          col(s"$rangeCol.min").alias("file_min"),
+          col(s"$rangeCol.max").alias("file_max")
+        )
+        .where(col("file_min").isNotNull && col("file_max").isNotNull)
+        .where(valueConditions.reduce(_ || _))
+        .select("filename")
+        .distinct()
+
+      collectFilenamesViaStaging(matchingFiles)
     }
-
-    // Use Spark lit() for type-safe comparisons instead of Comparable casts.
-    // This handles type coercion (e.g. Long vs Int) and NaN correctly.
-    val valueConditions = values.map { v =>
-      col("file_min") <= lit(v) && col("file_max") >= lit(v)
-    }
-
-    val matchingFiles = indexDf
-      .select(
-        col("filename"),
-        col(s"$rangeCol.min").alias("file_min"),
-        col(s"$rangeCol.max").alias("file_max")
-      )
-      .where(col("file_min").isNotNull && col("file_max").isNotNull)
-      .where(valueConditions.reduce(_ || _))
-      .select("filename")
-      .distinct()
-
-    collectFilenamesViaStaging(matchingFiles)
   }
 
   /** Locates files based on a DataFrame containing join column values. Handles
@@ -589,6 +619,7 @@ trait IndexQueryOperations extends IndexJoinOperations {
         }
 
         // Get files from bloom filters
+        val bloomStart = System.currentTimeMillis()
         val bloomFiles = if (bloomJoinColumns.nonEmpty) {
           bloomJoinColumns.map { joinColumn =>
             locateFilesWithBloomFromDataFrame(joinColumn, valuesDf, indexDf)
@@ -596,8 +627,10 @@ trait IndexQueryOperations extends IndexJoinOperations {
         } else {
           Set.empty[String]
         }
+        val bloomMs = System.currentTimeMillis() - bloomStart
 
         // Get files from temporal indexes (pruned to latest timestamp per value)
+        val temporalStart = System.currentTimeMillis()
         val temporalFiles = if (temporalJoinColumns.nonEmpty) {
           val repartitionedIndex = maybeRepartition(indexDf)
           temporalJoinColumns.map { joinColumn =>
@@ -606,8 +639,10 @@ trait IndexQueryOperations extends IndexJoinOperations {
         } else {
           Set.empty[String]
         }
+        val temporalMs = System.currentTimeMillis() - temporalStart
 
         // Get files from range indexes
+        val rangeStart = System.currentTimeMillis()
         val rangeFiles = if (rangeJoinColumns.nonEmpty) {
           rangeJoinColumns.map { joinColumn =>
             locateFilesWithRangeFromDataFrame(joinColumn, valuesDf, indexDf)
@@ -615,8 +650,10 @@ trait IndexQueryOperations extends IndexJoinOperations {
         } else {
           Set.empty[String]
         }
+        val rangeMs = System.currentTimeMillis() - rangeStart
 
         // Get files from regular indexes
+        val regularStart = System.currentTimeMillis()
         val regularFiles = if (regularJoinColumns.nonEmpty) {
           // Repartition the index DataFrame before explode to reduce
           // per-executor memory pressure on large indexes
@@ -652,6 +689,7 @@ trait IndexQueryOperations extends IndexJoinOperations {
         } else {
           Set.empty[String]
         }
+        val regularMs = System.currentTimeMillis() - regularStart
 
         // Combine results - intersect across types that returned results (AND semantics)
         // Track which categories were queried (had input), not just which returned results
@@ -667,9 +705,17 @@ trait IndexQueryOperations extends IndexJoinOperations {
         } else {
           queriedResults.reduce(_ intersect _)
         }
-        logger.warn(s"locateFilesFromDataFrame: ${allFiles.size} files matched in ${System.currentTimeMillis() - locateStart}ms")
+        val totalMs = System.currentTimeMillis() - locateStart
+        // Add per-type timing (#38) to match locateFiles
+        logger.warn(
+          s"locateFilesFromDataFrame: ${allFiles.size} files matched in ${totalMs}ms " +
+            s"(bloom=${bloomMs}ms, temporal=${temporalMs}ms, range=${rangeMs}ms, regular=${regularMs}ms)"
+        )
         if (allFiles.isEmpty) Set.empty else allFiles
-      case None => Set()
+      case None =>
+        // Log when index table is None (#33)
+        logger.warn(s"locateFilesFromDataFrame: no index table found for index '$name', returning empty result")
+        Set.empty
     }
   }
 
@@ -678,6 +724,7 @@ trait IndexQueryOperations extends IndexJoinOperations {
     *
     * Joins the exploded temporal index with distinct query values, then applies
     * a window function to keep only the file with the highest max_ts per value.
+    * This ensures joins against temporal indexes always use the most recent data.
     *
     * @param column The temporal index value column name
     * @param valuesDf DataFrame containing a column named `column` with values to search for
@@ -704,7 +751,10 @@ trait IndexQueryOperations extends IndexJoinOperations {
       .select("filename")
       .distinct()
 
-    collectFilenamesViaStaging(pruned)
+    val result = collectFilenamesViaStaging(pruned)
+    // Add result logging (#36)
+    logger.warn(s"Temporal DF query on column '$column': ${result.size} files matched")
+    result
   }
 
   /** Locates files using range indexes from a DataFrame of values.
@@ -712,6 +762,11 @@ trait IndexQueryOperations extends IndexJoinOperations {
     * Collects up to 10,000 distinct query values. For sets exceeding 1,000 values,
     * falls back to a bounding-box optimization (query min/max vs file min/max).
     * For smaller sets, checks per-value containment for precise pruning.
+    *
+    * @note Distinct values are truncated to 10,000 to avoid driver OOM.
+    *   For value sets exceeding 1,000, a bounding-box optimization is used
+    *   which may include false-positive files whose ranges overlap but contain
+    *   no actual matching values.
     *
     * @param column The range index column name
     * @param valuesDf DataFrame containing a column named `column` with values to search for
@@ -724,62 +779,71 @@ trait IndexQueryOperations extends IndexJoinOperations {
       indexDf: DataFrame
   ): Set[String] = {
     val rangeCol = s"range_${column}"
-    if (!indexDf.columns.contains(rangeCol)) return Set.empty
-
-    // Collect distinct query values (bounded to avoid driver OOM)
-    val rawCount = valuesDf.select(col(column)).distinct().count()
-    if (rawCount > 10000) {
-      logger.warn(s"Range query on '$column': truncating $rawCount distinct values to 10000 for per-value pruning")
-    }
-    val distinctValues = valuesDf
-      .select(col(column))
-      .distinct()
-      .limit(10000)
-      .collect()
-      .map(_.get(0))
-      .filter(_ != null)
-
-    if (distinctValues.isEmpty) return Set.empty
-
-    logger.warn(s"Range query on column '$column' with ${distinctValues.length} distinct values")
-
-    if (distinctValues.length > 1000) {
-      logger.warn(s"Range query: large value set (${distinctValues.length}), using bounding box optimization")
-      val minMaxRow = valuesDf.agg(
-        min(col(column)).alias("q_min"),
-        max(col(column)).alias("q_max")
-      ).head()
-
-      val matchingFiles = indexDf
-        .select(
-          col("filename"),
-          col(s"$rangeCol.min").alias("file_min"),
-          col(s"$rangeCol.max").alias("file_max")
-        )
-        .where(col("file_min").isNotNull && col("file_max").isNotNull)
-        .where(col("file_max") >= lit(minMaxRow.get(0)) && col("file_min") <= lit(minMaxRow.get(1)))
-        .select("filename")
-        .distinct()
-
-      collectFilenamesViaStaging(matchingFiles)
+    if (!indexDf.columns.contains(rangeCol)) {
+      Set.empty
     } else {
-      // For reasonable value sets, check per-value containment (precise pruning)
-      val valueConditions = distinctValues.map { v =>
-        col("file_min") <= lit(v) && col("file_max") >= lit(v)
+      // Collect distinct query values (bounded to avoid driver OOM)
+      val rawCount = valuesDf.select(col(column)).distinct().count()
+      if (rawCount > 10000) {
+        logger.warn(s"Range query on '$column': truncating $rawCount distinct values to 10000 for per-value pruning")
       }
-
-      val matchingFiles = indexDf
-        .select(
-          col("filename"),
-          col(s"$rangeCol.min").alias("file_min"),
-          col(s"$rangeCol.max").alias("file_max")
-        )
-        .where(col("file_min").isNotNull && col("file_max").isNotNull)
-        .where(valueConditions.reduce(_ || _))
-        .select("filename")
+      val distinctValues = valuesDf
+        .select(col(column))
         .distinct()
+        .limit(10000)
+        .collect()
+        .map(_.get(0))
+        .filter(_ != null)
 
-      collectFilenamesViaStaging(matchingFiles)
+      if (distinctValues.isEmpty) {
+        Set.empty
+      } else {
+        logger.warn(s"Range query on column '$column' with ${distinctValues.length} distinct values")
+
+        if (distinctValues.length > 1000) {
+          logger.warn(s"Range query: large value set (${distinctValues.length}), using bounding box optimization")
+          val minMaxRow = valuesDf.agg(
+            min(col(column)).alias("q_min"),
+            max(col(column)).alias("q_max")
+          ).head()
+
+          if (minMaxRow.isNullAt(0) || minMaxRow.isNullAt(1)) {
+            logger.warn(s"Range query for '$column': min/max values are null after aggregation, returning empty result")
+            Set.empty[String]
+          } else {
+            val matchingFiles = indexDf
+              .select(
+                col("filename"),
+                col(s"$rangeCol.min").alias("file_min"),
+                col(s"$rangeCol.max").alias("file_max")
+              )
+              .where(col("file_min").isNotNull && col("file_max").isNotNull)
+              .where(col("file_max") >= lit(minMaxRow.get(0)) && col("file_min") <= lit(minMaxRow.get(1)))
+              .select("filename")
+              .distinct()
+
+            collectFilenamesViaStaging(matchingFiles)
+          }
+        } else {
+          // For reasonable value sets, check per-value containment (precise pruning)
+          val valueConditions = distinctValues.map { v =>
+            col("file_min") <= lit(v) && col("file_max") >= lit(v)
+          }
+
+          val matchingFiles = indexDf
+            .select(
+              col("filename"),
+              col(s"$rangeCol.min").alias("file_min"),
+              col(s"$rangeCol.max").alias("file_max")
+            )
+            .where(col("file_min").isNotNull && col("file_max").isNotNull)
+            .where(valueConditions.reduce(_ || _))
+            .select("filename")
+            .distinct()
+
+          collectFilenamesViaStaging(matchingFiles)
+        }
+      }
     }
   }
 
@@ -793,6 +857,7 @@ trait IndexQueryOperations extends IndexJoinOperations {
     *         or an empty DataFrame if no index exists
     */
   def stats(): DataFrame = {
+    logger.warn(s"Computing stats for index '$name'")
     index match {
       case Some(df) =>
         // File count

--- a/src/main/scala/dev/cjfravel/ariadne/IndexQueryOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexQueryOperations.scala
@@ -160,6 +160,7 @@ trait IndexQueryOperations extends IndexJoinOperations {
     *   A set of file names matching the criteria.
     */
   def locateFiles(indexes: Map[String, Array[Any]]): Set[String] = {
+    logger.warn(s"locateFiles: querying columns ${indexes.keys.mkString(", ")} with ${indexes.values.map(_.length).sum} total values")
     index match {
       case Some(df) =>
         // Separate bloom, temporal, range, and regular index queries
@@ -230,6 +231,7 @@ trait IndexQueryOperations extends IndexJoinOperations {
               s"range=${rangeFiles.size}, regular=${regularFiles.size} -> final=${allFiles.size}"
           )
         }
+        logger.warn(s"locateFiles: ${allFiles.size} files matched")
         if (allFiles.isEmpty) Set.empty else allFiles
       case None => Set()
     }
@@ -483,6 +485,7 @@ trait IndexQueryOperations extends IndexJoinOperations {
       joinColumns: Seq[String]
   ): Set[String] = {
     val locateStart = System.currentTimeMillis()
+    logger.warn(s"locateFilesFromDataFrame: querying columns ${joinColumns.mkString(", ")}")
     index match {
       case Some(indexDf) =>
         if (debugEnabled) {
@@ -582,6 +585,7 @@ trait IndexQueryOperations extends IndexJoinOperations {
         } else {
           queriedResults.reduce(_ intersect _)
         }
+        logger.warn(s"locateFilesFromDataFrame: ${allFiles.size} files matched in ${System.currentTimeMillis() - locateStart}ms")
         if (allFiles.isEmpty) Set.empty else allFiles
       case None => Set()
     }

--- a/src/main/scala/dev/cjfravel/ariadne/SchemaHelper.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/SchemaHelper.scala
@@ -51,4 +51,17 @@ object SchemaHelper {
 
     findField(schema, parts.toList)
   }
+
+  /** Returns the data type of a top-level field in the schema.
+    *
+    * @param schema    The root `StructType` schema to search. Must not be null.
+    * @param fieldName The top-level field name to look up. Must not be null or blank.
+    * @return `Some(dataType)` if the field exists, `None` otherwise
+    * @throws IllegalArgumentException if schema is null or fieldName is null/blank
+    */
+  def fieldType(schema: StructType, fieldName: String): Option[DataType] = {
+    require(schema != null, "schema must not be null")
+    require(fieldName != null && fieldName.trim.nonEmpty, "fieldName must not be null or blank")
+    schema.fields.find(_.name == fieldName).map(_.dataType)
+  }
 }

--- a/src/main/scala/dev/cjfravel/ariadne/SchemaHelper.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/SchemaHelper.scala
@@ -22,11 +22,14 @@ object SchemaHelper {
     * struct). Only direct `StructType` nesting is traversed — `ArrayType`
     * elements are ''not'' descended into.
     *
-    * @param schema    The root `StructType` schema to search
-    * @param fieldName A field name or dot-separated path (e.g., `"user.profile.id"`)
+    * @param schema    The root `StructType` schema to search. Must not be null.
+    * @param fieldName A field name or dot-separated path (e.g., `"user.profile.id"`). Must not be null or blank.
     * @return `true` if the field exists at the specified path, `false` otherwise
+    * @throws IllegalArgumentException if schema is null or fieldName is null/blank
     */
   def fieldExists(schema: StructType, fieldName: String): Boolean = {
+    require(schema != null, "schema must not be null")
+    require(fieldName != null && fieldName.trim.nonEmpty, "fieldName must not be null or blank")
     val parts = fieldName.split("\\.")
 
     def findField(currentSchema: StructType, path: List[String]): Boolean = {

--- a/src/main/scala/dev/cjfravel/ariadne/SchemaHelper.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/SchemaHelper.scala
@@ -2,21 +2,29 @@ package dev.cjfravel.ariadne
 
 import org.apache.spark.sql.types._
 
-/** Utility object for schema-related operations.
+/** Utility object for Spark schema introspection.
   *
-  * Provides methods for validating field existence within Spark StructType schemas,
-  * including support for nested field paths using dot notation.
+  * Provides methods for validating field existence within
+  * [[org.apache.spark.sql.types.StructType]] schemas, including support for
+  * nested field paths using dot notation. Used throughout Ariadne to validate
+  * that indexed columns exist in the user-supplied schema before persisting
+  * metadata.
+  *
+  * '''Thread safety:''' All methods are pure functions with no mutable state;
+  * safe to call concurrently from any thread.
   */
 object SchemaHelper {
 
   /** Checks whether a field exists in the given schema, supporting nested paths.
     *
-    * Supports dot-separated field paths for nested struct navigation (e.g., "address.city").
-    * Note: Does not traverse into ArrayType elements — only direct StructType nesting is supported.
+    * Supports dot-separated field paths for nested struct navigation
+    * (e.g., `"address.city"` looks for a `city` field inside an `address`
+    * struct). Only direct `StructType` nesting is traversed — `ArrayType`
+    * elements are ''not'' descended into.
     *
-    * @param schema The StructType schema to search
-    * @param fieldName The field name or dot-separated path to check
-    * @return true if the field exists at the specified path
+    * @param schema    The root `StructType` schema to search
+    * @param fieldName A field name or dot-separated path (e.g., `"user.profile.id"`)
+    * @return `true` if the field exists at the specified path, `false` otherwise
     */
   def fieldExists(schema: StructType, fieldName: String): Boolean = {
     val parts = fieldName.split("\\.")

--- a/src/main/scala/dev/cjfravel/ariadne/SchemaHelper.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/SchemaHelper.scala
@@ -2,8 +2,22 @@ package dev.cjfravel.ariadne
 
 import org.apache.spark.sql.types._
 
+/** Utility object for schema-related operations.
+  *
+  * Provides methods for validating field existence within Spark StructType schemas,
+  * including support for nested field paths using dot notation.
+  */
 object SchemaHelper {
 
+  /** Checks whether a field exists in the given schema, supporting nested paths.
+    *
+    * Supports dot-separated field paths for nested struct navigation (e.g., "address.city").
+    * Note: Does not traverse into ArrayType elements — only direct StructType nesting is supported.
+    *
+    * @param schema The StructType schema to search
+    * @param fieldName The field name or dot-separated path to check
+    * @return true if the field exists at the specified path
+    */
   def fieldExists(schema: StructType, fieldName: String): Boolean = {
     val parts = fieldName.split("\\.")
 

--- a/src/main/scala/dev/cjfravel/ariadne/SchemaHelper.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/SchemaHelper.scala
@@ -3,7 +3,6 @@ package dev.cjfravel.ariadne
 import org.apache.spark.sql.types._
 
 object SchemaHelper {
-  import org.apache.spark.sql.types._
 
   def fieldExists(schema: StructType, fieldName: String): Boolean = {
     val parts = fieldName.split("\\.")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/AriadneException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/AriadneException.scala
@@ -6,6 +6,16 @@ package dev.cjfravel.ariadne.exceptions
   * All domain-specific exceptions in the Ariadne library extend this class, enabling
   * callers to catch any Ariadne error with a single handler if desired.
   *
+  * {{{
+  * try {
+  *   index.update("s3a://bucket/data/")
+  * } catch {
+  *   case e: AriadneException =>
+  *     // handles any Ariadne-specific error
+  *     logger.error(s"Ariadne operation failed: \${e.getMessage}", e)
+  * }
+  * }}}
+  *
   * @param message descriptive error message
   * @param cause   optional underlying cause of the error
   */

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/AriadneException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/AriadneException.scala
@@ -1,0 +1,13 @@
+package dev.cjfravel.ariadne.exceptions
+
+/** Base exception class for all Ariadne library errors.
+  *
+  * Extends `RuntimeException` following Scala conventions for unchecked exceptions.
+  * All domain-specific exceptions in the Ariadne library extend this class, enabling
+  * callers to catch any Ariadne error with a single handler if desired.
+  *
+  * @param message descriptive error message
+  * @param cause   optional underlying cause of the error
+  */
+class AriadneException(message: String, cause: Throwable = null)
+    extends RuntimeException(message, cause)

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/ColumnNotFoundException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/ColumnNotFoundException.scala
@@ -4,4 +4,4 @@ package dev.cjfravel.ariadne.exceptions
   *
   * @param column The name of the column that was not found
   */
-class ColumnNotFoundException(column: String) extends Exception(s"Column $column was not found in the dataframe")
+class ColumnNotFoundException(column: String) extends AriadneException(s"Column $column was not found in the dataframe")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/ColumnNotFoundException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/ColumnNotFoundException.scala
@@ -1,3 +1,7 @@
 package dev.cjfravel.ariadne.exceptions
 
+/** Thrown when a specified column is not found in the DataFrame schema or index configuration.
+  *
+  * @param column The name of the column that was not found
+  */
 class ColumnNotFoundException(column: String) extends Exception(s"Column $column was not found in the dataframe")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/ColumnNotFoundException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/ColumnNotFoundException.scala
@@ -1,6 +1,17 @@
 package dev.cjfravel.ariadne.exceptions
 
-/** Thrown when a specified column is not found in the DataFrame schema or index configuration.
+/** Thrown when a specified column is not found in the DataFrame schema or index
+  * configuration.
+  *
+  * This exception is raised by index build and query operations when a column
+  * referenced in the index configuration does not exist in the data schema.
+  * Typical callers include `Index.addIndex`, `Index.addBloomIndex`,
+  * `Index.addTemporalIndex`, and `Index.addRangeIndex`.
+  *
+  * {{{
+  * // Throws ColumnNotFoundException if "nonexistent_col" is not in the schema
+  * index.addIndex("nonexistent_col")
+  * }}}
   *
   * @param column The name of the column that was not found
   */

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/FileListNotFoundException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/FileListNotFoundException.scala
@@ -1,4 +1,8 @@
 package dev.cjfravel.ariadne.exceptions
 
+/** Thrown when a FileList with the specified name cannot be found.
+  *
+  * @param name The name of the FileList that was not found
+  */
 class FileListNotFoundException(name: String)
     extends Exception(s"FileList $name was not found")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/FileListNotFoundException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/FileListNotFoundException.scala
@@ -1,6 +1,16 @@
 package dev.cjfravel.ariadne.exceptions
 
-/** Thrown when a FileList with the specified name cannot be found.
+/** Thrown when a FileList with the specified name cannot be found on storage.
+  *
+  * Raised by `FileList.remove` when the Delta table backing the file list does
+  * not exist. Also encountered indirectly via `IndexPathUtils.remove` and
+  * `IndexCatalog.remove` when cleaning up an index whose file list has already
+  * been deleted.
+  *
+  * {{{
+  * // Throws FileListNotFoundException if the file list was already removed
+  * FileList.remove("[ariadne_index] myIndex")
+  * }}}
   *
   * @param name The name of the FileList that was not found
   */

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/FileListNotFoundException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/FileListNotFoundException.scala
@@ -5,4 +5,4 @@ package dev.cjfravel.ariadne.exceptions
   * @param name The name of the FileList that was not found
   */
 class FileListNotFoundException(name: String)
-    extends Exception(s"FileList $name was not found")
+    extends AriadneException(s"FileList $name was not found")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/FormatMismatchException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/FormatMismatchException.scala
@@ -2,6 +2,17 @@ package dev.cjfravel.ariadne.exceptions
 
 /** Thrown when the data format provided for an index operation does not match
   * the format stored in the index metadata.
+  *
+  * Raised by `Index.apply` when reconnecting to an existing index with a
+  * different format than what was originally configured (e.g., creating an
+  * index as "parquet" then attempting to use it as "json").
+  *
+  * {{{
+  * // First creation stores format = "parquet"
+  * Index("myIndex", schema, "parquet")
+  * // Throws FormatMismatchException — format conflict
+  * Index("myIndex", schema, "json")
+  * }}}
   */
 class FormatMismatchException
     extends AriadneException("Format provided does not match stored format")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/FormatMismatchException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/FormatMismatchException.scala
@@ -13,6 +13,12 @@ package dev.cjfravel.ariadne.exceptions
   * // Throws FormatMismatchException — format conflict
   * Index("myIndex", schema, "json")
   * }}}
+  *
+  * @param indexName the name of the index with the format conflict
+  * @param expected  the format stored in existing metadata
+  * @param actual    the format that was provided and does not match
   */
-class FormatMismatchException
-    extends AriadneException("Format provided does not match stored format")
+class FormatMismatchException(indexName: String, expected: String, actual: String)
+    extends AriadneException(
+      s"Format mismatch for index '$indexName': stored format is '$expected' but '$actual' was provided"
+    )

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/FormatMismatchException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/FormatMismatchException.scala
@@ -4,4 +4,4 @@ package dev.cjfravel.ariadne.exceptions
   * the format stored in the index metadata.
   */
 class FormatMismatchException
-    extends Exception("Format provided does not match stored format")
+    extends AriadneException("Format provided does not match stored format")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/FormatMismatchException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/FormatMismatchException.scala
@@ -1,4 +1,7 @@
 package dev.cjfravel.ariadne.exceptions
 
+/** Thrown when the data format provided for an index operation does not match
+  * the format stored in the index metadata.
+  */
 class FormatMismatchException
     extends Exception("Format provided does not match stored format")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexLockException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexLockException.scala
@@ -3,7 +3,21 @@ package dev.cjfravel.ariadne.exceptions
 /** Thrown when a distributed lock for an index operation cannot be acquired.
   *
   * This may occur when another process holds the lock and the maximum wait
-  * time is exceeded, or when lock acquisition is interrupted.
+  * time (`lockMaxWait`) is exceeded, when lock acquisition is interrupted,
+  * or when a corrupt lock file cannot be recovered after multiple attempts.
+  *
+  * Raised by [[dev.cjfravel.ariadne.IndexLock.acquire]] and propagated through
+  * `Index.update`, `Index.compact`, `Index.vacuum`, and `Index.deleteFiles`.
+  *
+  * {{{
+  * try {
+  *   index.update("s3a://bucket/data/")
+  * } catch {
+  *   case e: IndexLockException =>
+  *     // Another process holds the lock or lock file is corrupt
+  *     logger.error(s"Lock contention: \${e.getMessage}")
+  * }
+  * }}}
   *
   * @param message A descriptive error message including index name and lock holder details
   */

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexLockException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexLockException.scala
@@ -1,5 +1,12 @@
 package dev.cjfravel.ariadne.exceptions
 
+/** Thrown when a distributed lock for an index operation cannot be acquired.
+  *
+  * This may occur when another process holds the lock and the maximum wait
+  * time is exceeded, or when lock acquisition is interrupted.
+  *
+  * @param message A descriptive error message including index name and lock holder details
+  */
 class IndexLockException(message: String) extends Exception(message) {
   def this(indexName: String, holderCorrelationId: String, holderOwner: String) =
     this(

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexLockException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexLockException.scala
@@ -7,7 +7,7 @@ package dev.cjfravel.ariadne.exceptions
   *
   * @param message A descriptive error message including index name and lock holder details
   */
-class IndexLockException(message: String) extends Exception(message) {
+class IndexLockException(message: String) extends AriadneException(message) {
   def this(indexName: String, holderCorrelationId: String, holderOwner: String) =
     this(
       s"Could not acquire lock for index '$indexName'. Currently held by correlationId='$holderCorrelationId', owner='$holderOwner'"

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexLockException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexLockException.scala
@@ -28,7 +28,18 @@ class IndexLockException(message: String) extends AriadneException(message) {
     )
 }
 
+/** Factory for [[IndexLockException]] instances.
+  *
+  * Provides a convenient `apply` method to create timeout-based lock exceptions
+  * without specifying holder details.
+  */
 object IndexLockException {
+
+  /** Creates an [[IndexLockException]] for a lock acquisition timeout.
+    *
+    * @param indexName the name of the index whose lock could not be acquired
+    * @return a new `IndexLockException` with a timeout message
+    */
   def apply(indexName: String): IndexLockException =
     new IndexLockException(s"Could not acquire lock for index '$indexName' within the configured timeout")
 }

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexNotFoundException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexNotFoundException.scala
@@ -1,4 +1,8 @@
 package dev.cjfravel.ariadne.exceptions
 
+/** Thrown when an index with the specified name does not exist.
+  *
+  * @param name The name of the index that was not found
+  */
 class IndexNotFoundException(name: String)
     extends Exception(s"Index $name was not found")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexNotFoundException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexNotFoundException.scala
@@ -1,6 +1,15 @@
 package dev.cjfravel.ariadne.exceptions
 
-/** Thrown when an index with the specified name does not exist.
+/** Thrown when an index with the specified name does not exist in storage.
+  *
+  * Raised by `IndexCatalog.get`, `IndexCatalog.remove`, `IndexCatalog.describe`,
+  * and `IndexPathUtils.remove` when the requested index name cannot be found
+  * in the configured `spark.ariadne.storagePath`.
+  *
+  * {{{
+  * // Throws IndexNotFoundException if "missing" does not exist
+  * val index = IndexCatalog.get("missing")
+  * }}}
   *
   * @param name The name of the index that was not found
   */

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexNotFoundException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexNotFoundException.scala
@@ -5,4 +5,4 @@ package dev.cjfravel.ariadne.exceptions
   * @param name The name of the index that was not found
   */
 class IndexNotFoundException(name: String)
-    extends Exception(s"Index $name was not found")
+    extends AriadneException(s"Index $name was not found")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexNotFoundInNewSchemaException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexNotFoundInNewSchemaException.scala
@@ -3,6 +3,17 @@ package dev.cjfravel.ariadne.exceptions
 /** Thrown when a previously indexed column is not found in the new schema during
   * a schema evolution check.
   *
+  * Raised by `Index.apply` when `allowSchemaMismatch = false` (the default) and
+  * the provided schema is missing a column that the existing index tracks. This
+  * prevents silent data loss where an indexed column would become inaccessible.
+  *
+  * {{{
+  * // Original index has column "user_id"
+  * val newSchema = StructType(Seq(StructField("name", StringType)))
+  * // Throws IndexNotFoundInNewSchemaException — "user_id" is missing
+  * Index("myIndex", newSchema, "parquet")
+  * }}}
+  *
   * @param col The name of the indexed column missing from the new schema
   */
 class IndexNotFoundInNewSchemaException(col: String)

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexNotFoundInNewSchemaException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexNotFoundInNewSchemaException.scala
@@ -3,15 +3,17 @@ package dev.cjfravel.ariadne.exceptions
 /** Thrown when a previously indexed column is not found in the new schema during
   * a schema evolution check.
   *
-  * Raised by `Index.apply` when `allowSchemaMismatch = false` (the default) and
-  * the provided schema is missing a column that the existing index tracks. This
-  * prevents silent data loss where an indexed column would become inaccessible.
+  * Raised by `Index.apply` when `allowSchemaMismatch = true` and the provided
+  * schema is missing a column that the existing index tracks. When schema
+  * mismatch is allowed, Ariadne still validates that all indexed columns exist
+  * in the new schema to prevent silent data loss where an indexed column would
+  * become inaccessible.
   *
   * {{{
   * // Original index has column "user_id"
   * val newSchema = StructType(Seq(StructField("name", StringType)))
   * // Throws IndexNotFoundInNewSchemaException — "user_id" is missing
-  * Index("myIndex", newSchema, "parquet")
+  * Index("myIndex", newSchema, "parquet", allowSchemaMismatch = true)
   * }}}
   *
   * @param col The name of the indexed column missing from the new schema

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexNotFoundInNewSchemaException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexNotFoundInNewSchemaException.scala
@@ -6,4 +6,4 @@ package dev.cjfravel.ariadne.exceptions
   * @param col The name of the indexed column missing from the new schema
   */
 class IndexNotFoundInNewSchemaException(col: String)
-    extends Exception(s"Index $col was not found in new schema")
+    extends AriadneException(s"Index $col was not found in new schema")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexNotFoundInNewSchemaException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexNotFoundInNewSchemaException.scala
@@ -1,4 +1,9 @@
 package dev.cjfravel.ariadne.exceptions
 
+/** Thrown when a previously indexed column is not found in the new schema during
+  * a schema evolution check.
+  *
+  * @param col The name of the indexed column missing from the new schema
+  */
 class IndexNotFoundInNewSchemaException(col: String)
     extends Exception(s"Index $col was not found in new schema")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/MetadataMissingOrCorruptException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/MetadataMissingOrCorruptException.scala
@@ -1,5 +1,9 @@
 package dev.cjfravel.ariadne.exceptions
 
+/** Thrown when the index metadata file is missing, empty, or cannot be parsed.
+  *
+  * @param cause The underlying exception that caused the parse failure, or null if the file is missing
+  */
 class MetadataMissingOrCorruptException(cause: Throwable = null)
     extends Exception(
       "Index metadata is missing or corrupt. Delete and re-create the index.",

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/MetadataMissingOrCorruptException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/MetadataMissingOrCorruptException.scala
@@ -1,6 +1,23 @@
 package dev.cjfravel.ariadne.exceptions
 
-/** Thrown when the index metadata file is missing, empty, or cannot be parsed.
+/** Thrown when the index metadata file (`metadata.json`) is missing, empty,
+  * or cannot be parsed into a valid [[dev.cjfravel.ariadne.IndexMetadata]].
+  *
+  * Raised by `IndexMetadataOperations.refreshMetadata` when the file does not
+  * exist or contains invalid JSON, and by `IndexMetadata.apply` when the JSON
+  * string is null, empty, or deserializes to null. Recovery typically requires
+  * deleting the corrupt index and re-creating it.
+  *
+  * {{{
+  * try {
+  *   val index = Index("corruptIndex")
+  *   index.metadata // triggers read
+  * } catch {
+  *   case e: MetadataMissingOrCorruptException =>
+  *     // Delete and re-create the index
+  *     IndexCatalog.remove("corruptIndex")
+  * }
+  * }}}
   *
   * @param cause The underlying exception that caused the parse failure, or null if the file is missing
   */

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/MetadataMissingOrCorruptException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/MetadataMissingOrCorruptException.scala
@@ -1,4 +1,7 @@
 package dev.cjfravel.ariadne.exceptions
 
-class MetadataMissingOrCorruptException
-    extends Exception("IndexMetadata is missing or corrupt")
+class MetadataMissingOrCorruptException(cause: Throwable = null)
+    extends Exception(
+      "Index metadata is missing or corrupt. Delete and re-create the index.",
+      cause
+    )

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/MetadataMissingOrCorruptException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/MetadataMissingOrCorruptException.scala
@@ -5,7 +5,7 @@ package dev.cjfravel.ariadne.exceptions
   * @param cause The underlying exception that caused the parse failure, or null if the file is missing
   */
 class MetadataMissingOrCorruptException(cause: Throwable = null)
-    extends Exception(
+    extends AriadneException(
       "Index metadata is missing or corrupt. Delete and re-create the index.",
       cause
     )

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/MissingFormatException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/MissingFormatException.scala
@@ -1,6 +1,15 @@
 package dev.cjfravel.ariadne.exceptions
 
 /** Thrown when an index does not have a file format specified in its metadata.
+  *
+  * Raised during index operations that require knowing the data format
+  * (e.g., reading files for a join) when `IndexMetadata.format` is null or
+  * empty. This typically indicates a corrupt or manually edited metadata file.
+  *
+  * {{{
+  * // A metadata file with no "format" field will trigger this on join
+  * index.join(df, Seq("id")) // throws MissingFormatException
+  * }}}
   */
 class MissingFormatException
     extends AriadneException("Index doesn't have a specified fileformat")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/MissingFormatException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/MissingFormatException.scala
@@ -3,4 +3,4 @@ package dev.cjfravel.ariadne.exceptions
 /** Thrown when an index does not have a file format specified in its metadata.
   */
 class MissingFormatException
-    extends Exception("Index doesn't have a specified fileformat")
+    extends AriadneException("Index doesn't have a specified fileformat")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/MissingFormatException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/MissingFormatException.scala
@@ -1,4 +1,6 @@
 package dev.cjfravel.ariadne.exceptions
 
+/** Thrown when an index does not have a file format specified in its metadata.
+  */
 class MissingFormatException
     extends Exception("Index doesn't have a specified fileformat")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/MissingSchemaException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/MissingSchemaException.scala
@@ -1,5 +1,14 @@
 package dev.cjfravel.ariadne.exceptions
 
 /** Thrown when the schema field is missing from the index metadata.
+  *
+  * Raised during index operations that require the DataFrame schema
+  * (e.g., reading indexed files) when `IndexMetadata.schema` is null or
+  * empty. This typically indicates a corrupt or manually edited metadata file.
+  *
+  * {{{
+  * // A metadata file with no "schema" field will trigger this on join
+  * index.join(df, Seq("id")) // throws MissingSchemaException
+  * }}}
   */
 class MissingSchemaException extends AriadneException("Schema missing from metadata")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/MissingSchemaException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/MissingSchemaException.scala
@@ -2,4 +2,4 @@ package dev.cjfravel.ariadne.exceptions
 
 /** Thrown when the schema field is missing from the index metadata.
   */
-class MissingSchemaException extends Exception("Schema missing from metadata")
+class MissingSchemaException extends AriadneException("Schema missing from metadata")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/MissingSchemaException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/MissingSchemaException.scala
@@ -1,3 +1,5 @@
 package dev.cjfravel.ariadne.exceptions
 
+/** Thrown when the schema field is missing from the index metadata.
+  */
 class MissingSchemaException extends Exception("Schema missing from metadata")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/SchemaMismatchException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/SchemaMismatchException.scala
@@ -4,4 +4,4 @@ package dev.cjfravel.ariadne.exceptions
   * the schema stored in the existing index metadata.
   */
 class SchemaMismatchException
-    extends Exception("Schema provided does not match stored schema")
+    extends AriadneException("Schema provided does not match stored schema")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/SchemaMismatchException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/SchemaMismatchException.scala
@@ -1,4 +1,7 @@
 package dev.cjfravel.ariadne.exceptions
 
+/** Thrown when the schema provided for an index operation does not match
+  * the schema stored in the existing index metadata.
+  */
 class SchemaMismatchException
     extends Exception("Schema provided does not match stored schema")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/SchemaMismatchException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/SchemaMismatchException.scala
@@ -2,6 +2,18 @@ package dev.cjfravel.ariadne.exceptions
 
 /** Thrown when the schema provided for an index operation does not match
   * the schema stored in the existing index metadata.
+  *
+  * Raised by `Index.apply` when reconnecting to an existing index and the
+  * provided schema differs from the persisted one, with
+  * `allowSchemaMismatch = false` (the default).
+  *
+  * {{{
+  * val schema1 = StructType(Seq(StructField("id", IntegerType)))
+  * Index("myIndex", schema1, "parquet")
+  * val schema2 = StructType(Seq(StructField("id", StringType)))
+  * // Throws SchemaMismatchException — type changed from Int to String
+  * Index("myIndex", schema2, "parquet")
+  * }}}
   */
 class SchemaMismatchException
     extends AriadneException("Schema provided does not match stored schema")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/SchemaMismatchException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/SchemaMismatchException.scala
@@ -14,6 +14,11 @@ package dev.cjfravel.ariadne.exceptions
   * // Throws SchemaMismatchException — type changed from Int to String
   * Index("myIndex", schema2, "parquet")
   * }}}
+  *
+  * @param indexName the name of the index with the schema conflict
   */
-class SchemaMismatchException
-    extends AriadneException("Schema provided does not match stored schema")
+class SchemaMismatchException(indexName: String)
+    extends AriadneException(
+      s"Schema mismatch for index '$indexName': provided schema does not match stored schema. " +
+        "Use allowSchemaMismatch=true to update the stored schema."
+    )

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/SchemaNotProvidedException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/SchemaNotProvidedException.scala
@@ -2,6 +2,16 @@ package dev.cjfravel.ariadne.exceptions
 
 /** Thrown when no existing metadata is found and no schema was provided
   * to create a new index.
+  *
+  * Raised by `Index.apply` when the index does not yet exist on storage and
+  * the caller did not supply a schema. A schema is required for first-time
+  * index creation so that column validation can be performed.
+  *
+  * {{{
+  * // Index "newIndex" does not exist yet — schema is required
+  * Index("newIndex")                       // throws SchemaNotProvidedException
+  * Index("newIndex", schema, "parquet")    // OK
+  * }}}
   */
 class SchemaNotProvidedException
     extends AriadneException("No existing metadata found, schema must be provided")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/SchemaNotProvidedException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/SchemaNotProvidedException.scala
@@ -4,4 +4,4 @@ package dev.cjfravel.ariadne.exceptions
   * to create a new index.
   */
 class SchemaNotProvidedException
-    extends Exception("No existing metadata found, schema must be provided")
+    extends AriadneException("No existing metadata found, schema must be provided")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/SchemaNotProvidedException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/SchemaNotProvidedException.scala
@@ -1,4 +1,7 @@
 package dev.cjfravel.ariadne.exceptions
 
+/** Thrown when no existing metadata is found and no schema was provided
+  * to create a new index.
+  */
 class SchemaNotProvidedException
     extends Exception("No existing metadata found, schema must be provided")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/SchemaParseException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/SchemaParseException.scala
@@ -1,7 +1,17 @@
 package dev.cjfravel.ariadne.exceptions
 
 /** Thrown when a schema string is found in metadata but cannot be parsed
-  * into a valid Spark StructType.
+  * into a valid Spark `StructType`.
+  *
+  * Raised during `Index.apply` when `IndexMetadata.schema` contains a value
+  * that `DataType.fromJson` cannot deserialize. This typically indicates a
+  * corrupt metadata file or a metadata file written by an incompatible
+  * version of Spark.
+  *
+  * {{{
+  * // A metadata file with schema = "not valid json" triggers this
+  * val index = Index("corruptSchemaIndex") // throws SchemaParseException
+  * }}}
   */
 class SchemaParseException
     extends AriadneException("Schema was found, but could not be parsed")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/SchemaParseException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/SchemaParseException.scala
@@ -1,4 +1,7 @@
 package dev.cjfravel.ariadne.exceptions
 
+/** Thrown when a schema string is found in metadata but cannot be parsed
+  * into a valid Spark StructType.
+  */
 class SchemaParseException
     extends Exception("Schema was found, but could not be parsed")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/SchemaParseException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/SchemaParseException.scala
@@ -4,4 +4,4 @@ package dev.cjfravel.ariadne.exceptions
   * into a valid Spark StructType.
   */
 class SchemaParseException
-    extends Exception("Schema was found, but could not be parsed")
+    extends AriadneException("Schema was found, but could not be parsed")

--- a/src/test/resources/index_metadata/v7.json
+++ b/src/test/resources/index_metadata/v7.json
@@ -1,0 +1,56 @@
+{
+    "format": "parquet",
+    "schema": "not a real schema",
+    "indexes": [
+        "Test",
+        "Test2"
+    ],
+    "computed_indexes": {
+        "test": "expr1",
+        "test2": "expr2"
+    },
+    "exploded_field_indexes": [
+        {
+            "array_column": "users",
+            "field_path": "id",
+            "as_column": "user_id"
+        },
+        {
+            "array_column": "tags", 
+            "field_path": "name",
+            "as_column": "tag_name"
+        }
+    ],
+    "read_options": {
+        "header": "true",
+        "multiLine": "true"
+    },
+    "bloom_indexes": [
+        {
+            "column": "transaction_id",
+            "fpr": 0.01
+        },
+        {
+            "column": "session_id",
+            "fpr": 0.001
+        }
+    ],
+    "temporal_indexes": [
+        {
+            "column": "entity_id",
+            "timestamp_column": "updated_at"
+        },
+        {
+            "column": "user_id",
+            "timestamp_column": "last_modified"
+        }
+    ],
+    "range_indexes": [
+        {
+            "column": "amount"
+        },
+        {
+            "column": "score"
+        }
+    ]
+}

--- a/src/test/resources/index_metadata/v8.json
+++ b/src/test/resources/index_metadata/v8.json
@@ -1,0 +1,60 @@
+{
+    "format": "parquet",
+    "schema": "not a real schema",
+    "indexes": [
+        "Test",
+        "Test2"
+    ],
+    "computed_indexes": {
+        "test": "expr1",
+        "test2": "expr2"
+    },
+    "exploded_field_indexes": [
+        {
+            "array_column": "users",
+            "field_path": "id",
+            "as_column": "user_id"
+        },
+        {
+            "array_column": "tags", 
+            "field_path": "name",
+            "as_column": "tag_name"
+        }
+    ],
+    "read_options": {
+        "header": "true",
+        "multiLine": "true"
+    },
+    "bloom_indexes": [
+        {
+            "column": "transaction_id",
+            "fpr": 0.01
+        },
+        {
+            "column": "session_id",
+            "fpr": 0.001
+        }
+    ],
+    "temporal_indexes": [
+        {
+            "column": "entity_id",
+            "timestamp_column": "updated_at"
+        },
+        {
+            "column": "user_id",
+            "timestamp_column": "last_modified"
+        }
+    ],
+    "range_indexes": [
+        {
+            "column": "amount"
+        },
+        {
+            "column": "score"
+        }
+    ],
+    "auto_bloom_indexes": [
+        "Test",
+        "Test2"
+    ]
+}

--- a/src/test/resources/index_metadata/v9.json
+++ b/src/test/resources/index_metadata/v9.json
@@ -1,0 +1,61 @@
+{
+    "format": "parquet",
+    "schema": "not a real schema",
+    "indexes": [
+        "Test",
+        "Test2"
+    ],
+    "computed_indexes": {
+        "test": "expr1",
+        "test2": "expr2"
+    },
+    "exploded_field_indexes": [
+        {
+            "array_column": "users",
+            "field_path": "id",
+            "as_column": "user_id"
+        },
+        {
+            "array_column": "tags",
+            "field_path": "name",
+            "as_column": "tag_name"
+        }
+    ],
+    "read_options": {
+        "header": "true",
+        "multiLine": "true"
+    },
+    "bloom_indexes": [
+        {
+            "column": "transaction_id",
+            "fpr": 0.01
+        },
+        {
+            "column": "session_id",
+            "fpr": 0.001
+        }
+    ],
+    "temporal_indexes": [
+        {
+            "column": "entity_id",
+            "timestamp_column": "updated_at"
+        },
+        {
+            "column": "user_id",
+            "timestamp_column": "last_modified"
+        }
+    ],
+    "range_indexes": [
+        {
+            "column": "amount"
+        },
+        {
+            "column": "score"
+        }
+    ],
+    "auto_bloom_indexes": [
+        "Test",
+        "Test2"
+    ],
+    "total_indexed_file_size": 1048576
+}

--- a/src/test/scala/dev/cjfravel/AriadneContextTests.scala
+++ b/src/test/scala/dev/cjfravel/AriadneContextTests.scala
@@ -2,6 +2,9 @@ package dev.cjfravel
 
 import dev.cjfravel.ariadne.{AriadneContextUser, SparkTests}
 
+/** Tests for [[dev.cjfravel.ariadne.AriadneContextUser]] verifying that the implicit
+  * SparkSession is available and HDFS filesystem access works correctly.
+  */
 class AriadneContextTests extends SparkTests {
   test("implicit spark is available") {
     // Test that implicit spark is properly set up

--- a/src/test/scala/dev/cjfravel/ariadne/AriadneContextTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/AriadneContextTests.scala
@@ -1,5 +1,8 @@
 package dev.cjfravel.ariadne
 
+/** Tests for [[AriadneContextUser]] verifying storage path configuration
+  * is correctly read from the SparkSession.
+  */
 class AriadneContextTests extends SparkTests {
   test("storagePath") {
     val contextUser = new AriadneContextUser {

--- a/src/test/scala/dev/cjfravel/ariadne/AutoBloomLargeIndexTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/AutoBloomLargeIndexTests.scala
@@ -7,6 +7,9 @@ import org.apache.hadoop.fs.Path
 import scala.collection.JavaConverters._
 import java.nio.charset.StandardCharsets
 
+/** Tests for automatic bloom filter creation on large index columns, verifying
+  * that auto-bloom filters are built during `update` and used to pre-filter large index queries.
+  */
 class AutoBloomLargeIndexTests extends SparkTests with Matchers {
 
   val testSchema = StructType(

--- a/src/test/scala/dev/cjfravel/ariadne/AutoBloomLargeIndexTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/AutoBloomLargeIndexTests.scala
@@ -1,0 +1,164 @@
+package dev.cjfravel.ariadne
+
+import org.scalatest.matchers.should.Matchers
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.functions._
+import org.apache.hadoop.fs.Path
+import scala.collection.JavaConverters._
+import java.nio.charset.StandardCharsets
+
+class AutoBloomLargeIndexTests extends SparkTests with Matchers {
+
+  val testSchema = StructType(
+    Seq(
+      StructField("Id", IntegerType, nullable = false),
+      StructField("Version", IntegerType, nullable = false),
+      StructField("Value", DoubleType, nullable = false)
+    )
+  )
+
+  private def readMetadata(index: Index): IndexMetadata = {
+    val metadataPath = new Path(index.storagePath, "metadata.json")
+    val stream = index.open(metadataPath)
+    try {
+      val bytes = new Array[Byte](stream.available())
+      stream.readFully(bytes)
+      IndexMetadata(new String(bytes, StandardCharsets.UTF_8))
+    } finally {
+      stream.close()
+    }
+  }
+
+  test("should automatically create bloom filter for large columns") {
+    spark.conf.set("spark.ariadne.largeIndexLimit", "1")
+    try {
+      val index = Index("auto_bloom_create_test", testSchema, "csv", Map("header" -> "true"))
+      index.addFile(resourcePath("/data/table1_part0.csv"))
+      index.addIndex("Id")
+      index.update
+
+      // Verify auto_bloom column exists in the main index
+      val indexDf = spark.read.format("delta").load(new Path(index.storagePath, "index").toString)
+      indexDf.columns should contain("auto_bloom_Id")
+
+      // Verify metadata tracks auto_bloom_indexes
+      val meta = readMetadata(index)
+      meta.auto_bloom_indexes.asScala should contain("Id")
+    } finally {
+      spark.conf.set("spark.ariadne.largeIndexLimit", "500000")
+    }
+  }
+
+  test("should use auto-bloom to filter large index queries") {
+    spark.conf.set("spark.ariadne.largeIndexLimit", "1")
+    try {
+      val index = Index("auto_bloom_query_test", testSchema, "csv", Map("header" -> "true"))
+      index.addFile(resourcePath("/data/table1_part0.csv"))
+      index.addFile(resourcePath("/data/table1_part1.csv"))
+      index.addIndex("Id")
+      index.update
+
+      // part0 has IDs {1, 2, 3}, part1 has IDs {1, 3, 4}
+
+      // Query with a value that exists only in part0 (Id=2)
+      val files = index.locateFiles(Map("Id" -> Array(2)))
+      files should not be empty
+      files.size shouldBe 1
+
+      // Query with a value that exists in both parts (Id=3)
+      val filesForId3 = index.locateFiles(Map("Id" -> Array(3)))
+      filesForId3 should not be empty
+      filesForId3.size shouldBe 2
+
+      // Query with a value that exists only in part1 (Id=4)
+      val filesForId4 = index.locateFiles(Map("Id" -> Array(4)))
+      filesForId4 should not be empty
+      filesForId4.size shouldBe 1
+    } finally {
+      spark.conf.set("spark.ariadne.largeIndexLimit", "500000")
+    }
+  }
+
+  test("should handle backward compatibility with old metadata") {
+    // Load v7 metadata (no auto_bloom_indexes field)
+    val stream = getClass.getResourceAsStream("/index_metadata/v7.json")
+    require(stream != null, "Resource not found: /index_metadata/v7.json")
+    val jsonString = new String(stream.readAllBytes(), StandardCharsets.UTF_8)
+    val metadata = IndexMetadata(jsonString)
+
+    // Migration should create empty auto_bloom_indexes
+    metadata.auto_bloom_indexes should not be null
+    metadata.auto_bloom_indexes.size() shouldBe 0
+  }
+
+  test("should not create auto-bloom for columns under limit") {
+    // Use the default large limit so nothing triggers auto-bloom
+    spark.conf.set("spark.ariadne.largeIndexLimit", "500000")
+    val index = Index("auto_bloom_no_trigger_test", testSchema, "csv", Map("header" -> "true"))
+    index.addFile(resourcePath("/data/table1_part0.csv"))
+    index.addIndex("Id")
+    index.update
+
+    // No columns should have auto-bloom since all are well under 500,000
+    val meta = readMetadata(index)
+    meta.auto_bloom_indexes.size() shouldBe 0
+
+    // Index should still work normally
+    val files = index.locateFiles(Map("Id" -> Array(1)))
+    files should not be empty
+  }
+
+  test("should correctly identify files with auto-bloom filter via DataFrame join") {
+    spark.conf.set("spark.ariadne.largeIndexLimit", "1")
+    try {
+      val index = Index("auto_bloom_join_test", testSchema, "csv", Map("header" -> "true"))
+      index.addFile(resourcePath("/data/table1_part0.csv"))
+      index.addFile(resourcePath("/data/table1_part1.csv"))
+      index.addIndex("Id")
+      index.update
+
+      // Create a query DataFrame with specific Id values
+      val _spark = spark
+      import _spark.implicits._
+      val queryDf = Seq(2).toDF("Id")
+
+      // Join using the index
+      val result = index.join(queryDf, Seq("Id"))
+      result.count() should be > 0L
+
+      // Verify correct data returned
+      val ids = result.select("Id").collect().map(_.getInt(0)).toSet
+      ids should contain(2)
+    } finally {
+      spark.conf.set("spark.ariadne.largeIndexLimit", "500000")
+    }
+  }
+
+  test("should work with multiple auto-bloom columns") {
+    spark.conf.set("spark.ariadne.largeIndexLimit", "1")
+    try {
+      val index = Index("auto_bloom_multi_col_test", testSchema, "csv", Map("header" -> "true"))
+      index.addFile(resourcePath("/data/table1_part0.csv"))
+      index.addFile(resourcePath("/data/table1_part1.csv"))
+      index.addIndex("Id")
+      index.addIndex("Version")
+      index.update
+
+      // Both columns should have auto-bloom
+      val meta = readMetadata(index)
+      meta.auto_bloom_indexes.asScala should contain("Id")
+      meta.auto_bloom_indexes.asScala should contain("Version")
+
+      // Verify index has both auto_bloom columns
+      val indexDf = spark.read.format("delta").load(new Path(index.storagePath, "index").toString)
+      indexDf.columns should contain("auto_bloom_Id")
+      indexDf.columns should contain("auto_bloom_Version")
+
+      // Multi-column query should work
+      val files = index.locateFiles(Map("Id" -> Array(1), "Version" -> Array(1)))
+      files should not be empty
+    } finally {
+      spark.conf.set("spark.ariadne.largeIndexLimit", "500000")
+    }
+  }
+}

--- a/src/test/scala/dev/cjfravel/ariadne/BatchedIndexUpdateTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/BatchedIndexUpdateTests.scala
@@ -6,6 +6,9 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.Row
 
+/** Tests for batched index updates, verifying that files are grouped into optimal
+  * batches based on distinct value limits and staged correctly before consolidation.
+  */
 class BatchedIndexUpdateTests extends SparkTests with Matchers {
 
   val testSchema = StructType(

--- a/src/test/scala/dev/cjfravel/ariadne/BloomFilterOperationsTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/BloomFilterOperationsTests.scala
@@ -7,6 +7,9 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.Row
 
+/** Tests for [[BloomFilterOperations]] covering bloom filter index creation,
+  * custom false-positive-rate validation, and bloom-filter-based file location queries.
+  */
 class BloomFilterOperationsTests extends SparkTests with Matchers {
 
   val testSchema = StructType(

--- a/src/test/scala/dev/cjfravel/ariadne/ColumnBackfillTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/ColumnBackfillTests.scala
@@ -6,6 +6,9 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.Row
 
+/** Tests for column backfill functionality, verifying that newly added regular
+  * and computed index columns are correctly populated for previously indexed files.
+  */
 class ColumnBackfillTests extends SparkTests with Matchers {
 
   val testSchema = StructType(

--- a/src/test/scala/dev/cjfravel/ariadne/CompactionTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/CompactionTests.scala
@@ -1,0 +1,129 @@
+package dev.cjfravel.ariadne
+
+import org.scalatest.matchers.should.Matchers
+import org.apache.spark.sql.types._
+
+class CompactionTests extends SparkTests with Matchers {
+
+  val testSchema: StructType = StructType(
+    Seq(
+      StructField("Id", IntegerType, nullable = false),
+      StructField("Version", IntegerType, nullable = false),
+      StructField("Value", DoubleType, nullable = false)
+    )
+  )
+
+  val csvOptions: Map[String, String] = Map("header" -> "true")
+
+  test("should compact main index") {
+    val index = Index("compact_main_test", testSchema, "csv", csvOptions)
+    val csvPath0 = resourcePath("/data/table1_part0.csv")
+    val csvPath1 = resourcePath("/data/table1_part1.csv")
+
+    index.addFile(csvPath0, csvPath1)
+    index.addIndex("Id")
+    index.addIndex("Version")
+    index.update
+
+    val filesBefore = index.locateFiles(Map("Id" -> Array(1, 2)))
+    filesBefore should not be empty
+
+    // compact should not throw
+    index.compact()
+
+    // index should still work after compaction
+    val filesAfter = index.locateFiles(Map("Id" -> Array(1, 2)))
+    filesAfter shouldEqual filesBefore
+  }
+
+  test("should compact large index tables") {
+    // Use a very small largeIndexLimit so the index is forced into large_indexes
+    spark.conf.set("spark.ariadne.largeIndexLimit", "1")
+    try {
+      val index = Index("compact_large_test", testSchema, "csv", csvOptions)
+      val csvPath0 = resourcePath("/data/table1_part0.csv")
+
+      index.addFile(csvPath0)
+      index.addIndex("Id")
+      index.update
+
+      val filesBefore = index.locateFiles(Map("Id" -> Array(1, 2)))
+      filesBefore should not be empty
+
+      // compact should handle large index tables without error
+      index.compact()
+
+      val filesAfter = index.locateFiles(Map("Id" -> Array(1, 2)))
+      filesAfter shouldEqual filesBefore
+    } finally {
+      spark.conf.set("spark.ariadne.largeIndexLimit", "500000")
+    }
+  }
+
+  test("should handle compact on empty index") {
+    val index = Index("compact_empty_test", testSchema, "csv", csvOptions)
+    index.addIndex("Id")
+
+    // compact before any data — should not throw
+    noException should be thrownBy index.compact()
+  }
+
+  test("should auto-compact when threshold is reached") {
+    // Set a very low threshold (1 log file triggers compaction)
+    spark.conf.set("spark.ariadne.autoCompactThreshold", "1")
+    try {
+      val index = Index("compact_auto_test", testSchema, "csv", csvOptions)
+      val csvPath0 = resourcePath("/data/table1_part0.csv")
+
+      index.addFile(csvPath0)
+      index.addIndex("Id")
+      // update triggers maybeAutoCompact internally
+      index.update
+
+      // After update+auto-compact the index should still be queryable
+      val files = index.locateFiles(Map("Id" -> Array(1, 2)))
+      files should not be empty
+    } finally {
+      spark.conf.unset("spark.ariadne.autoCompactThreshold")
+    }
+  }
+
+  test("should not auto-compact when threshold is not set") {
+    // Ensure config is absent
+    spark.conf.unset("spark.ariadne.autoCompactThreshold")
+
+    val index = Index("compact_no_auto_test", testSchema, "csv", csvOptions)
+    val csvPath0 = resourcePath("/data/table1_part0.csv")
+
+    index.addFile(csvPath0)
+    index.addIndex("Id")
+    // update should complete without auto-compaction errors
+    noException should be thrownBy index.update
+
+    val files = index.locateFiles(Map("Id" -> Array(1, 2)))
+    files should not be empty
+  }
+
+  test("should vacuum with retention") {
+    val index = Index("compact_vacuum_test", testSchema, "csv", csvOptions)
+    val csvPath0 = resourcePath("/data/table1_part0.csv")
+    val csvPath1 = resourcePath("/data/table1_part1.csv")
+
+    index.addFile(csvPath0, csvPath1)
+    index.addIndex("Id")
+    index.update
+
+    val filesBefore = index.locateFiles(Map("Id" -> Array(1, 2)))
+    filesBefore should not be empty
+
+    // vacuum with default retention should not throw
+    noException should be thrownBy index.vacuum()
+
+    // vacuum with 0-hour retention should also work
+    noException should be thrownBy index.vacuum(retentionHours = 0)
+
+    // index should still work after vacuum
+    val filesAfter = index.locateFiles(Map("Id" -> Array(1, 2)))
+    filesAfter shouldEqual filesBefore
+  }
+}

--- a/src/test/scala/dev/cjfravel/ariadne/CompactionTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/CompactionTests.scala
@@ -3,6 +3,9 @@ package dev.cjfravel.ariadne
 import org.scalatest.matchers.should.Matchers
 import org.apache.spark.sql.types._
 
+/** Tests for `compact` and `vacuum` operations on the main index and large index
+  * Delta tables.
+  */
 class CompactionTests extends SparkTests with Matchers {
 
   val testSchema: StructType = StructType(

--- a/src/test/scala/dev/cjfravel/ariadne/ConsolidatedLargeIndexTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/ConsolidatedLargeIndexTests.scala
@@ -7,6 +7,9 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.Row
 import org.apache.hadoop.fs.Path
 
+/** Tests for large index consolidation, verifying that exploded per-column Delta tables
+  * are correctly created and queried for columns exceeding the `largeIndexLimit`.
+  */
 class ConsolidatedLargeIndexTests extends SparkTests with Matchers {
 
   val testSchema = StructType(

--- a/src/test/scala/dev/cjfravel/ariadne/DeleteFilesTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/DeleteFilesTests.scala
@@ -5,6 +5,9 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.Row
 import org.apache.hadoop.fs.Path
 
+/** Tests for `deleteFiles` covering single and multi-file deletion from the main index,
+  * large index table cleanup, and file list removal.
+  */
 class DeleteFilesTests extends SparkTests with Matchers {
 
   val table1Schema = StructType(

--- a/src/test/scala/dev/cjfravel/ariadne/DeleteFilesTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/DeleteFilesTests.scala
@@ -1,0 +1,163 @@
+package dev.cjfravel.ariadne
+
+import org.scalatest.matchers.should.Matchers
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.Row
+import org.apache.hadoop.fs.Path
+
+class DeleteFilesTests extends SparkTests with Matchers {
+
+  val table1Schema = StructType(
+    Seq(
+      StructField("Id", IntegerType, nullable = false),
+      StructField("Version", IntegerType, nullable = false),
+      StructField("Value", DoubleType, nullable = false)
+    )
+  )
+
+  test("should delete a single file from index") {
+    val csvOptions = Map("header" -> "true")
+    val index = Index("delete_single", table1Schema, "csv", csvOptions)
+    val path0 = resourcePath("/data/table1_part0.csv")
+    val path1 = resourcePath("/data/table1_part1.csv")
+    index.addFile(path0, path1)
+    index.addIndex("Id")
+    index.update
+
+    // Both files should be locatable
+    val beforeFiles = index.locateFiles(Map("Id" -> Array(1)))
+    beforeFiles should contain(path0)
+
+    index.deleteFiles(path0)
+
+    // After delete, only path1 should remain
+    val afterFiles = index.locateFiles(Map("Id" -> Array(1)))
+    afterFiles should not contain path0
+    afterFiles should contain(path1)
+  }
+
+  test("should delete multiple files from index") {
+    val csvOptions = Map("header" -> "true")
+    val index = Index("delete_multiple", table1Schema, "csv", csvOptions)
+    val path0 = resourcePath("/data/table1_part0.csv")
+    val path1 = resourcePath("/data/table1_part1.csv")
+    index.addFile(path0, path1)
+    index.addIndex("Id")
+    index.update
+
+    index.deleteFiles(path0, path1)
+
+    val afterFiles = index.locateFiles(Map("Id" -> Array(1)))
+    afterFiles shouldBe empty
+  }
+
+  test("should clean up large index tables on delete") {
+    val largeSchema = StructType(
+      Seq(
+        StructField("Id", IntegerType, nullable = false),
+        StructField("Category", StringType, nullable = false),
+        StructField("Value", DoubleType, nullable = false)
+      )
+    )
+
+    // Create data with enough distinct values to trigger large index (limit is 500,000)
+    val largeData = (1 to 600000).map { i =>
+      Row(i, s"cat_$i", i.toDouble)
+    }
+
+    val df = spark.createDataFrame(
+      spark.sparkContext.parallelize(largeData),
+      largeSchema
+    )
+
+    val tempPath = s"${System.getProperty("java.io.tmpdir")}/delete_large_test_${System.currentTimeMillis()}"
+    df.coalesce(1)
+      .write
+      .option("header", "true")
+      .mode("overwrite")
+      .csv(tempPath)
+
+    try {
+      val fileName = "file://" + java.nio.file.Files
+        .walk(java.nio.file.Paths.get(tempPath))
+        .filter(java.nio.file.Files.isRegularFile(_))
+        .filter(_.getFileName.toString.endsWith(".csv"))
+        .findFirst()
+        .get()
+        .toString
+
+      val index = Index("delete_large", largeSchema, "csv", Map("header" -> "true"))
+      index.addFile(fileName)
+      index.addIndex("Id")
+      index.addIndex("Category")
+      index.update
+
+      // Verify large index exists before delete
+      val largeIndexesPath = new Path(index.storagePath, "large_indexes")
+      index.exists(largeIndexesPath) shouldBe true
+
+      index.deleteFiles(fileName)
+
+      // After delete, locateFiles should return nothing
+      val afterFiles = index.locateFiles(Map("Id" -> Array(1)))
+      afterFiles shouldBe empty
+
+      // File should no longer be tracked
+      index.hasFile(fileName) shouldBe false
+    } finally {
+      deleteRecursive(tempPath)
+    }
+  }
+
+  test("should be a no-op for non-existent files") {
+    val csvOptions = Map("header" -> "true")
+    val index = Index("delete_noop", table1Schema, "csv", csvOptions)
+    val path0 = resourcePath("/data/table1_part0.csv")
+    index.addFile(path0)
+    index.addIndex("Id")
+    index.update
+
+    // Deleting a file that doesn't exist should not throw
+    noException should be thrownBy {
+      index.deleteFiles("file:///nonexistent/path.csv")
+    }
+
+    // Original file should still be intact
+    val files = index.locateFiles(Map("Id" -> Array(1)))
+    files should contain(path0)
+  }
+
+  test("should remove file from file list on delete") {
+    val csvOptions = Map("header" -> "true")
+    val index = Index("delete_filelist", table1Schema, "csv", csvOptions)
+    val path0 = resourcePath("/data/table1_part0.csv")
+    val path1 = resourcePath("/data/table1_part1.csv")
+    index.addFile(path0, path1)
+    index.addIndex("Id")
+    index.update
+
+    index.hasFile(path0) shouldBe true
+    index.deleteFiles(path0)
+    index.hasFile(path0) shouldBe false
+    index.hasFile(path1) shouldBe true
+  }
+
+  test("should handle delete on empty index") {
+    val csvOptions = Map("header" -> "true")
+    val index = Index("delete_empty", table1Schema, "csv", csvOptions)
+
+    noException should be thrownBy {
+      index.deleteFiles("file:///some/file.csv")
+    }
+  }
+
+  private def deleteRecursive(path: String): Unit = {
+    val dir = java.nio.file.Paths.get(path)
+    if (java.nio.file.Files.exists(dir)) {
+      java.nio.file.Files
+        .walk(dir)
+        .sorted(java.util.Comparator.reverseOrder())
+        .forEach(java.nio.file.Files.delete)
+    }
+  }
+}

--- a/src/test/scala/dev/cjfravel/ariadne/FileListTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/FileListTests.scala
@@ -1,5 +1,8 @@
 package dev.cjfravel.ariadne
 
+/** Tests for [[FileList]] covering file addition (single and batch), existence
+  * checks, and removal from the tracked file list.
+  */
 class FileListTests extends SparkTests {
   test("addFile") {
     val filelist = FileList("test")

--- a/src/test/scala/dev/cjfravel/ariadne/FileSizeTrackingTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/FileSizeTrackingTests.scala
@@ -6,6 +6,9 @@ import org.apache.spark.sql.functions._
 import scala.io.Source
 import java.nio.charset.StandardCharsets
 
+/** Tests for file size tracking, verifying that `file_size` is stored in the
+  * index table during `update` and accessible via index metadata.
+  */
 class FileSizeTrackingTests extends SparkTests with Matchers {
 
   val table1Schema = StructType(

--- a/src/test/scala/dev/cjfravel/ariadne/FileSizeTrackingTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/FileSizeTrackingTests.scala
@@ -1,0 +1,165 @@
+package dev.cjfravel.ariadne
+
+import org.scalatest.matchers.should.Matchers
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.functions._
+import scala.io.Source
+import java.nio.charset.StandardCharsets
+
+class FileSizeTrackingTests extends SparkTests with Matchers {
+
+  val table1Schema = StructType(
+    Seq(
+      StructField("Id", IntegerType, nullable = false),
+      StructField("Version", IntegerType, nullable = false),
+      StructField("Value", DoubleType, nullable = false)
+    )
+  )
+
+  /** Reads metadata from disk for the given index name. */
+  private def readMetadataFromDisk(indexName: String): IndexMetadata = {
+    val metadataPath = new org.apache.hadoop.fs.Path(
+      tempDir.toString + "/indexes/" + indexName + "/metadata.json"
+    )
+    val fs = metadataPath.getFileSystem(spark.sparkContext.hadoopConfiguration)
+    val inputStream = fs.open(metadataPath)
+    val jsonString = Source.fromInputStream(inputStream)(StandardCharsets.UTF_8).mkString
+    inputStream.close()
+    IndexMetadata(jsonString)
+  }
+
+  /** Writes metadata to disk for the given index name. */
+  private def writeMetadataToDisk(indexName: String, metadata: IndexMetadata): Unit = {
+    val metadataPath = new org.apache.hadoop.fs.Path(
+      tempDir.toString + "/indexes/" + indexName + "/metadata.json"
+    )
+    val fs = metadataPath.getFileSystem(spark.sparkContext.hadoopConfiguration)
+    val jsonString = new com.google.gson.Gson().toJson(metadata)
+    val outputStream = fs.create(metadataPath, true)
+    outputStream.write(jsonString.getBytes(StandardCharsets.UTF_8))
+    outputStream.flush()
+    outputStream.close()
+  }
+
+  /** Returns the path to the index Delta table. */
+  private def indexPath(indexName: String): String =
+    tempDir.toString + "/indexes/" + indexName + "/index"
+
+  test("should store file_size in index table during update") {
+    val csvOptions = Map("header" -> "true")
+    val index = Index("filesize_store", table1Schema, "csv", csvOptions)
+    val path0 = resourcePath("/data/table1_part0.csv")
+    val path1 = resourcePath("/data/table1_part1.csv")
+    index.addFile(path0, path1)
+    index.addIndex("Id")
+    index.update
+
+    val indexDf = spark.read.format("delta").load(indexPath("filesize_store"))
+    indexDf.columns should contain("file_size")
+
+    val fileSizes = indexDf.select("filename", "file_size").collect()
+    fileSizes.foreach { row =>
+      val fileSize = row.getLong(1)
+      fileSize should be > 0L
+    }
+  }
+
+  test("should track total_indexed_file_size in metadata") {
+    val csvOptions = Map("header" -> "true")
+    val index = Index("filesize_total", table1Schema, "csv", csvOptions)
+    val path0 = resourcePath("/data/table1_part0.csv")
+    val path1 = resourcePath("/data/table1_part1.csv")
+    index.addFile(path0, path1)
+    index.addIndex("Id")
+    index.update
+
+    val metadata = readMetadataFromDisk("filesize_total")
+    val total = metadata.total_indexed_file_size.toLong
+    total should be > 0L
+
+    // Verify total equals sum of individual file_size values
+    val indexDf = spark.read.format("delta").load(indexPath("filesize_total"))
+    val sumResult = indexDf.agg(sum("file_size")).head()
+    val sumOfSizes = sumResult.getLong(0)
+    total shouldBe sumOfSizes
+  }
+
+  test("should decrement total on deleteFiles") {
+    val csvOptions = Map("header" -> "true")
+    val index = Index("filesize_delete", table1Schema, "csv", csvOptions)
+    val path0 = resourcePath("/data/table1_part0.csv")
+    val path1 = resourcePath("/data/table1_part1.csv")
+    index.addFile(path0, path1)
+    index.addIndex("Id")
+    index.update
+
+    val metadataBefore = readMetadataFromDisk("filesize_delete")
+    val totalBefore = metadataBefore.total_indexed_file_size.toLong
+    totalBefore should be > 0L
+
+    // Get size of file being deleted
+    val indexDf = spark.read.format("delta").load(indexPath("filesize_delete"))
+    val file0Size = indexDf
+      .where(col("filename") === path0)
+      .select("file_size")
+      .head()
+      .getLong(0)
+    file0Size should be > 0L
+
+    index.deleteFiles(path0)
+
+    val metadataAfter = readMetadataFromDisk("filesize_delete")
+    val totalAfter = metadataAfter.total_indexed_file_size.toLong
+    totalAfter shouldBe (totalBefore - file0Size)
+    totalAfter should be > 0L
+  }
+
+  test("should backfill file_size for existing index rows") {
+    val csvOptions = Map("header" -> "true")
+    val index = Index("filesize_backfill", table1Schema, "csv", csvOptions)
+    val path0 = resourcePath("/data/table1_part0.csv")
+    index.addFile(path0)
+    index.addIndex("Id")
+    index.update
+
+    // Verify file_size exists
+    val indexDf = spark.read.format("delta").load(indexPath("filesize_backfill"))
+    indexDf.columns should contain("file_size")
+    val originalSize = indexDf.select("file_size").head().getLong(0)
+    originalSize should be > 0L
+
+    // Simulate old index by nulling out file_size via Delta merge
+    import io.delta.tables.DeltaTable
+    val dt = DeltaTable.forPath(spark, indexPath("filesize_backfill"))
+    val allFiles = spark.read.format("delta").load(indexPath("filesize_backfill"))
+      .select("filename").distinct()
+    dt.as("target")
+      .merge(allFiles.as("source"), "target.filename = source.filename")
+      .whenMatched()
+      .update(Map("file_size" -> lit(null).cast("long")))
+      .execute()
+
+    // Also reset metadata to trigger recalculation
+    val metadata = readMetadataFromDisk("filesize_backfill")
+    metadata.total_indexed_file_size = -1L
+    writeMetadataToDisk("filesize_backfill", metadata)
+
+    // Verify file_size is null now
+    val nullDf = spark.read.format("delta").load(indexPath("filesize_backfill"))
+    val nullCount = nullDf.where(col("file_size").isNull).count()
+    nullCount should be > 0L
+
+    // Reload index and call update - should trigger backfill
+    val reloadedIndex = Index("filesize_backfill", table1Schema, "csv", csvOptions)
+    reloadedIndex.update
+
+    // Verify file_size is populated again
+    val backfilledDf = spark.read.format("delta").load(indexPath("filesize_backfill"))
+    val backfilledSize = backfilledDf.select("file_size").head().getLong(0)
+    backfilledSize shouldBe originalSize
+
+    // Verify metadata total is recalculated
+    val finalMetadata = readMetadataFromDisk("filesize_backfill")
+    finalMetadata.total_indexed_file_size.toLong should be > 0L
+  }
+}

--- a/src/test/scala/dev/cjfravel/ariadne/IndexBuildOperationsTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexBuildOperationsTests.scala
@@ -6,6 +6,9 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.Row
 
+/** Tests for [[IndexBuildOperations]] verifying that regular and computed index
+  * columns are correctly built and persisted during the `update` workflow.
+  */
 class IndexBuildOperationsTests extends SparkTests with Matchers {
 
   val testSchema = StructType(

--- a/src/test/scala/dev/cjfravel/ariadne/IndexCatalogTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexCatalogTests.scala
@@ -243,6 +243,49 @@ class IndexCatalogTests extends SparkTests {
     assert(fetched.indexes.contains("Id"))
   }
 
+  // --- findIndexes ---
+
+  test("findIndexes returns empty for file not tracked by any index") {
+    Index("catalog_find_none", schema1, "parquet")
+    val result = IndexCatalog.findIndexes("nonexistent/file.parquet")
+    assert(result.isEmpty)
+  }
+
+  test("findIndexes returns indexes that track a given file") {
+    val file = resourcePath("/data/table1_part0.csv")
+
+    val idx1 = Index("catalog_find_a", schema1, "parquet")
+    idx1.addIndex("Id")
+    idx1.addFile(file)
+
+    val idx2 = Index("catalog_find_b", schema1, "parquet")
+    idx2.addIndex("Id")
+    idx2.addFile(file)
+
+    val idx3 = Index("catalog_find_c", schema1, "parquet")
+    idx3.addIndex("Id")
+    // idx3 does NOT have the file
+
+    val result = IndexCatalog.findIndexes(file)
+    assert(result.contains("catalog_find_a"))
+    assert(result.contains("catalog_find_b"))
+    assert(!result.contains("catalog_find_c"))
+  }
+
+  test("findIndexes returns results in sorted order") {
+    val file = resourcePath("/data/table1_part1.csv")
+
+    val idxZ = Index("catalog_find_z", schema1, "parquet")
+    idxZ.addFile(file)
+    val idxA = Index("catalog_find_aa", schema1, "parquet")
+    idxA.addFile(file)
+
+    val result = IndexCatalog.findIndexes(file)
+    val relevant = result.filter(_.startsWith("catalog_find_a"))
+    assert(relevant.nonEmpty)
+    assert(result == result.sorted)
+  }
+
   // --- toDF ---
 
   test("toDF returns correct schema") {

--- a/src/test/scala/dev/cjfravel/ariadne/IndexCatalogTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexCatalogTests.scala
@@ -1,0 +1,297 @@
+package dev.cjfravel.ariadne
+
+import dev.cjfravel.ariadne.exceptions.IndexNotFoundException
+import org.apache.spark.sql.types._
+
+/** Tests for [[IndexCatalog]] covering discovery, inspection, retrieval,
+  * DataFrame conversion, and removal of indexes from the catalog.
+  */
+class IndexCatalogTests extends SparkTests {
+
+  val schema1 = StructType(
+    Seq(
+      StructField("Id", IntegerType, nullable = false),
+      StructField("Version", IntegerType, nullable = false),
+      StructField("Value", DoubleType, nullable = false)
+    )
+  )
+
+  val schema2 = StructType(
+    Seq(
+      StructField("UserId", StringType, nullable = false),
+      StructField("Status", StringType, nullable = false),
+      StructField("UpdatedAt", TimestampType, nullable = false)
+    )
+  )
+
+  val schemaWithArray = StructType(
+    Seq(
+      StructField("Id", IntegerType, nullable = false),
+      StructField(
+        "Tags",
+        ArrayType(
+          StructType(
+            Seq(
+              StructField("name", StringType, nullable = false)
+            )
+          )
+        ),
+        nullable = false
+      )
+    )
+  )
+
+  // --- list ---
+
+  test("list returns empty when no indexes exist") {
+    val names = IndexCatalog.list()
+    assert(names.isEmpty)
+  }
+
+  test("list returns index names after creation") {
+    Index("catalog_list_a", schema1, "parquet")
+    Index("catalog_list_b", schema1, "parquet")
+    Index("catalog_list_c", schema1, "parquet")
+
+    val names = IndexCatalog.list()
+    assert(names.contains("catalog_list_a"))
+    assert(names.contains("catalog_list_b"))
+    assert(names.contains("catalog_list_c"))
+  }
+
+  test("list returns names in sorted order") {
+    Index("catalog_sorted_z", schema1, "parquet")
+    Index("catalog_sorted_a", schema1, "parquet")
+    Index("catalog_sorted_m", schema1, "parquet")
+
+    val names = IndexCatalog.list()
+    val relevant = names.filter(_.startsWith("catalog_sorted_"))
+    assert(relevant == relevant.sorted)
+  }
+
+  test("list does not include removed indexes") {
+    Index("catalog_remove_list", schema1, "parquet")
+    assert(IndexCatalog.list().contains("catalog_remove_list"))
+
+    IndexCatalog.remove("catalog_remove_list")
+    assert(!IndexCatalog.list().contains("catalog_remove_list"))
+  }
+
+  // --- exists ---
+
+  test("exists returns false for non-existent index") {
+    assert(!IndexCatalog.exists("does_not_exist"))
+  }
+
+  test("exists returns true for existing index") {
+    Index("catalog_exists", schema1, "parquet")
+    assert(IndexCatalog.exists("catalog_exists"))
+  }
+
+  // --- describe ---
+
+  test("describe throws IndexNotFoundException for missing index") {
+    assertThrows[IndexNotFoundException] {
+      IndexCatalog.describe("nonexistent_index")
+    }
+  }
+
+  test("describe returns correct summary for index with regular indexes") {
+    val index = Index("catalog_desc_regular", schema1, "parquet")
+    index.addIndex("Id")
+    index.addIndex("Version")
+
+    val summary = IndexCatalog.describe("catalog_desc_regular")
+    assert(summary.name == "catalog_desc_regular")
+    assert(summary.format == "parquet")
+    assert(summary.regularIndexes == Set("Id", "Version"))
+    assert(summary.bloomIndexes.isEmpty)
+    assert(summary.computedIndexes.isEmpty)
+    assert(summary.temporalIndexes.isEmpty)
+    assert(summary.rangeIndexes.isEmpty)
+    assert(summary.explodedFieldIndexes.isEmpty)
+    assert(summary.columns == Set("Id", "Version"))
+  }
+
+  test("describe returns correct summary for index with bloom indexes") {
+    val index = Index("catalog_desc_bloom", schema1, "parquet")
+    index.addBloomIndex("Id", 0.05)
+
+    val summary = IndexCatalog.describe("catalog_desc_bloom")
+    assert(summary.bloomIndexes == Set("Id"))
+    assert(summary.regularIndexes.isEmpty)
+    assert(summary.columns.contains("Id"))
+  }
+
+  test("describe returns correct summary for index with computed indexes") {
+    val index = Index("catalog_desc_computed", schema1, "parquet")
+    index.addComputedIndex("category", "substring(cast(Id as string), 1, 2)")
+
+    val summary = IndexCatalog.describe("catalog_desc_computed")
+    assert(summary.computedIndexes == Set("category"))
+    assert(summary.columns.contains("category"))
+  }
+
+  test("describe returns correct summary for index with temporal indexes") {
+    val index = Index("catalog_desc_temporal", schema2, "parquet")
+    index.addTemporalIndex("UserId", "UpdatedAt")
+
+    val summary = IndexCatalog.describe("catalog_desc_temporal")
+    assert(summary.temporalIndexes == Set("UserId"))
+    assert(summary.columns.contains("UserId"))
+  }
+
+  test("describe returns correct summary for index with range indexes") {
+    val index = Index("catalog_desc_range", schema1, "parquet")
+    index.addRangeIndex("Version")
+
+    val summary = IndexCatalog.describe("catalog_desc_range")
+    assert(summary.rangeIndexes == Set("Version"))
+    assert(summary.columns.contains("Version"))
+  }
+
+  test("describe returns correct summary for index with exploded field indexes") {
+    val index = Index("catalog_desc_exploded", schemaWithArray, "parquet")
+    index.addExplodedFieldIndex("Tags", "name", "tag_name")
+
+    val summary = IndexCatalog.describe("catalog_desc_exploded")
+    assert(summary.explodedFieldIndexes == Set("tag_name"))
+    assert(summary.columns.contains("tag_name"))
+  }
+
+  test("describe returns correct summary for index with mixed index types") {
+    val index = Index("catalog_desc_mixed", schema1, "parquet")
+    index.addIndex("Id")
+    index.addRangeIndex("Version")
+    index.addComputedIndex("cat", "substring(cast(Id as string), 1, 2)")
+
+    val summary = IndexCatalog.describe("catalog_desc_mixed")
+    assert(summary.regularIndexes == Set("Id"))
+    assert(summary.rangeIndexes == Set("Version"))
+    assert(summary.computedIndexes == Set("cat"))
+    assert(summary.columns == Set("Id", "Version", "cat"))
+  }
+
+  test("describe returns correct file count with tracked files") {
+    val index = Index("catalog_desc_files", schema1, "parquet")
+    index.addIndex("Id")
+    index.addFile(resourcePath("/data/table1_part0.csv"))
+
+    val summary = IndexCatalog.describe("catalog_desc_files")
+    assert(summary.fileCount == 1)
+  }
+
+  test("describe returns zero file count for index with no files") {
+    val index = Index("catalog_desc_no_files", schema1, "parquet")
+    index.addIndex("Id")
+
+    val summary = IndexCatalog.describe("catalog_desc_no_files")
+    assert(summary.fileCount == 0)
+  }
+
+  test("describe returns totalIndexedFileSize from metadata") {
+    val index = Index("catalog_desc_size", schema1, "parquet")
+    index.addIndex("Id")
+
+    val summary = IndexCatalog.describe("catalog_desc_size")
+    assert(summary.totalIndexedFileSize == -1L)
+  }
+
+  test("describe reflects index modifications") {
+    val index = Index("catalog_modify", schema1, "parquet")
+    index.addIndex("Id")
+
+    val summary1 = IndexCatalog.describe("catalog_modify")
+    assert(summary1.regularIndexes == Set("Id"))
+    assert(summary1.rangeIndexes.isEmpty)
+
+    index.addRangeIndex("Version")
+
+    val summary2 = IndexCatalog.describe("catalog_modify")
+    assert(summary2.regularIndexes == Set("Id"))
+    assert(summary2.rangeIndexes == Set("Version"))
+    assert(summary2.columns == Set("Id", "Version"))
+  }
+
+  // --- describeAll ---
+
+  test("describeAll returns summaries for all indexes") {
+    Index("catalog_all_1", schema1, "parquet")
+    Index("catalog_all_2", schema1, "parquet")
+
+    val summaries = IndexCatalog.describeAll()
+    val names = summaries.map(_.name)
+    assert(names.contains("catalog_all_1"))
+    assert(names.contains("catalog_all_2"))
+  }
+
+  // --- get ---
+
+  test("get throws IndexNotFoundException for missing index") {
+    assertThrows[IndexNotFoundException] {
+      IndexCatalog.get("nonexistent_get")
+    }
+  }
+
+  test("get returns a functional Index instance") {
+    val original = Index("catalog_get_test", schema1, "parquet")
+    original.addIndex("Id")
+
+    val fetched = IndexCatalog.get("catalog_get_test")
+    assert(fetched.name == "catalog_get_test")
+    assert(fetched.format == "parquet")
+    assert(fetched.indexes.contains("Id"))
+  }
+
+  // --- toDF ---
+
+  test("toDF returns correct schema") {
+    Index("catalog_df_schema", schema1, "parquet")
+
+    val df = IndexCatalog.toDF()
+    val expectedColumns = Set(
+      "name", "format", "regular_indexes", "bloom_indexes",
+      "computed_indexes", "temporal_indexes", "range_indexes",
+      "exploded_field_indexes", "file_count", "total_indexed_file_size"
+    )
+    assert(df.columns.toSet == expectedColumns)
+  }
+
+  test("toDF includes correct data for indexes") {
+    val index = Index("catalog_df_data", schema1, "parquet")
+    index.addIndex("Id")
+    index.addRangeIndex("Version")
+
+    val df = IndexCatalog.toDF()
+    val row = df.filter(df("name") === "catalog_df_data").collect()
+    assert(row.length == 1)
+    assert(row(0).getAs[String]("format") == "parquet")
+    assert(row(0).getAs[String]("regular_indexes").contains("Id"))
+    assert(row(0).getAs[String]("range_indexes").contains("Version"))
+  }
+
+  test("toDF returns one row per index") {
+    Index("catalog_df_count_a", schema1, "parquet")
+    Index("catalog_df_count_b", schema1, "parquet")
+
+    val df = IndexCatalog.toDF()
+    val relevantRows = df.filter(df("name").startsWith("catalog_df_count_")).collect()
+    assert(relevantRows.length == 2)
+  }
+
+  // --- remove ---
+
+  test("remove removes an existing index") {
+    Index("catalog_remove", schema1, "parquet")
+    assert(IndexCatalog.exists("catalog_remove"))
+
+    IndexCatalog.remove("catalog_remove")
+    assert(!IndexCatalog.exists("catalog_remove"))
+  }
+
+  test("remove throws IndexNotFoundException for missing index") {
+    assertThrows[IndexNotFoundException] {
+      IndexCatalog.remove("nonexistent_remove")
+    }
+  }
+}

--- a/src/test/scala/dev/cjfravel/ariadne/IndexFileOperationsTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexFileOperationsTests.scala
@@ -7,6 +7,9 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.Row
 import java.nio.file.Files
 
+/** Tests for file I/O operations on indexes, covering CSV and JSON formats
+  * with various read options (multiLine, headers, delimiters) and schema round-trips.
+  */
 class IndexFileOperationsTests extends SparkTests with Matchers {
 
   val csvSchema = StructType(

--- a/src/test/scala/dev/cjfravel/ariadne/IndexJoinOperationsTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexJoinOperationsTests.scala
@@ -7,6 +7,9 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.Row
 import dev.cjfravel.ariadne.Index.DataFrameOps
 
+/** Tests for [[IndexJoinOperations]] verifying index-accelerated joins between
+  * a DataFrame and indexed data, including both `index.join(df)` and `df.join(index)` directions.
+  */
 class IndexJoinOperationsTests extends SparkTests with Matchers {
 
   val indexSchema = StructType(

--- a/src/test/scala/dev/cjfravel/ariadne/IndexLockTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexLockTests.scala
@@ -8,6 +8,9 @@ import java.nio.charset.StandardCharsets
 import java.time.Instant
 import scala.io.Source
 
+/** Tests for [[IndexLock]] covering lock acquisition, release, refresh,
+  * stale lock auto-healing, and contention behavior.
+  */
 class IndexLockTests extends SparkTests {
 
   private val gson = new Gson()

--- a/src/test/scala/dev/cjfravel/ariadne/IndexMetadataOperationsTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexMetadataOperationsTests.scala
@@ -7,6 +7,9 @@ import dev.cjfravel.ariadne.exceptions._
 import java.util
 import java.util.Collections
 
+/** Tests for [[IndexMetadataOperations]] covering metadata read/write round-trips,
+  * format handling, schema storage, and configuration of regular, exploded, and computed indexes.
+  */
 class IndexMetadataOperationsTests extends SparkTests with Matchers {
 
   val testSchema = StructType(

--- a/src/test/scala/dev/cjfravel/ariadne/IndexMetadataTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexMetadataTests.scala
@@ -329,4 +329,53 @@ class IndexMetadataTests extends AnyFunSuite {
     assert(metadata.range_indexes.size() === 0)
     assert(metadata.auto_bloom_indexes.size() === 0)
   }
+
+  test("v8 -> v9") {
+    val stream = getClass.getResourceAsStream("/index_metadata/v8.json")
+    require(stream != null, "Resource not found: /index_metadata/v8.json")
+    val jsonString = new String(stream.readAllBytes(), StandardCharsets.UTF_8)
+    val metadata = IndexMetadata(jsonString)
+    assert(metadata.format === "parquet")
+    assert(metadata.schema === "not a real schema")
+    assert(metadata.indexes.size() === 2)
+    assert(metadata.auto_bloom_indexes.size() === 2)
+    // v8 -> v9 migration should add total_indexed_file_size = -1
+    assert(metadata.total_indexed_file_size === -1L)
+  }
+
+  test("v9") {
+    val stream = getClass.getResourceAsStream("/index_metadata/v9.json")
+    require(stream != null, "Resource not found: /index_metadata/v9.json")
+    val jsonString = new String(stream.readAllBytes(), StandardCharsets.UTF_8)
+    val metadata = IndexMetadata(jsonString)
+    assert(metadata.format === "parquet")
+    assert(metadata.schema === "not a real schema")
+    assert(metadata.indexes.size() === 2)
+    assert(metadata.computed_indexes.size() === 2)
+    assert(metadata.exploded_field_indexes.size() === 2)
+    assert(metadata.read_options.size() === 2)
+    assert(metadata.bloom_indexes.size() === 2)
+    assert(metadata.temporal_indexes.size() === 2)
+    assert(metadata.range_indexes.size() === 2)
+    assert(metadata.auto_bloom_indexes.size() === 2)
+    assert(metadata.total_indexed_file_size === 1048576L)
+  }
+
+  test("v1 -> v9 full migration") {
+    val stream = getClass.getResourceAsStream("/index_metadata/v1.json")
+    require(stream != null, "Resource not found: /index_metadata/v1.json")
+    val jsonString = new String(stream.readAllBytes(), StandardCharsets.UTF_8)
+    val metadata = IndexMetadata(jsonString)
+    assert(metadata.format === "parquet")
+    assert(metadata.schema === "not a real schema")
+    assert(metadata.indexes.size() === 2)
+    assert(metadata.computed_indexes.size() === 0)
+    assert(metadata.exploded_field_indexes.size() === 0)
+    assert(metadata.read_options.size() === 0)
+    assert(metadata.bloom_indexes.size() === 0)
+    assert(metadata.temporal_indexes.size() === 0)
+    assert(metadata.range_indexes.size() === 0)
+    assert(metadata.auto_bloom_indexes.size() === 0)
+    assert(metadata.total_indexed_file_size === -1L)
+  }
 }

--- a/src/test/scala/dev/cjfravel/ariadne/IndexMetadataTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexMetadataTests.scala
@@ -244,4 +244,89 @@ class IndexMetadataTests extends AnyFunSuite {
     assert(metadata.bloom_indexes.size() === 0)
     assert(metadata.temporal_indexes.size() === 0)
   }
+
+  test("v6 -> v7") {
+    val stream = getClass.getResourceAsStream("/index_metadata/v6.json")
+    require(stream != null, "Resource not found: /index_metadata/v6.json")
+    val jsonString = new String(stream.readAllBytes(), StandardCharsets.UTF_8)
+    val metadata = IndexMetadata(jsonString)
+    assert(metadata.format === "parquet")
+    assert(metadata.schema === "not a real schema")
+    assert(metadata.indexes.size() === 2)
+    assert(metadata.bloom_indexes.size() === 2)
+    assert(metadata.temporal_indexes.size() === 2)
+    // v6 -> v7 migration should add empty range_indexes
+    assert(metadata.range_indexes.size() === 0)
+  }
+
+  test("v7") {
+    val stream = getClass.getResourceAsStream("/index_metadata/v7.json")
+    require(stream != null, "Resource not found: /index_metadata/v7.json")
+    val jsonString = new String(stream.readAllBytes(), StandardCharsets.UTF_8)
+    val metadata = IndexMetadata(jsonString)
+    assert(metadata.format === "parquet")
+    assert(metadata.schema === "not a real schema")
+    assert(metadata.indexes.size() === 2)
+    assert(metadata.computed_indexes.size() === 2)
+    assert(metadata.exploded_field_indexes.size() === 2)
+    assert(metadata.read_options.size() === 2)
+    assert(metadata.bloom_indexes.size() === 2)
+    assert(metadata.temporal_indexes.size() === 2)
+    assert(metadata.range_indexes.size() === 2)
+
+    val rangeIndexes = metadata.range_indexes.asScala.toSeq
+    val amountIndex = rangeIndexes.find(_.column == "amount").get
+    assert(amountIndex.column === "amount")
+    val scoreIndex = rangeIndexes.find(_.column == "score").get
+    assert(scoreIndex.column === "score")
+  }
+
+  test("v7 -> v8") {
+    val stream = getClass.getResourceAsStream("/index_metadata/v7.json")
+    require(stream != null, "Resource not found: /index_metadata/v7.json")
+    val jsonString = new String(stream.readAllBytes(), StandardCharsets.UTF_8)
+    val metadata = IndexMetadata(jsonString)
+    assert(metadata.format === "parquet")
+    assert(metadata.schema === "not a real schema")
+    assert(metadata.indexes.size() === 2)
+    assert(metadata.range_indexes.size() === 2)
+    // v7 -> v8 migration should add empty auto_bloom_indexes
+    assert(metadata.auto_bloom_indexes.size() === 0)
+  }
+
+  test("v8") {
+    val stream = getClass.getResourceAsStream("/index_metadata/v8.json")
+    require(stream != null, "Resource not found: /index_metadata/v8.json")
+    val jsonString = new String(stream.readAllBytes(), StandardCharsets.UTF_8)
+    val metadata = IndexMetadata(jsonString)
+    assert(metadata.format === "parquet")
+    assert(metadata.schema === "not a real schema")
+    assert(metadata.indexes.size() === 2)
+    assert(metadata.computed_indexes.size() === 2)
+    assert(metadata.exploded_field_indexes.size() === 2)
+    assert(metadata.read_options.size() === 2)
+    assert(metadata.bloom_indexes.size() === 2)
+    assert(metadata.temporal_indexes.size() === 2)
+    assert(metadata.range_indexes.size() === 2)
+    assert(metadata.auto_bloom_indexes.size() === 2)
+    assert(metadata.auto_bloom_indexes.contains("Test"))
+    assert(metadata.auto_bloom_indexes.contains("Test2"))
+  }
+
+  test("v1 -> v8 full migration") {
+    val stream = getClass.getResourceAsStream("/index_metadata/v1.json")
+    require(stream != null, "Resource not found: /index_metadata/v1.json")
+    val jsonString = new String(stream.readAllBytes(), StandardCharsets.UTF_8)
+    val metadata = IndexMetadata(jsonString)
+    assert(metadata.format === "parquet")
+    assert(metadata.schema === "not a real schema")
+    assert(metadata.indexes.size() === 2)
+    assert(metadata.computed_indexes.size() === 0)
+    assert(metadata.exploded_field_indexes.size() === 0)
+    assert(metadata.read_options.size() === 0)
+    assert(metadata.bloom_indexes.size() === 0)
+    assert(metadata.temporal_indexes.size() === 0)
+    assert(metadata.range_indexes.size() === 0)
+    assert(metadata.auto_bloom_indexes.size() === 0)
+  }
 }

--- a/src/test/scala/dev/cjfravel/ariadne/IndexMetadataTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexMetadataTests.scala
@@ -8,6 +8,9 @@ import java.nio.file.Paths
 import java.nio.file.Files
 import collection.JavaConverters._
 
+/** Tests for [[IndexMetadata]] JSON parsing and version migration logic,
+  * verifying forward-compatible deserialization from v1 through the latest schema version.
+  */
 class IndexMetadataTests extends AnyFunSuite {
   test("v1") {
     val stream = getClass.getResourceAsStream("/index_metadata/v1.json")

--- a/src/test/scala/dev/cjfravel/ariadne/IndexPathUtilsTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexPathUtilsTests.scala
@@ -22,7 +22,9 @@ class IndexPathUtilsTests extends SparkTests with Matchers {
   test("fileListName should format correctly") {
     IndexPathUtils.fileListName("test_index") should be("[ariadne_index] test_index")
     IndexPathUtils.fileListName("my-index") should be("[ariadne_index] my-index")
-    IndexPathUtils.fileListName("") should be("[ariadne_index] ")
+    assertThrows[IllegalArgumentException] {
+      IndexPathUtils.fileListName("")
+    }
   }
 
   test("cleanFileName should handle special characters") {

--- a/src/test/scala/dev/cjfravel/ariadne/IndexPathUtilsTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexPathUtilsTests.scala
@@ -7,6 +7,9 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.types._
 import dev.cjfravel.ariadne.exceptions.IndexNotFoundException
 
+/** Tests for index path utility methods covering file list naming, special character
+  * handling in file names, path existence checks, and directory removal.
+  */
 class IndexPathUtilsTests extends SparkTests with Matchers {
 
   val basicSchema = StructType(

--- a/src/test/scala/dev/cjfravel/ariadne/IndexQueryOperationsTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexQueryOperationsTests.scala
@@ -6,6 +6,9 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.Row
 
+/** Tests for [[IndexQueryOperations]] covering `locateFiles` queries against
+  * single and multiple index values, including empty-result scenarios.
+  */
 class IndexQueryOperationsTests extends SparkTests with Matchers {
 
   val testSchema = StructType(

--- a/src/test/scala/dev/cjfravel/ariadne/IndexTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexTests.scala
@@ -158,10 +158,11 @@ class IndexTests extends SparkTests {
     assert(index.unindexedFiles.size === 0)
     index.printIndex(false)
     index.printMetadata
+    // AND semantics: Version=3 only in part1, Id=1 in both → intersection = part1 only
     assert(
       index
         .locateFiles(Map("Version" -> Array("3"), "Id" -> Array("1")))
-        .size === 2
+        .size === 1
     )
     assert(index.locateFiles(Map("Value" -> Array(4.5))).size === 1)
     assert(index.locateFiles(Map("Value" -> Array(-1))).size === 0)
@@ -193,7 +194,8 @@ class IndexTests extends SparkTests {
 
     assert(table2.join(index, Seq("Version", "Id"), "left_semi").count === 1)
     assert(table2.join(index, Seq("Version"), "fullouter").count === 4)
-    assert(table2.join(index, Seq("Version", "Id"), "fullouter").count === 8)
+    // AND semantics: intersection reads only part1 (4 rows), so fullouter = 4
+    assert(table2.join(index, Seq("Version", "Id"), "fullouter").count === 4)
     assert(
       normalizeSchema(
         table2.join(index, Seq("Version"), "left_semi").schema
@@ -202,7 +204,8 @@ class IndexTests extends SparkTests {
 
     assert(index.join(table2, Seq("Version", "Id"), "left_semi").count === 1)
     assert(index.join(table2, Seq("Version"), "fullouter").count === 4)
-    assert(index.join(table2, Seq("Version", "Id"), "fullouter").count === 8)
+    // AND semantics: intersection reads only part1 (4 rows), so fullouter = 4
+    assert(index.join(table2, Seq("Version", "Id"), "fullouter").count === 4)
     assert(
       normalizeSchema(
         index.join(table2, Seq("Version"), "left_semi").schema

--- a/src/test/scala/dev/cjfravel/ariadne/IndexTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexTests.scala
@@ -7,6 +7,9 @@ import org.apache.spark.sql.Row
 import dev.cjfravel.ariadne.Index.DataFrameOps
 import java.nio.file.Files
 
+/** Tests for the [[Index]] case class covering schema validation, index type
+  * mutual exclusivity, idempotent add operations, and configuration options.
+  */
 class IndexTests extends SparkTests {
   val table1Schema = StructType(
     Seq(

--- a/src/test/scala/dev/cjfravel/ariadne/MixedIndexIntersectionTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/MixedIndexIntersectionTests.scala
@@ -4,6 +4,9 @@ import org.scalatest.matchers.should.Matchers
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.Row
 
+/** Tests for intersection of heterogeneous index types (regular and bloom filter),
+  * verifying AND semantics when locating files across mixed index columns.
+  */
 class MixedIndexIntersectionTests extends SparkTests with Matchers {
 
   val testSchema = StructType(

--- a/src/test/scala/dev/cjfravel/ariadne/MixedIndexIntersectionTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/MixedIndexIntersectionTests.scala
@@ -1,0 +1,61 @@
+package dev.cjfravel.ariadne
+
+import org.scalatest.matchers.should.Matchers
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.Row
+
+class MixedIndexIntersectionTests extends SparkTests with Matchers {
+
+  val testSchema = StructType(
+    Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("category", StringType, nullable = false),
+      StructField("value", DoubleType, nullable = false)
+    )
+  )
+
+  test("should intersect regular and bloom indexes correctly (AND semantics)") {
+    val indexName = "mixed_index_intersect"
+    val index = Index(indexName, testSchema, "csv", Map("header" -> "true"))
+    
+    // Create dummy data
+    val _spark = spark
+    import _spark.implicits._
+    val data1 = Seq((1, "A", 10.0), (2, "B", 20.0)).toDF("id", "category", "value")
+    val data2 = Seq((3, "C", 30.0), (4, "D", 40.0)).toDF("id", "category", "value")
+    
+    val path1 = s"$tempDir/data1.csv"
+    val path2 = s"$tempDir/data2.csv"
+    
+    data1.write.option("header", "true").csv(path1)
+    data2.write.option("header", "true").csv(path2)
+    
+    index.addFile(path1, path2)
+    
+    // category as bloom index
+    index.addBloomIndex("category", 0.01)
+    // id as regular index
+    index.addIndex("id")
+    
+    index.update
+    
+    // Query: id=1 (present in path1) AND category="Z" (not present in any file)
+    // Expected: Empty set
+    // Bug: If bloom filter returns empty set (no match), it might be ignored, and regular index (id=1) returns path1.
+    
+    // We need to use locateFilesFromDataFrame logic, which is used by join() or can be called directly if we expose it or use locateFiles
+    // locateFiles maps to locateFilesFromDataFrame internally? No, locateFiles maps to locateFilesRegular usually.
+    // Let's check Index.scala locateFiles.
+    
+    val queryDf = Seq((1, "Z")).toDF("id", "category")
+    
+    // Using join to trigger locateFilesFromDataFrame
+    val result = index.join(queryDf, Seq("id", "category"), "inner")
+    
+    // If the bug exists, result will contain rows from path1 because id=1 matches path1
+    // and the bloom filter constraint (category="Z") returning 0 files is ignored.
+    
+    val rows = result.collect()
+    rows.length shouldBe 0
+  }
+}

--- a/src/test/scala/dev/cjfravel/ariadne/MultiColumnIntersectTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/MultiColumnIntersectTests.scala
@@ -1,0 +1,108 @@
+package dev.cjfravel.ariadne
+
+import org.scalatest.matchers.should.Matchers
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.Row
+
+class MultiColumnIntersectTests extends SparkTests with Matchers {
+
+  val testSchema = StructType(
+    Seq(
+      StructField("Id", IntegerType, nullable = false),
+      StructField("Version", IntegerType, nullable = false),
+      StructField("Value", DoubleType, nullable = false)
+    )
+  )
+
+  test("should intersect files when querying multiple columns") {
+    val index = Index("intersect_multi", testSchema, "csv", Map("header" -> "true"))
+
+    val path0 = resourcePath("/data/table1_part0.csv")
+    val path1 = resourcePath("/data/table1_part1.csv")
+    index.addFile(path0, path1)
+    index.addIndex("Id")
+    index.addIndex("Version")
+    index.update
+
+    // Id=4 is in part1 only. Version=1 is in both part0 and part1.
+    // Intersection should yield only part1.
+    val files = index.locateFiles(Map("Id" -> Array(4), "Version" -> Array(1)))
+    files should have size 1
+    files should contain(path1)
+  }
+
+  test("should return all files when single column matches all") {
+    val index = Index("intersect_all", testSchema, "csv", Map("header" -> "true"))
+
+    val path0 = resourcePath("/data/table1_part0.csv")
+    val path1 = resourcePath("/data/table1_part1.csv")
+    index.addFile(path0, path1)
+    index.addIndex("Id")
+    index.update
+
+    // Id=1 is in both files
+    val files = index.locateFiles(Map("Id" -> Array(1)))
+    files should have size 2
+    files should contain allOf (path0, path1)
+  }
+
+  test("should return empty when intersection is empty") {
+    val index = Index("intersect_empty", testSchema, "csv", Map("header" -> "true"))
+
+    val path0 = resourcePath("/data/table1_part0.csv")
+    val path1 = resourcePath("/data/table1_part1.csv")
+    index.addFile(path0, path1)
+    index.addIndex("Id")
+    index.addIndex("Version")
+    index.update
+
+    // Id=2 is in part0 only. Version=3 is in part1 only.
+    // Intersection is empty.
+    val files = index.locateFiles(Map("Id" -> Array(2), "Version" -> Array(3)))
+    files shouldBe empty
+  }
+
+  test("should intersect in DataFrame-based join") {
+    val index = Index("intersect_join", testSchema, "csv", Map("header" -> "true"))
+
+    val path0 = resourcePath("/data/table1_part0.csv")
+    val path1 = resourcePath("/data/table1_part1.csv")
+    index.addFile(path0, path1)
+    index.addIndex("Id")
+    index.addIndex("Version")
+    index.update
+
+    // Query for Id=4, Version=2 — both only in part1
+    val queryData = spark.createDataFrame(
+      spark.sparkContext.parallelize(Seq(Row(4, 2))),
+      StructType(Seq(
+        StructField("Id", IntegerType, nullable = false),
+        StructField("Version", IntegerType, nullable = false)
+      ))
+    )
+
+    val result = index.join(queryData, Seq("Id", "Version"), "inner")
+    val resultRows = result.collect()
+    resultRows.length should be > 0
+    // All results should come from part1 data (Id=4, Version=2, Value=9.0)
+    resultRows.foreach { row =>
+      row.getAs[Int]("Id") shouldBe 4
+      row.getAs[Int]("Version") shouldBe 2
+    }
+  }
+
+  test("should handle single column query unchanged") {
+    val index = Index("intersect_single", testSchema, "csv", Map("header" -> "true"))
+
+    val path0 = resourcePath("/data/table1_part0.csv")
+    val path1 = resourcePath("/data/table1_part1.csv")
+    index.addFile(path0, path1)
+    index.addIndex("Id")
+    index.update
+
+    // Id=4 is only in part1
+    val files = index.locateFiles(Map("Id" -> Array(4)))
+    files should have size 1
+    files should contain(path1)
+  }
+}

--- a/src/test/scala/dev/cjfravel/ariadne/MultiColumnIntersectTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/MultiColumnIntersectTests.scala
@@ -4,6 +4,9 @@ import org.scalatest.matchers.should.Matchers
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.Row
 
+/** Tests for multi-column index intersection logic, verifying that `locateFiles`
+  * correctly computes the set intersection of matching files across multiple indexed columns.
+  */
 class MultiColumnIntersectTests extends SparkTests with Matchers {
 
   val testSchema = StructType(

--- a/src/test/scala/dev/cjfravel/ariadne/MultiColumnIntersectTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/MultiColumnIntersectTests.scala
@@ -105,4 +105,47 @@ class MultiColumnIntersectTests extends SparkTests with Matchers {
     files should have size 1
     files should contain(path1)
   }
+
+  test("should return empty when one queried type returns no matches") {
+    val index = Index("intersect_empty_type", testSchema, "csv", Map("header" -> "true"))
+
+    val path0 = resourcePath("/data/table1_part0.csv")
+    val path1 = resourcePath("/data/table1_part1.csv")
+    index.addFile(path0, path1)
+
+    index.addBloomIndex("Id")
+    index.addIndex("Version")
+    index.update
+
+    // Version=1 exists in both files, but Id=999 exists in neither.
+    // With correct AND semantics across index types, the result must be empty.
+    val files = index.locateFiles(Map(
+      "Id" -> Array(999),
+      "Version" -> Array(1)
+    ))
+
+    files shouldBe empty
+  }
+
+  test("should intersect across multiple bloom columns") {
+    val index = Index("bloom_intersect_multi", testSchema, "csv", Map("header" -> "true"))
+
+    val path0 = resourcePath("/data/table1_part0.csv")
+    val path1 = resourcePath("/data/table1_part1.csv")
+    index.addFile(path0, path1)
+
+    index.addBloomIndex("Id")
+    index.addBloomIndex("Version")
+    index.update
+
+    // Id=1 is in both files. Version=3 is only in part1.
+    // AND across both bloom columns should yield only part1.
+    val files = index.locateFiles(Map(
+      "Id" -> Array(1),
+      "Version" -> Array(3)
+    ))
+
+    files should have size 1
+    files.head should include("table1_part1")
+  }
 }

--- a/src/test/scala/dev/cjfravel/ariadne/RangeIndexTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/RangeIndexTests.scala
@@ -1,0 +1,224 @@
+package dev.cjfravel.ariadne
+
+import dev.cjfravel.ariadne.exceptions.ColumnNotFoundException
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.Row
+import dev.cjfravel.ariadne.Index.DataFrameOps
+
+class RangeIndexTests extends SparkTests with Matchers {
+
+  // table1_part0.csv: Id=[1,2,3,1], Version=[1,1,1,2], Value=[5.0,3.0,4.0,4.5]
+  //   -> Id range [1,3], Version range [1,2], Value range [3.0,5.0]
+  // table1_part1.csv: Id=[4,4,3,1], Version=[1,2,2,3], Value=[2.0,9.0,4.0,5.0]
+  //   -> Id range [1,4], Version range [1,3], Value range [2.0,9.0]
+  val testSchema: StructType = StructType(
+    Seq(
+      StructField("Id", IntegerType, nullable = false),
+      StructField("Version", IntegerType, nullable = false),
+      StructField("Value", DoubleType, nullable = false)
+    )
+  )
+
+  test("should add range index") {
+    val index = Index("range_add_test", testSchema, "csv", Map("header" -> "true"))
+    index.addRangeIndex("Id")
+    index.indexes should contain("Id")
+  }
+
+  test("should be idempotent") {
+    val index = Index("range_idempotent_test", testSchema, "csv", Map("header" -> "true"))
+    index.addRangeIndex("Id")
+    index.addRangeIndex("Id")
+    index.indexes.count(_ == "Id") should be(1)
+  }
+
+  test("should store min/max per file") {
+    val index = Index("range_minmax_test", testSchema, "csv", Map("header" -> "true"))
+    val csvPath0 = resourcePath("/data/table1_part0.csv")
+    val csvPath1 = resourcePath("/data/table1_part1.csv")
+    index.addFile(csvPath0)
+    index.addFile(csvPath1)
+    index.addRangeIndex("Id")
+    index.update
+
+    // Read the index table directly
+    val indexPath = new org.apache.hadoop.fs.Path(index.storagePath, "index")
+    val df = spark.read.format("delta").load(indexPath.toString)
+    df.columns should contain("range_Id")
+
+    val rows = df.select("filename", "range_Id").collect()
+    rows.length should be(2)
+
+    rows.foreach { row =>
+      val filename = row.getString(0)
+      val rangeStruct = row.getStruct(1)
+      val minVal = rangeStruct.getInt(0)
+      val maxVal = rangeStruct.getInt(1)
+
+      if (filename.contains("part0")) {
+        minVal should be(1)
+        maxVal should be(3)
+      } else {
+        minVal should be(1)
+        maxVal should be(4)
+      }
+    }
+  }
+
+  test("should prune files by range") {
+    val index = Index("range_prune_test", testSchema, "csv", Map("header" -> "true"))
+    val csvPath0 = resourcePath("/data/table1_part0.csv")
+    val csvPath1 = resourcePath("/data/table1_part1.csv")
+    index.addFile(csvPath0)
+    index.addFile(csvPath1)
+    index.addRangeIndex("Id")
+    index.update
+
+    // Id=4 only exists in part1 (range [1,4]), part0 range is [1,3]
+    val files = index.locateFiles(Map("Id" -> Array(4)))
+    files should have size 1
+    files.head should include("part1")
+  }
+
+  test("should return all files when value in all ranges") {
+    val index = Index("range_all_files_test", testSchema, "csv", Map("header" -> "true"))
+    val csvPath0 = resourcePath("/data/table1_part0.csv")
+    val csvPath1 = resourcePath("/data/table1_part1.csv")
+    index.addFile(csvPath0)
+    index.addFile(csvPath1)
+    index.addRangeIndex("Id")
+    index.update
+
+    // Id=1 is in range for both files
+    val files = index.locateFiles(Map("Id" -> Array(1)))
+    files should have size 2
+  }
+
+  test("should handle range query with DataFrame join") {
+    val index = Index("range_join_test", testSchema, "csv", Map("header" -> "true"))
+    val csvPath0 = resourcePath("/data/table1_part0.csv")
+    val csvPath1 = resourcePath("/data/table1_part1.csv")
+    index.addFile(csvPath0)
+    index.addFile(csvPath1)
+    index.addRangeIndex("Id")
+    index.update
+
+    // Create a DataFrame with Id=4 which only appears in part1
+    val queryDf = spark.createDataFrame(
+      spark.sparkContext.parallelize(Seq(Row(4))),
+      StructType(Seq(StructField("Id", IntegerType, nullable = false)))
+    )
+
+    val result = index.join(queryDf, Seq("Id"))
+    result.count() should be > 0L
+    // Should only have rows from part1 (Id=4 data)
+    result.select("Id").distinct().collect().map(_.getInt(0)) should contain(4)
+  }
+
+  test("should enforce mutual exclusivity with regular index") {
+    val index = Index("range_excl_regular", testSchema, "csv", Map("header" -> "true"))
+    index.addIndex("Id")
+    an[IllegalArgumentException] should be thrownBy {
+      index.addRangeIndex("Id")
+    }
+  }
+
+  test("should enforce mutual exclusivity with bloom index") {
+    val index = Index("range_excl_bloom", testSchema, "csv", Map("header" -> "true"))
+    index.addBloomIndex("Id")
+    an[IllegalArgumentException] should be thrownBy {
+      index.addRangeIndex("Id")
+    }
+  }
+
+  test("should enforce mutual exclusivity - range blocks regular") {
+    val index = Index("range_blocks_regular", testSchema, "csv", Map("header" -> "true"))
+    index.addRangeIndex("Id")
+    an[IllegalArgumentException] should be thrownBy {
+      index.addIndex("Id")
+    }
+  }
+
+  test("should enforce mutual exclusivity - range blocks bloom") {
+    val index = Index("range_blocks_bloom", testSchema, "csv", Map("header" -> "true"))
+    index.addRangeIndex("Id")
+    an[IllegalArgumentException] should be thrownBy {
+      index.addBloomIndex("Id")
+    }
+  }
+
+  test("should enforce mutual exclusivity - range blocks temporal") {
+    val index = Index("range_blocks_temporal", testSchema, "csv", Map("header" -> "true"))
+    index.addRangeIndex("Id")
+    an[IllegalArgumentException] should be thrownBy {
+      index.addTemporalIndex("Id", "Version")
+    }
+  }
+
+  test("should throw ColumnNotFoundException for nonexistent column") {
+    val index = Index("range_bad_col", testSchema, "csv", Map("header" -> "true"))
+    a[ColumnNotFoundException] should be thrownBy {
+      index.addRangeIndex("NonExistent")
+    }
+  }
+
+  test("should handle metadata migration from v6") {
+    val stream = getClass.getResourceAsStream("/index_metadata/v6.json")
+    require(stream != null, "Resource not found: /index_metadata/v6.json")
+    val jsonString = new String(stream.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8)
+    val metadata = IndexMetadata(jsonString)
+    // v6 -> v7 migration should add empty range_indexes
+    metadata.range_indexes should not be null
+    metadata.range_indexes.size() should be(0)
+  }
+
+  test("should parse v7 metadata with range indexes") {
+    val stream = getClass.getResourceAsStream("/index_metadata/v7.json")
+    require(stream != null, "Resource not found: /index_metadata/v7.json")
+    val jsonString = new String(stream.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8)
+    val metadata = IndexMetadata(jsonString)
+    metadata.range_indexes.size() should be(2)
+
+    import scala.collection.JavaConverters._
+    val rangeIndexes = metadata.range_indexes.asScala.toSeq
+    rangeIndexes.map(_.column) should contain allOf ("amount", "score")
+  }
+
+  test("should backfill range index on existing files") {
+    val index = Index("range_backfill_test", testSchema, "csv", Map("header" -> "true"))
+    val csvPath0 = resourcePath("/data/table1_part0.csv")
+    val csvPath1 = resourcePath("/data/table1_part1.csv")
+    index.addFile(csvPath0)
+    index.addFile(csvPath1)
+    index.addIndex("Id")
+    index.update
+
+    // Now add range index and update again
+    index.addRangeIndex("Version")
+    index.update
+
+    val indexPath = new org.apache.hadoop.fs.Path(index.storagePath, "index")
+    val df = spark.read.format("delta").load(indexPath.toString)
+    df.columns should contain("range_Version")
+
+    // Verify range values
+    val rows = df.select("filename", "range_Version").collect()
+    rows.foreach { row =>
+      val filename = row.getString(0)
+      val rangeStruct = row.getStruct(1)
+      val minVal = rangeStruct.getInt(0)
+      val maxVal = rangeStruct.getInt(1)
+
+      if (filename.contains("part0")) {
+        minVal should be(1)
+        maxVal should be(2)
+      } else {
+        minVal should be(1)
+        maxVal should be(3)
+      }
+    }
+  }
+}

--- a/src/test/scala/dev/cjfravel/ariadne/RangeIndexTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/RangeIndexTests.scala
@@ -8,6 +8,9 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.Row
 import dev.cjfravel.ariadne.Index.DataFrameOps
 
+/** Tests for range index support covering index creation, idempotency,
+  * min/max value tracking per file, and range-based file location queries.
+  */
 class RangeIndexTests extends SparkTests with Matchers {
 
   // table1_part0.csv: Id=[1,2,3,1], Version=[1,1,1,2], Value=[5.0,3.0,4.0,4.5]

--- a/src/test/scala/dev/cjfravel/ariadne/SchemaHelperTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/SchemaHelperTests.scala
@@ -4,6 +4,7 @@ import org.apache.spark.sql.types._
 
 import org.scalatest.funsuite.AnyFunSuite
 
+/** Tests for [[SchemaHelper]] verifying field lookup in flat and nested schemas. */
 class SchemaHelperTests extends AnyFunSuite {
   val schema = StructType(
     Seq(

--- a/src/test/scala/dev/cjfravel/ariadne/SparkTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/SparkTests.scala
@@ -8,6 +8,13 @@ import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.{Files, Path}
 
+/** Base test infrastructure trait for all Ariadne Spark tests.
+  *
+  * Creates a local-mode `SparkSession` with Delta Lake extensions and a temporary
+  * directory as `spark.ariadne.storagePath`. The session is torn down after each suite.
+  *
+  * Provides `resourcePath(fileName)` to resolve test data files from `src/test/resources/`.
+  */
 trait SparkTests extends AnyFunSuite with BeforeAndAfterAll {
   implicit var spark: SparkSession = _
   var sc: SparkContext = _

--- a/src/test/scala/dev/cjfravel/ariadne/TemporalIndexTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/TemporalIndexTests.scala
@@ -8,6 +8,9 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.Row
 import dev.cjfravel.ariadne.Index.DataFrameOps
 
+/** Tests for temporal index support covering index creation, idempotency,
+  * validation of key/value columns, and temporal deduplication during joins.
+  */
 class TemporalIndexTests extends SparkTests with Matchers {
 
   // Schema with Id, Value, and UpdatedAt timestamp


### PR DESCRIPTION
## v0.0.1-alpha-45 — New Index Features, Production Hardening, and Metrics

### New Features
- **IndexCatalog** — Global index discovery (`list`, `exists`, `get`, `summary`, `remove`) and file-to-index lookup (`findIndexes`)
- **Range indexes** — Min/max pruning for ordered columns via `addRangeIndex()`
- **Exploded field indexes** — Index elements within array columns via `addExplodedFieldIndex()`
- **Auto-bloom filters** — Automatic bloom filter generation for large index columns exceeding `largeIndexLimit`
- **File size tracking** — Per-file size metrics stored in the index for data pruning insights
- **Cross-job autocompact** — `batches_since_compact` counter persisted in metadata across Spark jobs
- **Delete files** — `deleteFiles()` removes files from main, large, and staging indexes
- **Compaction & vacuum** — `compact()` (Delta OPTIMIZE) and `vacuum()` (Delta VACUUM) on all index tables
- **Multi-column intersection** — `locateFiles` uses AND semantics across all index types (regular, bloom, temporal, range, auto-bloom)

### Production Hardening (Multi-Model Review)
Analysis performed in parallel by **Claude Opus 4.6**, **Gemini 3 Pro**, and **GPT-5.1 Codex**:

#### Edge Cases & Coding Standards
- Fixed string concatenation in `stats()` — uses string interpolation with backtick-quoted column names
- Documented thread-safety limitations of SparkConf mutation in `consolidateMainStaging`, `vacuumDeltaTables`, and `deleteFiles`
- Added input validation (`require` guards) across public API methods
- Guarded all `.head`/`.last`/`.get` calls with `nonEmpty`/`isDefined` checks
- Added try-finally for resource cleanup (broadcast variables, cached DataFrames, streams)
- Documented TOCTOU race conditions and driver OOM risks with `@note` annotations

#### Logging Improvements
- Added completion/duration logging to `addFile`, `stats()`, `findIndexes()`, `appendToStaging`, `appendToLargeIndex`
- Added debug-level completion logging to all `addIndex`/`addBloomIndex`/`addComputedIndex`/`addTemporalIndex`/`addRangeIndex`/`addExplodedFieldIndex` methods
- All public mutating methods now log entry with key params and completion with duration
- Catch-log-rethrow pattern applied to lock-protected operations

#### Scaladoc Completion
- Complete scaladoc on all classes, traits, objects, and public/protected methods
- Added `@param`, `@return`, `@throws` annotations throughout
- Fixed `index()` return type documentation (`Option[DataFrame]` not `DataFrame`)
- Added scaladoc to `IndexLockException` companion object and `apply` factory
- Added recovery steps documentation to all exception classes
- Added thread-safety notes to all stateful traits and classes

#### Documentation
- Fixed README.md: updated lock usage docs, added 4 missing exceptions to reference
- Fixed ARCHITECTURE.md: 12 corrections including missing methods, fixed data flows, added IndexCatalog and SchemaHelper sections, corrected metadata field documentation

### Metadata
- Version: `0.0.1-alpha-45`
- Metadata schema version: v10 (`batches_since_compact` field)
- **236/236 tests pass** ✅
- Java 11, Scala 2.12.17, Spark 3.4.1/3.5.x, Delta 2.4.0/3.2.x
