### PR TITLE
fix: migrate legacy indexes lacking the file_size column without a rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 <dependency>
     <groupId>dev.cjfravel</groupId>
     <artifactId>ariadne-spark35_2.12</artifactId>
-    <version>0.1.2-beta</version>
+    <version>0.1.3-beta</version>
 </dependency>
 ```
 

--- a/docs/users/getting-started.html
+++ b/docs/users/getting-started.html
@@ -61,11 +61,11 @@
 <pre><code class="language-xml">&lt;dependency&gt;
     &lt;groupId&gt;dev.cjfravel&lt;/groupId&gt;
     &lt;artifactId&gt;ariadne-spark35_2.12&lt;/artifactId&gt;
-    &lt;version&gt;0.1.2-beta&lt;/version&gt;
+    &lt;version&gt;0.1.3-beta&lt;/version&gt;
 &lt;/dependency&gt;</code></pre>
 
     <h3>SBT</h3>
-<pre><code class="language-scala">libraryDependencies += "dev.cjfravel" %% "ariadne-spark35" % "0.1.2-beta"</code></pre>
+<pre><code class="language-scala">libraryDependencies += "dev.cjfravel" %% "ariadne-spark35" % "0.1.3-beta"</code></pre>
 
     <div class="callout note">
       <p><strong>Scala 2.12 only.</strong> The artifact is built against Scala 2.12 to match Spark. Scala 2.13 is not supported.</p>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>dev.cjfravel</groupId>
     <artifactId>ariadne-spark${spark.suffix}_2.12</artifactId>
-    <version>0.1.2-beta</version>
+    <version>0.1.3-beta</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/scala/dev/cjfravel/ariadne/Index.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/Index.scala
@@ -897,64 +897,70 @@ case class Index private (
     val correlationId = UUID.randomUUID().toString
     lock.acquire(correlationId)
     try {
-      // Backfill file_size for existing index rows that don't have it
+      // Ensure legacy indexes have the file_size column before backfilling.
+      // Indexes created before ariadne introduced file_size (alpha-45) have no
+      // file_size column in their Delta schema at all. Delta MERGE schema
+      // evolution only adds new columns for star (updateAll/insertAll) actions,
+      // not for a named `update(Map("file_size" -> ...))`, so the column must
+      // be added explicitly first. This is a metadata-only change that sets
+      // file_size to null for all existing rows; the merge below populates it.
       delta(indexFilePath).foreach { dt =>
-        val indexDf = dt.toDF
-        if (
-          !indexDf.columns.contains("file_size") || indexDf
-            .where(col("file_size").isNull)
-            .limit(1)
-            .count() > 0
-        ) {
-          val nullSizeFiles = if (indexDf.columns.contains("file_size")) {
-            indexDf
-              .where(col("file_size").isNull)
-              .select("filename")
-              .collect()
-              .map(_.getString(0))
-              .toSet
-          } else {
-            indexDf.select("filename").collect().map(_.getString(0)).toSet
-          }
-          if (nullSizeFiles.nonEmpty) {
-            logger.warn(
-              s"Backfilling file sizes for ${nullSizeFiles.size} files"
+        if (!dt.toDF.columns.contains("file_size")) {
+          logger.warn(
+            s"Index '$name' predates file_size tracking; adding file_size column to its schema"
+          )
+          spark.sql(
+            s"ALTER TABLE delta.`${indexFilePath.toString}` ADD COLUMNS (file_size BIGINT)"
+          )
+        }
+      }
+
+      // Backfill file_size for index rows that don't have it yet. The Delta
+      // table is re-fetched here so the snapshot reflects any schema change
+      // applied above.
+      delta(indexFilePath).foreach { dt =>
+        val nullSizeFiles = dt.toDF
+          .where(col("file_size").isNull)
+          .select("filename")
+          .collect()
+          .map(_.getString(0))
+          .toSet
+        if (nullSizeFiles.nonEmpty) {
+          logger.warn(
+            s"Backfilling file sizes for ${nullSizeFiles.size} files"
+          )
+          val sizes = getFileSizes(nullSizeFiles)
+          val sizesBroadcast = spark.sparkContext.broadcast(sizes)
+          try {
+            val sizeUdf = udf((filename: String) =>
+              sizesBroadcast.value.getOrElse(filename, 0L)
             )
-            val sizes = getFileSizes(nullSizeFiles)
-            val sizesBroadcast = spark.sparkContext.broadcast(sizes)
-            try {
-              val sizeUdf = udf((filename: String) =>
-                sizesBroadcast.value.getOrElse(filename, 0L)
+
+            import spark.implicits._
+            val updateDf = nullSizeFiles.toSeq
+              .toDF("filename")
+              .withColumn("file_size", sizeUdf(col("filename")))
+
+            dt.as("target")
+              .merge(
+                updateDf.as("source"),
+                "target.filename = source.filename"
               )
+              .whenMatched()
+              .update(Map("file_size" -> col("source.file_size")))
+              .execute()
 
-              import spark.implicits._
-              val updateDf = nullSizeFiles.toSeq
-                .toDF("filename")
-                .withColumn("file_size", sizeUdf(col("filename")))
-
-              // Delta 3.2+: per-merge schema evolution; no shared session config.
-              dt.as("target")
-                .merge(
-                  updateDf.as("source"),
-                  "target.filename = source.filename"
-                )
-                .withSchemaEvolution()
-                .whenMatched()
-                .update(Map("file_size" -> col("source.file_size")))
-                .execute()
-
-              // Update total from the full index table
-              val totalResult = dt.toDF.agg(sum("file_size")).head()
-              metadata.total_indexed_file_size =
-                if (totalResult.isNullAt(0)) 0L else totalResult.getLong(0)
-              writeMetadata(metadata)
-            } finally {
-              safeDestroyBroadcast(sizesBroadcast)
-            }
-            logger.warn(
-              s"Backfilled file sizes for ${nullSizeFiles.size} files"
-            )
+            // Update total from the full index table
+            val totalResult = dt.toDF.agg(sum("file_size")).head()
+            metadata.total_indexed_file_size =
+              if (totalResult.isNullAt(0)) 0L else totalResult.getLong(0)
+            writeMetadata(metadata)
+          } finally {
+            safeDestroyBroadcast(sizesBroadcast)
           }
+          logger.warn(
+            s"Backfilled file sizes for ${nullSizeFiles.size} files"
+          )
         }
       }
 

--- a/src/test/scala/dev/cjfravel/ariadne/FileSizeTrackingTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/FileSizeTrackingTests.scala
@@ -175,4 +175,54 @@ class FileSizeTrackingTests extends SparkTests with Matchers {
     val finalMetadata = readMetadataFromDisk("filesize_backfill")
     finalMetadata.total_indexed_file_size.toLong should be > 0L
   }
+
+  test("should backfill file_size when column is absent from schema") {
+    val csvOptions = Map("header" -> "true")
+    val index = Index("filesize_absent", table1Schema, "csv", csvOptions)
+    val path0 = resourcePath("/data/table1_part0.csv")
+    val path1 = resourcePath("/data/table1_part1.csv")
+    index.addFile(path0, path1)
+    index.addIndex("Id")
+    index.update
+
+    // Capture the expected total before simulating a legacy index.
+    val originalDf =
+      spark.read.format("delta").load(indexPath("filesize_absent"))
+    originalDf.columns should contain("file_size")
+    val expectedTotal = originalDf.agg(sum("file_size")).head().getLong(0)
+    expectedTotal should be > 0L
+
+    // Simulate an alpha-45-era index by rewriting the Delta table WITHOUT the
+    // file_size column entirely (not merely null), so the column is absent from
+    // the schema. This is the real legacy migration case that requires schema
+    // evolution, which a named Delta MERGE update does not provide.
+    originalDf
+      .drop("file_size")
+      .write
+      .format("delta")
+      .option("overwriteSchema", "true")
+      .mode("overwrite")
+      .save(indexPath("filesize_absent"))
+
+    val legacyDf = spark.read.format("delta").load(indexPath("filesize_absent"))
+    legacyDf.columns should not contain "file_size"
+
+    // Reset metadata total to -1 (legacy indexes had no total_indexed_file_size).
+    val metadata = readMetadataFromDisk("filesize_absent")
+    metadata.total_indexed_file_size = -1L
+    writeMetadataToDisk("filesize_absent", metadata)
+
+    // Reload and update — must add the column and backfill without a rebuild.
+    val reloaded = Index("filesize_absent", table1Schema, "csv", csvOptions)
+    reloaded.update
+
+    val migratedDf =
+      spark.read.format("delta").load(indexPath("filesize_absent"))
+    migratedDf.columns should contain("file_size")
+    migratedDf.where(col("file_size").isNull).count() shouldBe 0L
+    migratedDf.agg(sum("file_size")).head().getLong(0) shouldBe expectedTotal
+
+    val finalMetadata = readMetadataFromDisk("filesize_absent")
+    finalMetadata.total_indexed_file_size.toLong shouldBe expectedTotal
+  }
 }


### PR DESCRIPTION
## Problem

Indexes created before ariadne introduced `file_size` tracking (`alpha-45`, #48) have **no `file_size` column in their Delta schema at all**. On `Index.update`, ariadne tries to backfill the column via a Delta `MERGE` with `withSchemaEvolution()` — but Delta only auto-adds new columns for **star** actions (`updateAll`/`insertAll`), **not** for a named `update(Map("file_size" -> ...))`. So the column is never created, and the follow-up `sum("file_size")` fails with:

```
[UNRESOLVED_COLUMN.WITH_SUGGESTION] A column ... `file_size` cannot be resolved...
```

This forces downstream consumers to drop and **fully rebuild** such indexes (e.g. a package-level `loadAndUpdateIndex` override that calls `Index.remove` then retries). The `withSchemaEvolution()` change in #56 looked like it fixed this but was incomplete — and untested for the absent-column case.

## Fix

When the `file_size` column is absent, add it explicitly via a **metadata-only** `ALTER TABLE delta.\`...\` ADD COLUMNS (file_size BIGINT)`, then re-fetch the Delta table and run the existing null-backfill. This migrates legacy indexes **in place — no rebuild required**.

## Tests

The previous backfill test only *nulled* `file_size` while keeping it in the schema, so it never exercised the real legacy case. Added a regression test (`should backfill file_size when column is absent from schema`) that removes the column entirely and verifies it is re-added, backfilled, and that the metadata total matches.

- ✅ Full suite: **278/278 pass**
- ✅ scalafmt clean

## Version

Bumped patch `0.1.2-beta` → `0.1.3-beta` (`pom.xml`, `README.md`, `docs/users/getting-started.html`).