### PR TITLE
Add tests to bring statement coverage above 80%

### DIFF
--- a/src/test/scala/dev/cjfravel/ariadne/IndexTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexTests.scala
@@ -676,6 +676,46 @@ class IndexTests extends SparkTests {
     )
   }
 
+  test("select restricts columns in join result") {
+    val csvOptions = Map("header" -> "true")
+    val index = Index("select_test", table1Schema, "csv", csvOptions)
+    index.addFile(resourcePath("/data/table1_part0.csv"))
+    index.addFile(resourcePath("/data/table1_part1.csv"))
+    index.addIndex("Id")
+    index.addIndex("Version")
+    index.update
+
+    val table2 = spark.read
+      .schema(table2Schema)
+      .option("header", "true")
+      .csv(resourcePath("/data/table2_part0.csv"))
+
+    // Without select — result has all table1 columns
+    val fullResult = index.join(table2, Seq("Id", "Version"), "left_semi")
+    assert(fullResult.columns.toSet === Set("Id", "Version", "Value"))
+
+    // With select("Id", "Version") — result only has selected columns
+    val selectedResult =
+      index.select("Id", "Version").join(table2, Seq("Id", "Version"), "left_semi")
+    assert(selectedResult.columns.toSet === Set("Id", "Version"))
+    assert(selectedResult.count() === fullResult.count())
+  }
+
+  test("select validates column names") {
+    val index = Index("select_validate_test", table1Schema, "csv")
+
+    // Null/empty rejected
+    intercept[IllegalArgumentException] { index.select() }
+    intercept[IllegalArgumentException] { index.select("  ") }
+
+    // Non-existent column rejected
+    intercept[ColumnNotFoundException] { index.select("NonExistent") }
+
+    // Valid column works
+    val result = index.select("Id")
+    assert(result.getSelectedColumns === Some(Seq("Id")))
+  }
+
   test("JSON format validation - requires same format") {
     val jsonSchema = StructType(
       Seq(

--- a/src/test/scala/dev/cjfravel/ariadne/catalog/AriadneCatalogTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/catalog/AriadneCatalogTests.scala
@@ -4,8 +4,10 @@ import dev.cjfravel.ariadne.{Index, IndexCatalog, SparkTests}
 import dev.cjfravel.ariadne.Index.DataFrameOps
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.functions
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.scalatest.matchers.should.Matchers
 
 import java.nio.file.{Files, Path}
@@ -614,5 +616,28 @@ class AriadneCatalogTests extends SparkTests with Matchers {
     result.columns should contain allOf ("Id", "Version", "Value")
     result.columns should not contain "IdTimes10"
     result.collect().length should be(8)
+  }
+
+  test("tableExists returns true for existing index and false for missing") {
+    createTestIndex("catalog_exists_test")
+
+    val catalog = new AriadneCatalog()
+    catalog.initialize(
+      "ariadne",
+      new CaseInsensitiveStringMap(new java.util.HashMap[String, String]())
+    )
+
+    val existsIdent =
+      Identifier.of(Array.empty[String], "catalog_exists_test")
+    catalog.tableExists(existsIdent) should be(true)
+
+    val missingIdent =
+      Identifier.of(Array.empty[String], "no_such_index")
+    catalog.tableExists(missingIdent) should be(false)
+
+    // Non-default namespace should return false
+    val nsIdent =
+      Identifier.of(Array("other_ns"), "catalog_exists_test")
+    catalog.tableExists(nsIdent) should be(false)
   }
 }


### PR DESCRIPTION
## Summary

Adds targeted tests to cross the 80% scoverage threshold.

### Changes
- **`Index.select()` tests** — Validates column projection restricts join output and validates column names (null, blank, non-existent)
- **`AriadneCatalog.tableExists()` test** — Verifies returns true for existing indexes, false for missing, and false for non-default namespace

### Coverage Impact
| Metric | Before | After |
|--------|--------|-------|
| Statement coverage | 79.48% | **80.45%** |
| Branch coverage | 71.94% | **72.92%** |
| Tests | 270 | **273** |