### PR TITLE
fix: Beta bug fixes and version bump to 0.1.1-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ It works with **Parquet**, **CSV**, and **JSON** files, stores its indexes as De
 <dependency>
     <groupId>dev.cjfravel</groupId>
     <artifactId>ariadne-spark35_2.12</artifactId>
-    <version>0.1.0-beta</version>
+    <version>0.1.1-beta</version>
 </dependency>
 
 <!-- Spark 3.4 / Delta 2.4 (Azure Synapse) -->
 <dependency>
     <groupId>dev.cjfravel</groupId>
     <artifactId>ariadne-spark34_2.12</artifactId>
-    <version>0.1.0-beta</version>
+    <version>0.1.1-beta</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>dev.cjfravel</groupId>
     <artifactId>ariadne-spark${spark.suffix}_2.12</artifactId>
-    <version>0.1.0-beta</version>
+    <version>0.1.1-beta</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/scala/dev/cjfravel/ariadne/AriadneContext.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/AriadneContext.scala
@@ -116,7 +116,13 @@ trait AriadneContextUser {
   lazy val indexRepartitionCount: Option[Int] = {
     val count = spark.conf.getOption("spark.ariadne.indexRepartitionCount").flatMap { v =>
       try {
-        Some(v.toInt)
+        val parsed = v.toInt
+        if (parsed <= 0) {
+          logger.warn(s"spark.ariadne.indexRepartitionCount must be positive (got $parsed), ignoring")
+          None
+        } else {
+          Some(parsed)
+        }
       } catch {
         case e: NumberFormatException =>
           logger.warn(s"Invalid spark.ariadne.indexRepartitionCount value, ignoring: ${e.getMessage}")
@@ -240,8 +246,12 @@ trait AriadneContextUser {
         logger.warn(s"Invalid spark.ariadne.lockTimeout value, using default 1800: ${e.getMessage}")
         1800L
     }
-    logger.warn(s"lockTimeout initialized: $value")
-    value
+    val validated = if (value <= 0) {
+      logger.warn(s"spark.ariadne.lockTimeout must be positive (got $value), using default 1800")
+      1800L
+    } else value
+    logger.warn(s"lockTimeout initialized: $validated")
+    validated
   }
 
   /** Base interval in seconds between lock acquisition retries (exponential backoff applied).
@@ -255,8 +265,12 @@ trait AriadneContextUser {
         logger.warn(s"Invalid spark.ariadne.lockRetryInterval value, using default 60: ${e.getMessage}")
         60L
     }
-    logger.warn(s"lockRetryInterval initialized: $value")
-    value
+    val validated = if (value <= 0) {
+      logger.warn(s"spark.ariadne.lockRetryInterval must be positive (got $value), using default 60")
+      60L
+    } else value
+    logger.warn(s"lockRetryInterval initialized: $validated")
+    validated
   }
 
   /** Maximum total time in seconds to wait for lock acquisition before failing.

--- a/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
@@ -93,6 +93,68 @@ trait IndexBuildOperations extends BloomFilterOperations {
     */
   protected def stagingFilePath: Path = new Path(storagePath, "staging")
 
+  /** Tracks whether the exploded field column migration has already been checked. */
+  @transient private var _explodedMigrationChecked: Boolean = false
+
+  /** Migrates pre-0.1.1 indexes that stored exploded field columns under
+    * `array_column` names to the current `as_column` naming convention.
+    *
+    * Detection: reads the main index Delta table schema and checks whether any
+    * `ExplodedFieldMapping.array_column` appears as a column while the
+    * corresponding `as_column` does not. When this pattern is found, the table
+    * is rewritten with renamed columns, and any large-index directories named
+    * by `array_column` are similarly migrated.
+    *
+    * This method is idempotent and fast when no migration is needed (single
+    * schema check). It is called automatically on the first index read.
+    */
+  protected def migrateExplodedFieldColumns(): Unit = {
+    if (_explodedMigrationChecked) return
+    _explodedMigrationChecked = true
+
+    val mappings = metadata.exploded_field_indexes.asScala.toSeq
+    if (mappings.isEmpty) return
+
+    delta(indexFilePath) match {
+      case None => // No index table yet, nothing to migrate
+      case Some(dt) =>
+        val schema = dt.toDF.schema.fieldNames.toSet
+        val columnsToRename = mappings.filter { m =>
+          schema.contains(m.array_column) && !schema.contains(m.as_column)
+        }
+        if (columnsToRename.isEmpty) return
+
+        logger.warn(
+          s"Migrating exploded field columns for index '$name': " +
+            columnsToRename.map(m => s"${m.array_column} -> ${m.as_column}").mkString(", ")
+        )
+        val startTime = System.currentTimeMillis()
+
+        // Rewrite main index with renamed columns
+        var df = dt.toDF
+        columnsToRename.foreach { m =>
+          df = df.withColumnRenamed(m.array_column, m.as_column)
+        }
+        df.write
+          .format("delta")
+          .option("overwriteSchema", "true")
+          .mode("overwrite")
+          .save(indexFilePath.toString)
+
+        // Migrate large index directories
+        columnsToRename.foreach { m =>
+          val oldPath = new Path(largeIndexesFilePath, m.array_column)
+          val newPath = new Path(largeIndexesFilePath, m.as_column)
+          if (exists(oldPath) && !exists(newPath)) {
+            logger.warn(s"Renaming large index directory: ${m.array_column} -> ${m.as_column}")
+            fs.rename(oldPath, newPath)
+          }
+        }
+
+        logger.warn(s"Exploded field migration completed for index '$name' in ${System.currentTimeMillis() - startTime}ms")
+    }
+  }
+
   /** Returns the set of all storage column names across regular, computed,
     * exploded-field, and temporal index types.
     *

--- a/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
@@ -732,6 +732,7 @@ trait IndexBuildOperations extends BloomFilterOperations {
     
     val allStorageColumns = storageColumns ++ bloomStorageColumns ++ rangeStorageColumns ++ autoBloomStorageColumns
     val stagingDf = spark.read.format("delta").load(stagingFilePath.toString)
+      .dropDuplicates("filename")
     val stagingRowCount = stagingDf.count()
     logger.warn(s"Merging $stagingRowCount staged rows into main index")
     

--- a/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
@@ -104,7 +104,7 @@ trait IndexBuildOperations extends BloomFilterOperations {
   protected def storageColumns: Set[String] =
     metadata.indexes.asScala.toSet ++
       metadata.computed_indexes.keySet().asScala ++
-      metadata.exploded_field_indexes.asScala.map(_.array_column).toSet ++
+      metadata.exploded_field_indexes.asScala.map(_.as_column).toSet ++
       metadata.temporal_indexes.asScala.map(_.column).toSet
 
   /** Returns the set of range index storage column names (each prefixed with `range_`).
@@ -158,7 +158,8 @@ trait IndexBuildOperations extends BloomFilterOperations {
     // Read files with just indexed columns + filename
     val baseDf = createBaseDataFrame(files)
     val withComputedIndexes = applyComputedIndexes(baseDf)
-    val withFilename = addFilenameColumn(withComputedIndexes, files)
+    val withExplodedFields = applyExplodedFields(withComputedIndexes)
+    val withFilename = addFilenameColumn(withExplodedFields, files)
     
     // For each file, count distinct values per indexed column
     val analysisColumns = allStorageColumns.toSeq
@@ -310,7 +311,7 @@ trait IndexBuildOperations extends BloomFilterOperations {
         .select("filename", explodedField.array_column)
         .withColumn("temp_exploded", explode(col(s"${explodedField.array_column}.${explodedField.field_path}")))
         .groupBy("filename")
-        .agg(collect_set(col("temp_exploded")).alias(explodedField.array_column))
+        .agg(collect_set(col("temp_exploded")).alias(explodedField.as_column))
 
       accumDf.join(explodedDf, Seq("filename"), "full_outer")
     }
@@ -520,7 +521,7 @@ trait IndexBuildOperations extends BloomFilterOperations {
   private def autoBloomEligibleColumns: Set[String] =
     metadata.indexes.asScala.toSet ++
       metadata.computed_indexes.keySet().asScala ++
-      metadata.exploded_field_indexes.asScala.map(_.array_column).toSet
+      metadata.exploded_field_indexes.asScala.map(_.as_column).toSet
 
   /** Tracks the cached DataFrame from [[buildAutoBloomIndexes]] for deferred cleanup.
     *

--- a/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
@@ -49,7 +49,7 @@ trait IndexJoinOperations extends IndexBuildOperations {
         val explodedMapping =
           metadata.exploded_field_indexes.asScala.find(_.as_column == joinCol)
         explodedMapping match {
-          case Some(mapping) => joinCol -> mapping.array_column
+          case Some(mapping) => joinCol -> mapping.as_column
           case None          => joinCol -> joinCol
         }
       }
@@ -130,6 +130,15 @@ trait IndexJoinOperations extends IndexBuildOperations {
         columnMappings(col)
       )
     )
+
+    if (joinColumnsToUse.isEmpty) {
+      val unindexed = usingColumns.filterNot(c => storageColumnsToUse.contains(columnMappings.getOrElse(c, c)))
+      throw new IllegalArgumentException(
+        s"None of the join columns [${usingColumns.mkString(", ")}] have indexes. " +
+          s"Unindexed columns: [${unindexed.mkString(", ")}]. " +
+          "Add indexes on these columns before joining."
+      )
+    }
 
     // Get values from the user DataFrame using join column names
     val filteredValuesDf = df.select(joinColumnsToUse.map(col): _*)

--- a/src/main/scala/dev/cjfravel/ariadne/IndexLock.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexLock.scala
@@ -404,7 +404,7 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
             Source.fromInputStream(inputStream)(StandardCharsets.UTF_8)
           try {
             val jsonString = source.mkString
-            Some(gson.fromJson(jsonString, classOf[LockInfo]))
+            Option(gson.fromJson(jsonString, classOf[LockInfo]))
           } finally {
             source.close()
           }

--- a/src/main/scala/dev/cjfravel/ariadne/IndexMetadata.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexMetadata.scala
@@ -156,6 +156,10 @@ object IndexMetadata {
     if (indexMetadata == null) {
       throw new MetadataMissingOrCorruptException()
     }
+    // v0 -> v1
+    if (indexMetadata.indexes == null) {
+      indexMetadata.indexes = new util.ArrayList[String]()
+    }
     // v1 -> v2
     if (indexMetadata.computed_indexes == null) {
       indexMetadata.computed_indexes =

--- a/src/main/scala/dev/cjfravel/ariadne/IndexPathUtils.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexPathUtils.scala
@@ -67,7 +67,7 @@ object IndexPathUtils {
       implicit def spark: SparkSession = sparkSession
     }
     FileList.exists(fileListName(name))(sparkSession) || contextUser.exists(
-      new Path(contextUser.storagePath, name)
+      new Path(storagePath(sparkSession), name)
     )
   }
 
@@ -105,7 +105,7 @@ object IndexPathUtils {
     }
     val fileListRemoved = FileList.remove(fileListName(name))(sparkSession)
     val result = contextUser.delete(
-      new Path(contextUser.storagePath, name)
+      new Path(storagePath(sparkSession), name)
     ) || fileListRemoved
     val elapsed = System.currentTimeMillis() - startTime
     logger.warn(s"Successfully removed index '$name' in ${elapsed}ms")

--- a/src/main/scala/dev/cjfravel/ariadne/IndexPathUtils.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexPathUtils.scala
@@ -103,7 +103,13 @@ object IndexPathUtils {
     val contextUser = new AriadneContextUser {
       implicit def spark: SparkSession = sparkSession
     }
-    val fileListRemoved = FileList.remove(fileListName(name))(sparkSession)
+    val fileListRemoved = try {
+      FileList.remove(fileListName(name))(sparkSession)
+    } catch {
+      case e: Exception =>
+        logger.warn(s"FileList removal failed for index '$name' (continuing with directory deletion): ${e.getMessage}")
+        false
+    }
     val result = contextUser.delete(
       new Path(storagePath(sparkSession), name)
     ) || fileListRemoved

--- a/src/main/scala/dev/cjfravel/ariadne/IndexQueryOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexQueryOperations.scala
@@ -44,11 +44,15 @@ trait IndexQueryOperations extends IndexJoinOperations {
 
   /** Helper function to load the index.
     *
+    * On first call, checks for and performs any needed exploded field column
+    * migration (pre-0.1.1 indexes stored columns under `array_column` names).
+    *
     * @return
     *   `Some(DataFrame)` containing the latest version of the index,
     *   or `None` if the index Delta table does not yet exist
     */
   protected def index: Option[DataFrame] = {
+    migrateExplodedFieldColumns()
     delta(indexFilePath).map(_.toDF)
   }
 

--- a/src/main/scala/dev/cjfravel/ariadne/catalog/AriadneJoinRule.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/catalog/AriadneJoinRule.scala
@@ -193,7 +193,8 @@ class AriadneJoinRule(sparkSession: SparkSession) extends Rule[LogicalPlan] {
 
       val prunedDf = if (files.nonEmpty) {
         val rawDf = index.readFiles(files)
-        val dedupedDf = index.applyTemporalDeduplication(rawDf, ariadneJoinCols)
+        val temporalCols = index.metadata.temporal_indexes.asScala.map(_.column).toSeq
+        val dedupedDf = index.applyTemporalDeduplication(rawDf, temporalCols)
         dedupedDf.select(originalOutput.map(a => functions.col(a.name)): _*)
       } else {
         val schema = StructType(originalOutput.map(a =>

--- a/src/main/scala/dev/cjfravel/ariadne/catalog/AriadneScan.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/catalog/AriadneScan.scala
@@ -138,7 +138,7 @@ class AriadneV1Scan(
     val allFiles = FileList(fileListName).files
       .select("filename")
       .collect()
-      .map(_.getString(0))
+      .flatMap(r => Option(r.getString(0)))
       .toSet
 
     if (pushedFilters.isEmpty) {

--- a/src/test/scala/dev/cjfravel/ariadne/BugFixTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/BugFixTests.scala
@@ -179,4 +179,76 @@ class BugFixTests extends SparkTests {
     assert(IndexCatalog.exists("m11_catalog_test"),
       "IndexCatalog.exists should be true")
   }
+
+  // ---------- Migration: old array_column indexes auto-migrate to as_column ----------
+
+  test("Migration - old exploded field indexes are auto-migrated on read") {
+    val arrayTestSchema = StructType(
+      Seq(
+        StructField("event_id", StringType, nullable = false),
+        StructField(
+          "users",
+          ArrayType(
+            StructType(
+              Seq(
+                StructField("id", IntegerType, nullable = false),
+                StructField("name", StringType, nullable = false)
+              )
+            )
+          ),
+          nullable = false
+        )
+      )
+    )
+
+    val testData = spark.createDataFrame(
+      spark.sparkContext.parallelize(
+        Seq(
+          Row("e1", Array(Row(100, "Alice"), Row(101, "Bob"))),
+          Row("e2", Array(Row(102, "Charlie")))
+        )
+      ),
+      arrayTestSchema
+    )
+
+    val tempPath =
+      s"${System.getProperty("java.io.tmpdir")}/migration_test_${System.currentTimeMillis()}"
+    testData.write.mode("overwrite").parquet(tempPath)
+
+    // Create the index and configure exploded field
+    val index = Index("migration_test", arrayTestSchema, "parquet")
+    index.addFile(tempPath)
+    index.addExplodedFieldIndex("users", "id", "user_id")
+
+    // Manually build an OLD-STYLE index with array_column as storage name
+    // by directly writing a Delta table with "users" column instead of "user_id"
+    val baseDf = spark.read.parquet(tempPath)
+      .withColumn("filename", input_file_name())
+    val oldStyleIndex = baseDf
+      .select("filename", "users")
+      .withColumn("temp", explode(col("users.id")))
+      .groupBy("filename")
+      .agg(collect_set(col("temp")).alias("users"))  // OLD: stored as "users"
+
+    val indexPath = new Path(new Path(IndexPathUtils.storagePath, "migration_test"), "index")
+    oldStyleIndex.write
+      .format("delta")
+      .mode("overwrite")
+      .save(indexPath.toString)
+
+    // Verify the Delta table has "users" column (old style)
+    val beforeSchema = spark.read.format("delta").load(indexPath.toString).schema.fieldNames.toSet
+    assert(beforeSchema.contains("users"), "Pre-migration: should have 'users' column")
+    assert(!beforeSchema.contains("user_id"), "Pre-migration: should NOT have 'user_id' column")
+
+    // Now reconnect and query — migration should happen automatically
+    val index2 = Index("migration_test")
+    val files = index2.locateFiles(Map("user_id" -> Array(100)))
+    assert(files.nonEmpty, "Should find files after auto-migration")
+
+    // Verify the Delta table now has "user_id" column (new style)
+    val afterSchema = spark.read.format("delta").load(indexPath.toString).schema.fieldNames.toSet
+    assert(afterSchema.contains("user_id"), "Post-migration: should have 'user_id' column")
+    assert(!afterSchema.contains("users"), "Post-migration: should NOT have 'users' column")
+  }
 }

--- a/src/test/scala/dev/cjfravel/ariadne/BugFixTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/BugFixTests.scala
@@ -1,0 +1,182 @@
+package dev.cjfravel.ariadne
+
+import dev.cjfravel.ariadne.exceptions._
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.Row
+import org.apache.hadoop.fs.Path
+
+/** TDD tests for bugs H2, H3, H5, H7, M4, M8, M9, M10, M11
+  * identified during the beta bug audit.
+  */
+class BugFixTests extends SparkTests {
+
+  val basicSchema = StructType(
+    Seq(
+      StructField("Id", IntegerType, nullable = false),
+      StructField("Value", StringType, nullable = false)
+    )
+  )
+
+  // ---------- H2: Exploded field duplicate array_column in buildExplodedFieldIndexes ----------
+
+  test("H2 - two exploded fields from same array column should not collide during build") {
+    val arrayTestSchema = StructType(
+      Seq(
+        StructField("event_id", StringType, nullable = false),
+        StructField(
+          "users",
+          ArrayType(
+            StructType(
+              Seq(
+                StructField("id", IntegerType, nullable = false),
+                StructField("name", StringType, nullable = false)
+              )
+            )
+          ),
+          nullable = false
+        )
+      )
+    )
+
+    val testData = spark.createDataFrame(
+      spark.sparkContext.parallelize(
+        Seq(
+          Row("e1", Array(Row(100, "Alice"), Row(101, "Bob"))),
+          Row("e2", Array(Row(102, "Charlie")))
+        )
+      ),
+      arrayTestSchema
+    )
+
+    val tempPath =
+      s"${System.getProperty("java.io.tmpdir")}/h2_test_${System.currentTimeMillis()}"
+    testData.write.mode("overwrite").parquet(tempPath)
+
+    val index = Index("h2_exploded_test", arrayTestSchema, "parquet")
+    index.addFile(tempPath)
+    index.addExplodedFieldIndex("users", "id", "user_id")
+    index.addExplodedFieldIndex("users", "name", "user_name")
+
+    // This should not throw — the build should handle two fields from the same array
+    index.update
+
+    // Both columns should be queryable
+    val userIdQuery = spark.createDataFrame(
+      spark.sparkContext.parallelize(Seq(Row(100))),
+      StructType(Seq(StructField("user_id", IntegerType, nullable = false)))
+    )
+    val result = userIdQuery.join(index, Seq("user_id"))
+    assert(result.count() > 0, "Should find rows matching user_id=100")
+
+    val userNameQuery = spark.createDataFrame(
+      spark.sparkContext.parallelize(Seq(Row("Alice"))),
+      StructType(Seq(StructField("user_name", StringType, nullable = false)))
+    )
+    val nameResult = userNameQuery.join(index, Seq("user_name"))
+    assert(nameResult.count() > 0, "Should find rows matching user_name=Alice")
+  }
+
+  // ---------- H5: joinDf silently returns empty for non-indexed columns ----------
+
+  test("H5 - joinDf should warn or error when join columns have no index") {
+    val index = Index("h5_test", basicSchema, "parquet")
+    // Add a file but NO indexes — columns exist in schema but are not indexed
+    val testData = spark.createDataFrame(
+      spark.sparkContext.parallelize(Seq(Row(1, "a"), Row(2, "b"))),
+      basicSchema
+    )
+    val tempPath =
+      s"${System.getProperty("java.io.tmpdir")}/h5_test_${System.currentTimeMillis()}"
+    testData.write.mode("overwrite").parquet(tempPath)
+    index.addFile(tempPath)
+
+    val queryDf = spark.createDataFrame(
+      spark.sparkContext.parallelize(Seq(Row(1, "a"))),
+      basicSchema
+    )
+
+    // Joining on columns that exist in schema but have no index should throw
+    assertThrows[IllegalArgumentException] {
+      queryDf.join(index, Seq("Id", "Value"))
+    }
+  }
+
+  // ---------- H7: add*Index metadata mutation before writeMetadata ----------
+
+  test("H7 - addIndex should not corrupt metadata if writeMetadata fails") {
+    // We verify that if writeMetadata throws, the in-memory metadata is not
+    // left in a half-mutated state. We can test this indirectly: after a
+    // failed add, the metadata should NOT contain the column.
+    // This test would require injecting a failure, which is hard without mocks.
+    // Instead, we test the simpler invariant: metadata.indexes should match
+    // what was successfully written.
+    val index = Index("h7_test", basicSchema, "parquet")
+    index.addIndex("Id")
+    assert(index.indexes.contains("Id"))
+
+    // Verify the metadata on disk matches in-memory
+    val reloadedIndex = Index("h7_test")
+    assert(reloadedIndex.indexes.contains("Id"),
+      "Reloaded index should have 'Id' in indexes")
+  }
+
+  // ---------- M8: Overly broad IOException catch in lock acquisition ----------
+
+  test("M8 - lock IOException catch should not mask non-lock-contention errors") {
+    // Create a lock and verify it handles FileAlreadyExistsException correctly
+    // (existing behavior) vs other IOExceptions
+    val lockPath = new Path(new Path(tempDir.toUri), "m8-test-lock.json")
+    val fs = org.apache.hadoop.fs.FileSystem.get(
+      tempDir.toUri, spark.sparkContext.hadoopConfiguration)
+    if (fs.exists(lockPath)) fs.delete(lockPath, true)
+
+    val lock = IndexLock(lockPath, "m8-test")
+    // Normal acquire/release should still work
+    lock.acquire("m8-corr")
+    assert(fs.exists(lockPath))
+    lock.release("m8-corr")
+    assert(!fs.exists(lockPath))
+  }
+
+  // ---------- M9: IndexPathUtils.remove() - FileList failure prevents dir deletion ----------
+
+  test("M9 - remove should delete storage dir even if FileList.remove fails") {
+    val index = Index("m9_remove_test", basicSchema, "parquet")
+    // Create the storage directory by writing metadata
+    index.addIndex("Id")
+    assert(IndexPathUtils.exists("m9_remove_test"),
+      "Index should exist after creation")
+
+    // Remove it — should succeed even if file list doesn't exist
+    IndexPathUtils.remove("m9_remove_test")
+    assert(!IndexPathUtils.exists("m9_remove_test"),
+      "Index should be gone after remove")
+  }
+
+  // ---------- M10: cleanFileName empty result ----------
+
+  test("M10 - cleanFileName returns empty for all-special-char input") {
+    // Existing behavior: cleanFileName("___") returns ""
+    // This is expected and should remain as-is
+    assert(IndexPathUtils.cleanFileName("___") === "")
+    assert(IndexPathUtils.cleanFileName("@#$") === "")
+    // But normal filenames should work
+    assert(IndexPathUtils.cleanFileName("abc") === "abc")
+    assert(IndexPathUtils.cleanFileName("a.b") === "a_b")
+  }
+
+  // ---------- M11: AriadneCatalog.tableExists vs IndexCatalog.exists ----------
+
+  test("M11 - catalog exists should check metadata.json") {
+    // Create an index with metadata
+    val index = Index("m11_catalog_test", basicSchema, "parquet")
+    index.addIndex("Id")
+
+    // Both should report it exists
+    assert(IndexPathUtils.exists("m11_catalog_test"),
+      "IndexPathUtils.exists should be true")
+    assert(IndexCatalog.exists("m11_catalog_test"),
+      "IndexCatalog.exists should be true")
+  }
+}

--- a/src/test/scala/dev/cjfravel/ariadne/IndexBuildOperationsTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexBuildOperationsTests.scala
@@ -158,7 +158,7 @@ class IndexBuildOperationsTests extends SparkTests with Matchers {
       val priorityFiles = index.locateFiles(Map("priority_level" -> Array("high")))
       priorityFiles should not be empty
       
-      val userFiles = index.locateFiles(Map("users" -> Array(100L)))
+      val userFiles = index.locateFiles(Map("user_id" -> Array(100L)))
       userFiles should not be empty
       
     } finally {

--- a/src/test/scala/dev/cjfravel/ariadne/IndexFileOperationsTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexFileOperationsTests.scala
@@ -194,7 +194,7 @@ class IndexFileOperationsTests extends SparkTests with Matchers {
       val priorityFiles = index.locateFiles(Map("high_priority" -> Array("high")))
       priorityFiles should not be empty
       
-      val userFiles = index.locateFiles(Map("users" -> Array(101L)))
+      val userFiles = index.locateFiles(Map("user_id" -> Array(101L)))
       userFiles should not be empty
       
     } finally {

--- a/src/test/scala/dev/cjfravel/ariadne/IndexQueryOperationsTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexQueryOperationsTests.scala
@@ -101,8 +101,8 @@ class IndexQueryOperationsTests extends SparkTests with Matchers {
       index.addExplodedFieldIndex("users", "id", "user_id")
       index.update
       
-      // Query using the storage column name (not the as_column name)
-      val files = index.locateFiles(Map("users" -> Array(100L, 101L)))
+      // Query using the as_column name (storage column for exploded fields)
+      val files = index.locateFiles(Map("user_id" -> Array(100L, 101L)))
       files should not be empty
       files.exists(_.contains("query_exploded_test")) should be(true)
       
@@ -278,13 +278,13 @@ class IndexQueryOperationsTests extends SparkTests with Matchers {
       priorityFiles should not be empty
       
       // Test exploded field query
-      val userFiles = index.locateFiles(Map("users" -> Array(100L)))
+      val userFiles = index.locateFiles(Map("user_id" -> Array(100L)))
       userFiles should not be empty
       
       // Test combined query
       val combinedFiles = index.locateFiles(Map(
         "event_id" -> Array("evt1"),
-        "users" -> Array(100L)
+        "user_id" -> Array(100L)
       ))
       combinedFiles should not be empty
       

--- a/src/test/scala/dev/cjfravel/ariadne/IndexTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexTests.scala
@@ -432,14 +432,14 @@ class IndexTests extends SparkTests {
     index.update
 
     // Test that we can find files by user_id
-    val userFiles = index.locateFiles(Map("users" -> Array(100, 101)))
+    val userFiles = index.locateFiles(Map("user_id" -> Array(100, 101)))
     assert(
       userFiles.nonEmpty,
       "Should find files containing user IDs 100 or 101"
     )
 
     // Test that we can find files by tag
-    val tagFiles = index.locateFiles(Map("tags" -> Array("security")))
+    val tagFiles = index.locateFiles(Map("tag_name" -> Array("security")))
     assert(tagFiles.nonEmpty, "Should find files containing security tag")
 
     // Test join with user_id
@@ -596,7 +596,7 @@ class IndexTests extends SparkTests {
     )
 
     // Test locating files by exploded field values - use correct storage column name
-    val userIdFiles = index.locateFiles(Map("users" -> Array(100L, 101L)))
+    val userIdFiles = index.locateFiles(Map("user_id" -> Array(100L, 101L)))
     assert(
       userIdFiles.nonEmpty,
       "Should find files containing user IDs 100 or 101"


### PR DESCRIPTION
## Summary

Fixes 11 bugs identified during a multi-model beta audit (Claude Opus + GPT Codex) across all ~7,150 lines of production code. Bumps version to `0.1.1-beta`.

## Bug Fixes

### High Priority
| Bug | Description | Fix |
|-----|-------------|-----|
| **H1** | `AriadneJoinRule` temporal dedup used join columns instead of temporal columns | Use all temporal columns for deduplication |
| **H2** | Two exploded fields from the same array column caused `AMBIGUOUS_REFERENCE` during build | Storage columns now use `as_column` names instead of `array_column`; old indexes auto-migrate on first read |
| **H5** | `joinDf` silently returned empty when all join columns had no indexes | Throws `IllegalArgumentException` listing unindexed columns |
| **H8** | `readLock()` used `Some(gson.fromJson(...))` which wraps null | Changed to `Option(...)` |

### Medium Priority
| Bug | Description | Fix |
|-----|-------------|-----|
| **M1/M2** | No validation on `lockTimeout`, `lockRetryInterval`, `indexRepartitionCount` | Added positive-value validation in `AriadneContext` |
| **M3** | `IndexMetadata` migration missing null guard for `indexes` field | Added null check in migration chain |
| **M9** | `IndexPathUtils.remove()` failed if FileList didn't exist | Wrapped `FileList.remove()` in try-catch |
| **M12** | `AriadneScan` null filename from `.getString(0)` | Changed to `.flatMap(r => Option(r.getString(0)))` |

### Concurrency
| Bug | Description | Fix |
|-----|-------------|-----|
| **C1** | Staging consolidation MERGE could fail on duplicate filenames | Added `.dropDuplicates("filename")` before MERGE |
| **C2** | `IndexPathUtils.exists/remove` used wrong base path | Fixed to use `storagePath(sparkSession)` |

## Exploded Field Storage Change (H2) — Backward Compatible

**What changed**: Exploded field index columns in the Delta table are now named by `as_column` (e.g., `user_id`) instead of `array_column` (e.g., `users`). This fixes a crash when two fields are extracted from the same array column.

**Backward compatibility**: Old indexes are **automatically migrated** on first read. The migration detects old-style column names in the Delta table schema, rewrites the table with renamed columns, and renames any large-index directories. The migration is idempotent and fast when not needed (single schema check).

**API change**: `locateFiles(Map(...))` for exploded fields now uses `as_column` names (e.g., `"user_id"`) instead of `array_column` names (e.g., `"users"`). The DataFrame join API (`index.join(df, Seq("user_id"))`) is unchanged — it already used `as_column` names.

## Tests
- 270 tests pass (262 existing + 8 new in `BugFixTests.scala`)
- New tests cover H2 (exploded field collision), H5 (unindexed join validation), M9 (remove resilience), and auto-migration of old-style indexes
- Version check script validates README contains `0.1.1-beta`