### PR TITLE
Add CI workflow with build, test, and code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           cache: maven
 
       - name: Build and test with coverage
-        run: mvn verify scoverage:report -P ${{ matrix.profile }} -B -q
+        run: mvn verify scoverage:report -P ${{ matrix.profile }} -Dgpg.skip=true -B -q
 
       - name: Upload coverage report
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - profile: spark34
+            name: Spark 3.4
+          - profile: spark35
+            name: Spark 3.5
+
+    name: Build & Test (${{ matrix.name }})
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 11
+          cache: maven
+
+      - name: Build and test with coverage
+        run: mvn verify scoverage:report -P ${{ matrix.profile }} -B -q
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.profile }}
+          path: target/cobertura.xml
+
+      - name: Post coverage to PR
+        if: github.event_name == 'pull_request'
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: target/cobertura.xml
+          format: markdown
+          output: both
+          badge: true
+          fail_below_min: false
+          hide_complexity: true
+          thresholds: "60 80"
+
+      - name: Prepend header to coverage report
+        if: github.event_name == 'pull_request'
+        run: |
+          sed -i '1s/^/## Code Coverage — ${{ matrix.name }}\n\n/' code-coverage-results.md
+
+      - name: Add coverage comment to PR
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: coverage-${{ matrix.profile }}
+          path: code-coverage-results.md


### PR DESCRIPTION
## Summary

Adds a GitHub Actions CI workflow that builds, tests, and reports code coverage.

### What's included

- **Matrix build** across Spark 3.4 and Spark 3.5 profiles (parallel, `fail-fast: false`)
- **Build, test & coverage** via `mvn verify scoverage:report`
- **Coverage artifact** — Cobertura XML uploaded per profile
- **PR comments** — Sticky coverage summary with badge posted per Spark profile (thresholds: 60%/80%)
- **Triggers** — Push to `main` and PRs targeting `main`
- **Java 11 + Maven caching** for fast builds