### PR TITLE
Add scalafmt, scalafix, and scalastyle to the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
           java-version: 11
           cache: maven
 
+      - name: Check Scala formatting (scalafmt)
+        run: mvn -B validate -Dgpg.skip=true
+
       - name: Build and test with coverage
         run: mvn verify scoverage:report -Dgpg.skip=true -B -q
 

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,19 @@
+rules = [
+  RemoveUnused,
+  OrganizeImports
+]
+
+OrganizeImports {
+  groupedImports = Keep
+  coalesceToWildcardImportThreshold = 3
+  groups = [
+    "re:javax?\\.",
+    "scala.",
+    "*"
+  ]
+}
+
+triggered.rules = [
+  RemoveUnused,
+  OrganizeImports
+]

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,2 +1,29 @@
-version = "3.7.15"
+version = "3.11.1"
 runner.dialect = scala212
+
+preset=default
+maxColumn = 120
+assumeStandardLibraryStripMargin = false
+align = none
+align.openParenDefnSite = false
+align.openParenCallSite = false
+align.tokens = []
+danglingParentheses = false
+align.stripMargin = true
+indent.defnSite = 4
+danglingParentheses.defnSite = false
+danglingParentheses.callSite = false
+
+docstrings.style = Asterisk
+rewrite.rules = [RedundantBraces, RedundantParens, SortModifiers]
+rewrite.redundantBraces.stringInterpolation = true
+rewrite.redundantBraces.generalExpressions = false
+rewrite.redundantBraces.ifElseExpressions = false
+rewrite.redundantBraces.methodBodies = true
+rewrite.redundantBraces.parensForOneLineApply = true
+rewrite.redundantParens.infixSide = all
+rewrite.trailingCommas.style = never
+
+optIn.configStyleArguments = false
+newlines.forceBeforeMultilineAssign = any
+newlines.afterCurlyLambdaParams=squash

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -9,3 +9,10 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 2. **SaaS Provision**: If you use this software to provide a Software-as-a-Service (SaaS) offering, you must provide access to the source code of the modified version of the Software that you are using in your service, under the terms of this license. The access must be provided within a reasonable time, but no later than 30 days, and the access method should be publicly documented.
 
 THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+---
+
+## Third-party components
+
+This repository includes one file that is **not** covered by the license above:
+
+- **`scalastyle-config.xml`** is derived from [Apache Spark](https://github.com/apache/spark) and is licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0). The full license grant is retained in the file's header. It is a build-time static-analysis configuration and is not included in the published library artifacts.

--- a/docs/contributors/index.html
+++ b/docs/contributors/index.html
@@ -92,7 +92,7 @@
     <dl class="kv">
       <dt>Java 11</dt><dd><code>JAVA_HOME=/usr/lib/jvm/java-11-openjdk</code> or equivalent — newer JDKs are not supported by the target Spark versions.</dd>
       <dt>Maven 3.x</dt><dd>Used for build, test, packaging.</dd>
-      <dt>scalafmt</dt><dd>Required — all code must be formatted before submission (<code>runner.dialect = scala212</code>).</dd>
+      <dt>scalafmt / scalafix / scalastyle</dt><dd>Enforced by the build. Run <code>mvn scalafmt:format</code> to format; scalafix (<code>RemoveUnused</code> + <code>OrganizeImports</code>) and scalastyle (adapted from Apache Spark) run in the <code>verify</code> phase, so <code>mvn verify</code> (and CI) fail on any violation.</dd>
     </dl>
 
     <div class="callout warn">
@@ -117,7 +117,7 @@ mvn package</code></pre>
 
     <h2 id="style">Code style</h2>
     <ul>
-      <li>Format with <strong>scalafmt</strong> (<code>runner.dialect = scala212</code>).</li>
+      <li>Format with <strong>scalafmt</strong> (<code>mvn scalafmt:format</code>). Imports are organized and unused code removed by <strong>scalafix</strong> (<code>RemoveUnused</code> + <code>OrganizeImports</code>), and <strong>scalastyle</strong> (adapted from Apache Spark) enforces static checks. All three run in the build and CI, so a violation fails the build.</li>
       <li>Standard Scala naming: <code>camelCase</code> for methods/vals, <code>PascalCase</code> for types.</li>
       <li>Expression-oriented style — prefer <code>if/else</code> expressions over <code>return</code>.</li>
       <li>Use <code>import scala.collection.JavaConverters._</code> (the project is Scala 2.12; <code>CollectionConverters</code> is 2.13+).</li>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,12 @@
 
     <properties>
         <scala.version>2.12.17</scala.version>
+        <scala.binary.version>2.12</scala.binary.version>
         <scoverage.plugin.version>2.0.6</scoverage.plugin.version>
+        <mvn.scalafmt.version>1.1.1640084764.9f463a9</mvn.scalafmt.version>
+        <scalafix.plugin.version>0.1.12_0.14.6</scalafix.plugin.version>
+        <semanticdb.version>4.14.2</semanticdb.version>
+        <scalastyle.plugin.version>1.0.0</scalastyle.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <spark.suffix>35</spark.suffix>
@@ -161,6 +166,96 @@
                             <goal>testCompile</goal>
                             <goal>add-source</goal>
                             <goal>doc-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <scalaVersion>${scala.version}</scalaVersion>
+                    <args>
+                        <!-- SemanticDB for scalafix semantic rules (RemoveUnused/OrganizeImports). -->
+                        <arg>-Yrangepos</arg>
+                        <arg>-Ywarn-unused</arg>
+                    </args>
+                    <compilerPlugins>
+                        <compilerPlugin>
+                            <groupId>org.scalameta</groupId>
+                            <artifactId>semanticdb-scalac_${scala.version}</artifactId>
+                            <version>${semanticdb.version}</version>
+                        </compilerPlugin>
+                    </compilerPlugins>
+                </configuration>
+            </plugin>
+
+            <!-- scalafmt: format check bound to `validate` (fails the build if a Scala source is
+                 not formatted per .scalafmt.conf). Run `mvn scalafmt:format` to reformat. -->
+            <plugin>
+                <groupId>org.antipathy</groupId>
+                <artifactId>mvn-scalafmt_${scala.binary.version}</artifactId>
+                <version>${mvn.scalafmt.version}</version>
+                <configuration>
+                    <configLocation>${project.basedir}/.scalafmt.conf</configLocation>
+                    <skipSources>false</skipSources>
+                    <skipTestSources>false</skipTestSources>
+                    <validateOnly>false</validateOnly>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>scalafmt-check</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                        <configuration>
+                            <validateOnly>true</validateOnly>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- scalafix: lint check (RemoveUnused + OrganizeImports) bound to `verify`, after
+                 test-compile has produced SemanticDB. Run with -Dscalafix.mode=IN_PLACE to fix. -->
+            <plugin>
+                <groupId>io.github.evis</groupId>
+                <artifactId>scalafix-maven-plugin_${scala.binary.version}</artifactId>
+                <version>${scalafix.plugin.version}</version>
+                <configuration>
+                    <config>${project.basedir}/.scalafix.conf</config>
+                    <mode>CHECK</mode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>scalafix-check</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>scalafix</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- scalastyle: static style checks (adapted from Apache Spark's config, license-header
+                 rule removed) bound to `verify`; fails the build on any violation. -->
+            <plugin>
+                <groupId>org.scalastyle</groupId>
+                <artifactId>scalastyle-maven-plugin</artifactId>
+                <version>${scalastyle.plugin.version}</version>
+                <configuration>
+                    <verbose>false</verbose>
+                    <failOnViolation>true</failOnViolation>
+                    <failOnWarning>false</failOnWarning>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                    <sourceDirectory>${project.basedir}/src/main/scala</sourceDirectory>
+                    <testSourceDirectory>${project.basedir}/src/test/scala</testSourceDirectory>
+                    <configLocation>${project.basedir}/scalastyle-config.xml</configLocation>
+                    <inputEncoding>UTF-8</inputEncoding>
+                    <outputEncoding>UTF-8</outputEncoding>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>scalastyle-check</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -1,0 +1,865 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!--
+  Adapted from Apache Spark's scalastyle-config.xml (Apache License 2.0, retained above).
+  The only change from upstream is the removal of the HeaderMatchesChecker (license-header)
+  rule: this project does not require a license header on source files.
+-->
+<!--
+
+If you wish to turn off checking for a section of code, you can put a comment in the source
+before and after the section, with the following syntax:
+
+  // scalastyle:off
+  ...  // stuff that breaks the styles
+  // scalastyle:on
+
+You can also disable only one rule, by specifying its rule id, as specified in:
+  http://www.scalastyle.org/rules-0.7.0.html
+
+  // scalastyle:off no.finalize
+  override def finalize(): Unit = ...
+  // scalastyle:on no.finalize
+
+This file is divided into 3 sections:
+ (1) rules that we enforce.
+ (2) rules that we would like to enforce, but haven't cleaned up the codebase to turn on yet
+     (or we need to make the scalastyle rule more configurable).
+ (3) rules that we don't want to enforce.
+-->
+
+<scalastyle>
+  <name>Scalastyle standard configuration</name>
+
+  <!-- ================================================================================ -->
+  <!--                               rules we enforce                                   -->
+  <!-- ================================================================================ -->
+
+  <check level="error" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
+
+  <check level="error" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
+
+  <check level="error" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
+
+  <check level="error" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
+
+  <check level="error" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
+    <parameters>
+      <parameter name="maxLineLength"><![CDATA[120]]></parameter>
+      <parameter name="tabSize"><![CDATA[2]]></parameter>
+      <parameter name="ignoreImports">true</parameter>
+    </parameters>
+  </check>
+
+  <check level="error" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
+    <parameters><parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter></parameters>
+  </check>
+
+  <check level="error" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+    <parameters><parameter name="regex"><![CDATA[(config|[A-Z][A-Za-z]*)]]></parameter></parameters>
+  </check>
+
+  <check level="error" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
+    <parameters><parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter></parameters>
+  </check>
+
+  <check customId="argcount" level="error" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
+    <parameters><parameter name="maxParameters"><![CDATA[10]]></parameter></parameters>
+  </check>
+
+  <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
+
+  <check level="error" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
+
+  <check level="error" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
+
+  <check level="error" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
+
+  <!-- Brace style on if blocks is owned by scalafmt (the project uses a brace-less style); disabled
+       so the two tools don't conflict. -->
+  <check level="error" class="org.scalastyle.scalariform.IfBraceChecker" enabled="false">
+    <parameters>
+      <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
+      <parameter name="doubleLineAllowed"><![CDATA[true]]></parameter>
+    </parameters>
+  </check>
+
+  <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
+
+  <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
+
+  <!-- Non-ASCII/Unicode content is allowed in sources (e.g. in comments and string/test data),
+       so the non-ASCII rule is disabled. -->
+  <check customId="nonascii" level="error" class="org.scalastyle.scalariform.NonASCIICharacterChecker" enabled="false"></check>
+
+  <check level="error" class="org.scalastyle.scalariform.SpaceAfterCommentStartChecker" enabled="true"></check>
+
+  <check level="error" class="org.scalastyle.scalariform.EnsureSingleSpaceBeforeTokenChecker" enabled="true">
+   <parameters>
+     <parameter name="tokens">ARROW, EQUALS, ELSE, TRY, CATCH, FINALLY, LARROW, RARROW</parameter>
+   </parameters>
+  </check>
+
+  <check level="error" class="org.scalastyle.scalariform.EnsureSingleSpaceAfterTokenChecker" enabled="true">
+    <parameters>
+     <parameter name="tokens">ARROW, EQUALS, COMMA, COLON, IF, ELSE, DO, WHILE, FOR, MATCH, TRY, CATCH, FINALLY, LARROW, RARROW</parameter>
+    </parameters>
+  </check>
+
+  <!-- ??? usually shouldn't be checked into the code base. -->
+  <check level="error" class="org.scalastyle.scalariform.NotImplementedErrorUsage" enabled="true"></check>
+
+  <!-- Disabled: org.apache.spark.SparkFunSuite is Spark-internal (not published for external use),
+       so this project's tests extend ScalaTest's AnyFunSuite directly. -->
+  <check customId="funsuite" level="error" class="org.scalastyle.scalariform.TokenChecker" enabled="false">
+    <parameters><parameter name="regex">^AnyFunSuite[A-Za-z]*$</parameter></parameters>
+    <customMessage>Tests must extend org.apache.spark.SparkFunSuite instead.</customMessage>
+  </check>
+
+  <!-- As of SPARK-7977 all printlns need to be wrapped in '// scalastyle:off/on println' -->
+  <check customId="println" level="error" class="org.scalastyle.scalariform.TokenChecker" enabled="true">
+    <parameters><parameter name="regex">^println$</parameter></parameters>
+    <customMessage><![CDATA[Are you sure you want to println? If yes, wrap the code block with
+      // scalastyle:off println
+      println(...)
+      // scalastyle:on println]]></customMessage>
+  </check>
+
+  <check customId="invalidMDC" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">s".*\$\{MDC\(</parameter></parameters>
+    <customMessage><![CDATA[MDC should be used in string interpolation log"..." instead of s"..."]]></customMessage>
+  </check>
+
+  <!-- Disabled: sparkContext.hadoopConfiguration is the supported public API for an external Spark
+       library; the suggested spark.sessionState.newHadoopConf() is a Spark-internal API. -->
+  <check customId="hadoopconfiguration" level="error" class="org.scalastyle.file.RegexChecker" enabled="false">
+    <parameters><parameter name="regex">spark(.sqlContext)?.sparkContext.hadoopConfiguration</parameter></parameters>
+    <customMessage><![CDATA[
+      Are you sure that you want to use sparkContext.hadoopConfiguration? In most cases, you should use
+      spark.sessionState.newHadoopConf() instead, so that the hadoop configurations specified in Spark session
+      configuration will come into effect.
+      If you must use sparkContext.hadoopConfiguration, wrap the code block with
+      // scalastyle:off hadoopconfiguration
+      spark.sparkContext.hadoopConfiguration...
+      // scalastyle:on hadoopconfiguration
+    ]]></customMessage>
+  </check>
+
+  <check customId="visiblefortesting" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">@VisibleForTesting</parameter></parameters>
+    <customMessage><![CDATA[
+      @VisibleForTesting causes classpath issues. Please note this in the java doc instead (SPARK-11615).
+    ]]></customMessage>
+  </check>
+
+  <check customId="runtimeaddshutdownhook" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">Runtime\.getRuntime\.addShutdownHook</parameter></parameters>
+    <customMessage><![CDATA[
+      Are you sure that you want to use Runtime.getRuntime.addShutdownHook? In most cases, you should use
+      ShutdownHookManager.addShutdownHook instead.
+      If you must use Runtime.getRuntime.addShutdownHook, wrap the code block with
+      // scalastyle:off runtimeaddshutdownhook
+      Runtime.getRuntime.addShutdownHook(...)
+      // scalastyle:on runtimeaddshutdownhook
+    ]]></customMessage>
+  </check>
+
+  <check customId="mutablesynchronizedbuffer" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">mutable\.SynchronizedBuffer</parameter></parameters>
+    <customMessage><![CDATA[
+      Are you sure that you want to use mutable.SynchronizedBuffer? In most cases, you should use
+      java.util.concurrent.ConcurrentLinkedQueue instead.
+      If you must use mutable.SynchronizedBuffer, wrap the code block with
+      // scalastyle:off mutablesynchronizedbuffer
+      mutable.SynchronizedBuffer[...]
+      // scalastyle:on mutablesynchronizedbuffer
+    ]]></customMessage>
+  </check>
+
+  <check customId="classforname" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">Class\.forName</parameter></parameters>
+    <customMessage><![CDATA[
+      Are you sure that you want to use Class.forName? In most cases, you should use Utils.classForName instead.
+      If you must use Class.forName, wrap the code block with
+      // scalastyle:off classforname
+      Class.forName(...)
+      // scalastyle:on classforname
+    ]]></customMessage>
+  </check>
+
+  <check customId="awaitresult" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">Await\.result</parameter></parameters>
+    <customMessage><![CDATA[
+      Are you sure that you want to use Await.result? In most cases, you should use ThreadUtils.awaitResult instead.
+      If you must use Await.result, wrap the code block with
+      // scalastyle:off awaitresult
+      Await.result(...)
+      // scalastyle:on awaitresult
+    ]]></customMessage>
+  </check>
+
+  <check customId="awaitready" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">Await\.ready</parameter></parameters>
+    <customMessage><![CDATA[
+      Are you sure that you want to use Await.ready? In most cases, you should use ThreadUtils.awaitReady instead.
+      If you must use Await.ready, wrap the code block with
+      // scalastyle:off awaitready
+      Await.ready(...)
+      // scalastyle:on awaitready
+    ]]></customMessage>
+  </check>
+
+  <check customId="parvector" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">new.*ParVector</parameter></parameters>
+    <customMessage><![CDATA[
+      Are you sure you want to create a ParVector? It will not automatically propagate Spark ThreadLocals or the
+      active SparkSession for the submitted tasks. In most cases, you should use ThreadUtils.parmap instead.
+      If you must use ParVector, then wrap your creation of the ParVector with
+      // scalastyle:off parvector
+      ...ParVector...
+      // scalastyle:on parvector
+    ]]></customMessage>
+  </check>
+
+  <check customId="caselocale" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">(\.toUpperCase|\.toLowerCase)(?!(\(|\(Locale.ROOT\)))</parameter></parameters>
+    <customMessage><![CDATA[
+      Are you sure that you want to use toUpperCase or toLowerCase without the root locale? In most cases, you
+      should use toUpperCase(Locale.ROOT) or toLowerCase(Locale.ROOT) instead.
+      If you must use toUpperCase or toLowerCase without the root locale, wrap the code block with
+      // scalastyle:off caselocale
+      .toUpperCase
+      .toLowerCase
+      // scalastyle:on caselocale
+    ]]></customMessage>
+  </check>
+
+  <check customId="throwerror" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">throw new \w+Error\(</parameter></parameters>
+    <customMessage><![CDATA[
+      Are you sure that you want to throw Error? In most cases, you should use appropriate Exception instead.
+      If you must throw Error, wrap the code block with
+      // scalastyle:off throwerror
+      throw new XXXError(...)
+      // scalastyle:on throwerror
+    ]]></customMessage>
+  </check>
+
+  <!-- As of SPARK-45338 JavaConversions should be replaced with CollectionConverters -->
+  <check customId="javaconversions" level="error" class="org.scalastyle.scalariform.TokenChecker" enabled="true">
+    <parameters><parameter name="regex">JavaConversions</parameter></parameters>
+    <customMessage>Instead of importing implicits in scala.collection.JavaConversions._, import
+      scala.jdk.CollectionConverters._ and use .asScala / .asJava methods</customMessage>
+  </check>
+
+  <!-- scala.jdk.CollectionConverters is Scala 2.13+; on Scala 2.12 scala.collection.JavaConverters
+       is the correct API, so this rule is disabled. -->
+  <check customId="javaconverters" level="error" class="org.scalastyle.scalariform.TokenChecker" enabled="false">
+    <parameters><parameter name="regex">JavaConverters</parameter></parameters>
+    <customMessage>Instead of importing implicits in scala.collection.JavaConverters._, import
+      scala.jdk.CollectionConverters._ and use .asScala / .asJava methods</customMessage>
+  </check>
+
+  <check customId="createParentDirs" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFiles\.createParentDirs\b</parameter></parameters>
+    <customMessage>Use createParentDirs of SparkFileUtils or Utils instead.</customMessage>
+  </check>
+
+  <check customId="filesequal" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFiles\.equal\b</parameter></parameters>
+    <customMessage>Use contentEquals of SparkFileUtils or Utils instead.</customMessage>
+  </check>
+
+  <check customId="toByteArray" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFiles\.toByteArray\b</parameter></parameters>
+    <customMessage>Use java.nio.file.Files.readAllBytes instead.</customMessage>
+  </check>
+
+  <check customId="asByteSource" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFiles\.asByteSource\b</parameter></parameters>
+    <customMessage>Use java.nio.file.Files.newInputStream instead.</customMessage>
+  </check>
+
+  <check customId="getTempDirectory" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.getTempDirectory\b</parameter></parameters>
+    <customMessage>Use System.getProperty instead.</customMessage>
+  </check>
+
+  <check customId="readLines" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.readLines\b</parameter></parameters>
+    <customMessage>Use Files.readAllLines instead.</customMessage>
+  </check>
+
+  <check customId="filesreadLines" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFiles\.readLines\b</parameter></parameters>
+    <customMessage>Use Files.readAllLines instead.</customMessage>
+  </check>
+
+  <check customId="readFileToString" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.readFileToString\b</parameter></parameters>
+    <customMessage>Use Files.readString instead.</customMessage>
+  </check>
+
+  <check customId="asCharSource" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFiles\.asCharSource\b</parameter></parameters>
+    <customMessage>Use Files.readString instead.</customMessage>
+  </check>
+
+  <check customId="write" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.write\b</parameter></parameters>
+    <customMessage>Use Files.writeString instead.</customMessage>
+  </check>
+
+  <check customId="asCharSink" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFiles\.asCharSink\b</parameter></parameters>
+    <customMessage>Use Files.writeString instead.</customMessage>
+  </check>
+
+  <check customId="writeLines" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.writeLines\b</parameter></parameters>
+    <customMessage>Use Files.write instead.</customMessage>
+  </check>
+
+  <check customId="cleanDirectory" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.cleanDirectory\b</parameter></parameters>
+    <customMessage>Use cleanDirectory of JavaUtils/SparkFileUtils/Utils</customMessage>
+  </check>
+
+  <check customId="deleteRecursively" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.deleteDirectory\b</parameter></parameters>
+    <customMessage>Use deleteRecursively of JavaUtils/SparkFileUtils/Utils</customMessage>
+  </check>
+
+  <check customId="forceDelete" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.forceDelete\b</parameter></parameters>
+    <customMessage>Use deleteRecursively of JavaUtils/SparkFileUtils/Utils</customMessage>
+  </check>
+
+  <check customId="forceDeleteOnExit" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.forceDeleteOnExit\b</parameter></parameters>
+    <customMessage>Use forceDeleteOnExit of JavaUtils/SparkFileUtils/Utils instead.</customMessage>
+  </check>
+
+  <check customId="deleteQuietly" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.deleteQuietly\b</parameter></parameters>
+    <customMessage>Use deleteQuietly of JavaUtils/SparkFileUtils/Utils</customMessage>
+  </check>
+
+  <check customId="readFileToByteArray" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.readFileToByteArray\b</parameter></parameters>
+    <customMessage>Use java.nio.file.Files.readAllBytes</customMessage>
+  </check>
+
+  <check customId="sizeOf" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.sizeOf(Directory)?\b</parameter></parameters>
+    <customMessage>Use sizeOf of JavaUtils or Utils instead.</customMessage>
+  </check>
+
+  <check customId="moveFile" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.moveFile\b</parameter></parameters>
+    <customMessage>Use copyFile of JavaUtils/SparkFileUtils/Utils instead.</customMessage>
+  </check>
+
+  <check customId="copyURLToFile" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.copyURLToFile\b</parameter></parameters>
+    <customMessage>Use copyURLToFile of JavaUtils instead.</customMessage>
+  </check>
+
+  <check customId="copyFile" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.copyFile\b</parameter></parameters>
+    <customMessage>Use copyFile of SparkFileUtils or Utils instead.</customMessage>
+  </check>
+
+  <check customId="copyFileToDirectory" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.copyFileToDirectory\b</parameter></parameters>
+    <customMessage>Use copyFileToDirectory of SparkFileUtils or Utils instead.</customMessage>
+  </check>
+
+  <check customId="copyDirectory" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.copyDirectory\b</parameter></parameters>
+    <customMessage>Use copyDirectory of JavaUtils/SparkFileUtils/Utils instead.</customMessage>
+  </check>
+
+  <check customId="moveDirectory" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.moveDirectory\b</parameter></parameters>
+    <customMessage>Use copyDirectory of SparkFileUtils or Utils instead.</customMessage>
+  </check>
+
+  <check customId="contentEquals" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.contentEquals\b</parameter></parameters>
+    <customMessage>Use contentEquals of SparkFileUtils or Utils instead.</customMessage>
+  </check>
+
+  <check customId="commonscompresscompressors" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">org\.apache\.commons\.compress\.compressors\b</parameter></parameters>
+    <customMessage>Use Java API instead</customMessage>
+  </check>
+
+  <check customId="commonslang2" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">org\.apache\.commons\.lang\.</parameter></parameters>
+    <customMessage>Use Commons Lang 3 classes (package org.apache.commons.lang3.*) instead
+    of Commons Lang 2 (package org.apache.commons.lang.*)</customMessage>
+  </check>
+
+  <check customId="getFile" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.getFile\b</parameter></parameters>
+    <customMessage>Use getFile of SparkFileUtil or Utils instead.</customMessage>
+  </check>
+
+  <check customId="touch" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.touch\b</parameter></parameters>
+    <customMessage>Use touch of SparkFileUtil or Utils instead.</customMessage>
+  </check>
+
+  <check customId="filestouch" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFiles\.touch\b</parameter></parameters>
+    <customMessage>Use touch of SparkFileUtil or Utils instead.</customMessage>
+  </check>
+
+  <check customId="writeStringToFile" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.writeStringToFile\b</parameter></parameters>
+    <customMessage>Use java.nio.file.Files.writeString instead.</customMessage>
+  </check>
+
+  <check customId="listFiles" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.listFiles\b</parameter></parameters>
+    <customMessage>Use listFiles of SparkFileUtil or Utils instead.</customMessage>
+  </check>
+
+  <check customId="commonscodecbase64" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">org\.apache\.commons\.codec\.binary\.Base64\b</parameter></parameters>
+    <customMessage>Use java.util.Base64 instead</customMessage>
+  </check>
+
+  <check customId="commonslang3javaversion" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">org\.apache\.commons\.lang3\..*JavaVersion</parameter></parameters>
+    <customMessage>Use JEP 223 API (java.lang.Runtime.Version) instead of
+      Commons Lang 3 JavaVersion (org.apache.commons.lang3.JavaVersion)</customMessage>
+  </check>
+
+  <check customId="commonslang3tuple" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">org\.apache\.commons\.lang3\.tuple</parameter></parameters>
+    <customMessage>Use org.apache.spark.util.Pair instead</customMessage>
+  </check>
+
+  <check customId="commonslang3tostringbuilder" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">org\.apache\.commons\.lang3\.builder\.ToStringBuilder</parameter></parameters>
+    <customMessage>Use String concatenation instead</customMessage>
+  </check>
+
+  <check customId="commonslang3pad" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bStringUtils\.(left|right)Pad\b</parameter></parameters>
+    <customMessage>Use (left|right)Pad of SparkStringUtils or Utils instead</customMessage>
+  </check>
+
+  <check customId="commonslang3split" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bStringUtils\.split\b</parameter></parameters>
+    <customMessage>Use Utils.stringToSeq instead</customMessage>
+  </check>
+
+  <check customId="commonslang3isblankorempty" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bStringUtils\.is(Not)?(Blank|Empty)\b</parameter></parameters>
+    <customMessage>Use Utils.is(Not)?(Blank|Empty) instead</customMessage>
+  </check>
+
+  <check customId="commonslang3getrootcause" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bExceptionUtils\.getRootCause\b</parameter></parameters>
+    <customMessage>Use getRootCause of SparkErrorUtils or Utils instead</customMessage>
+  </check>
+
+  <check customId="commonslang3getstacktrace" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bExceptionUtils\.getStackTrace\b</parameter></parameters>
+    <customMessage>Use stackTraceToString of JavaUtils/SparkFileUtils/Utils instead.</customMessage>
+  </check>
+
+  <check customId="commonslang3strings" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">org\.apache\.commons\.lang3\.Strings\b</parameter></parameters>
+    <customMessage>Use Java String methods instead</customMessage>
+  </check>
+
+  <check customId="commonslang3strip" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bStringUtils\.strip\b</parameter></parameters>
+    <customMessage>Use Utils.strip method instead</customMessage>
+  </check>
+
+  <check customId="encodeHexString" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bHex\.encodeHexString\b</parameter></parameters>
+    <customMessage>Use java.util.HexFormat instead</customMessage>
+  </check>
+
+  <check customId="commonsiofileutils" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">org\.apache\.commons\.io\.FileUtils\b</parameter></parameters>
+    <customMessage>Use Java API or Spark's JavaUtils/SparkSystemUtils/Utils instead</customMessage>
+  </check>
+
+  <check customId="commonslang3stringutils" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">org\.apache\.commons\.lang3\.StringUtils\b</parameter></parameters>
+    <customMessage>Use Java String or Spark's Utils/JavaUtils methods instead</customMessage>
+  </check>
+
+  <check customId="commonslang3systemutils" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">org\.apache\.commons\.lang3\.SystemUtils\b</parameter></parameters>
+    <customMessage>Use SparkSystemUtils or Utils instead</customMessage>
+  </check>
+
+  <check customId="commonstextstringsubstitutor" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">org\.apache\.commons\.text\.StringSubstitutor\b</parameter></parameters>
+    <customMessage>Use org.apache.spark.StringSubstitutor instead</customMessage>
+  </check>
+
+  <check customId="commonslang3abbreviate" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bStringUtils\.abbreviate\b</parameter></parameters>
+    <customMessage>Use Utils.abbreviate method instead</customMessage>
+  </check>
+
+  <check customId="commonslang3substring" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bStringUtils\.substring\b</parameter></parameters>
+    <customMessage>Use Java String.substring instead.</customMessage>
+  </check>
+
+  <check customId="hadoopstringifyexception" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bStringUtils\.stringifyException\b</parameter></parameters>
+    <customMessage>Use org.apache.spark.util.Utils.stringifyException instead.</customMessage>
+  </check>
+
+  <check customId="uribuilder" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bUriBuilder\.fromUri\b</parameter></parameters>
+    <customMessage>Use Utils.getUriBuilder instead.</customMessage>
+  </check>
+
+  <check customId="executioncontextglobal" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">scala\.concurrent\.ExecutionContext\.Implicits\.global</parameter></parameters>
+    <customMessage> User queries can use global thread pool, causing starvation and eventual OOM.
+      Thus, Spark-internal APIs should not use this thread pool</customMessage>
+  </check>
+
+  <check customId="FileSystemGet" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileSystem\.get\([a-zA-Z_$][a-zA-Z_$0-9]*\)</parameter></parameters>
+    <customMessage><![CDATA[
+      Are you sure that you want to use "FileSystem.get(Configuration conf)"? If the input
+      configuration is not set properly, a default FileSystem instance will be returned. It can
+      lead to errors when you deal with multiple file systems. Please consider using
+      "FileSystem.get(URI uri, Configuration conf)" or "Path.getFileSystem(Configuration conf)" instead.
+      If you must use the method "FileSystem.get(Configuration conf)", wrap the code block with
+      // scalastyle:off FileSystemGet
+      FileSystem.get(...)
+      // scalastyle:on FileSystemGet
+    ]]></customMessage>
+  </check>
+
+  <!-- json4s-specific rule; disabled so it does not false-match project identifiers that contain
+       the `extractOpt` substring. -->
+  <check customId="extractopt" level="error" class="org.scalastyle.scalariform.TokenChecker" enabled="false">
+    <parameters><parameter name="regex">extractOpt</parameter></parameters>
+    <customMessage>Use jsonOption(x).map(.extract[T]) instead of .extractOpt[T], as the latter
+    is slower.  </customMessage>
+  </check>
+
+  <!-- Import organization is owned by scalafix (OrganizeImports in .scalafix.conf); disable the
+       scalastyle import-order rule so the two tools don't enforce conflicting orderings. -->
+  <check level="error" class="org.scalastyle.scalariform.ImportOrderChecker" enabled="false">
+    <parameters>
+      <parameter name="groups">java,scala,3rdParty,spark</parameter>
+      <parameter name="group.java">javax?\..*</parameter>
+      <parameter name="group.scala">scala\..*</parameter>
+      <parameter name="group.3rdParty">(?!(javax?\.|scala\.|org\.apache\.spark\.)).*</parameter>
+      <parameter name="group.spark">org\.apache\.spark\..*</parameter>
+    </parameters>
+  </check>
+
+  <check level="error" class="org.scalastyle.scalariform.DisallowSpaceBeforeTokenChecker" enabled="true">
+    <parameters>
+      <parameter name="tokens">COMMA</parameter>
+    </parameters>
+  </check>
+
+  <!-- SPARK-3854: Single Space between ')' and '{' -->
+  <check customId="SingleSpaceBetweenRParenAndLCurlyBrace" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\)\{</parameter></parameters>
+    <customMessage><![CDATA[
+      Single Space between ')' and `{`.
+    ]]></customMessage>
+  </check>
+
+  <check customId="NoScalaDoc" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">(?m)^(\s*)/[*][*].*$(\r|)\n^\1  [*]</parameter></parameters>
+    <customMessage>Use Javadoc style indentation for multiline comments</customMessage>
+  </check>
+
+  <check customId="OmitBracesInCase" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">case[^\n>]*=>\s*\{</parameter></parameters>
+    <customMessage>Omit braces in case clauses.</customMessage>
+  </check>
+
+  <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">new (java\.lang\.)?(Byte|Integer|Long|Short)\(</parameter></parameters>
+    <customMessage>Use static factory 'valueOf' or 'parseXXX' instead of the deprecated constructors.</customMessage>
+  </check>
+
+  <!-- SPARK-16877: Avoid Java annotations -->
+  <check level="error" class="org.scalastyle.scalariform.OverrideJavaChecker" enabled="true"></check>
+
+  <check level="error" class="org.scalastyle.scalariform.DeprecatedJavaChecker" enabled="true"></check>
+
+  <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
+    <parameters><parameter name="illegalImports"><![CDATA[collection]]></parameter></parameters>
+    <customMessage>Please use scala.collection instead.</customMessage>
+  </check>
+
+  <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
+    <parameters><parameter name="illegalImports"><![CDATA[org.apache.log4j]]></parameter></parameters>
+    <customMessage>Please use Apache Log4j 2 instead.</customMessage>
+  </check>
+
+  <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
+    <parameters><parameter name="illegalImports"><![CDATA[org.apache.commons.codec.digest]]></parameter></parameters>
+    <customMessage>Please use org.apache.spark.network.util.JavaUtils.digestToHexString instead.</customMessage>
+  </check>
+
+
+  <!-- ================================================================================ -->
+  <!--       rules we'd like to enforce, but haven't cleaned up the codebase yet        -->
+  <!-- ================================================================================ -->
+
+  <!-- We cannot turn the following two on, because it'd fail a lot of string interpolation use cases. -->
+  <!-- Ideally the following two rules should be configurable to rule out string interpolation. -->
+  <check level="error" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="false"></check>
+  <check level="error" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="false"></check>
+
+  <!-- This breaks symbolic method names so we don't turn it on. -->
+  <!-- Maybe we should update it to allow basic symbolic names, and then we are good to go. -->
+  <check level="error" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="false">
+    <parameters>
+    <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
+    </parameters>
+  </check>
+
+  <!-- Should turn this on, but we have a few places that need to be fixed first -->
+  <check level="error" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
+
+  <!-- ================================================================================ -->
+  <!--                               rules we don't want                                -->
+  <!-- ================================================================================ -->
+
+  <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="false">
+    <parameters><parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter></parameters>
+  </check>
+
+  <!-- We want the opposite of this: NewLineAtEofChecker -->
+  <check level="error" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+
+  <!-- This one complains about all kinds of random things. Disable. -->
+  <check level="error" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="false"></check>
+
+  <!-- We use return quite a bit for control flows and guards -->
+  <check level="error" class="org.scalastyle.scalariform.ReturnChecker" enabled="false"></check>
+
+  <!-- We use null a lot in low level code and to interface with 3rd party code -->
+  <check level="error" class="org.scalastyle.scalariform.NullChecker" enabled="false"></check>
+
+  <!-- Doesn't seem super big deal here ... -->
+  <check level="error" class="org.scalastyle.scalariform.NoCloneChecker" enabled="false"></check>
+
+  <!-- Doesn't seem super big deal here ... -->
+  <check level="error" class="org.scalastyle.file.FileLengthChecker" enabled="false">
+    <parameters><parameter name="maxFileLength">800></parameter></parameters>
+  </check>
+
+  <!-- Doesn't seem super big deal here ... -->
+  <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="false">
+    <parameters><parameter name="maxTypes">30</parameter></parameters>
+  </check>
+
+  <!-- Doesn't seem super big deal here ... -->
+  <check level="error" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="false">
+    <parameters><parameter name="maximum">10</parameter></parameters>
+  </check>
+
+  <!-- Doesn't seem super big deal here ... -->
+  <check level="error" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="false">
+    <parameters><parameter name="maxLength">50</parameter></parameters>
+  </check>
+
+  <!-- Not exactly feasible to enforce this right now. -->
+  <!-- It is also infrequent that somebody introduces a new class with a lot of methods. -->
+  <check level="error" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="false">
+    <parameters><parameter name="maxMethods"><![CDATA[30]]></parameter></parameters>
+  </check>
+
+  <!-- Doesn't seem super big deal here, and we have a lot of magic numbers ... -->
+  <check level="error" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="false">
+    <parameters><parameter name="ignore">-1,0,1,2,3</parameter></parameters>
+  </check>
+
+  <check customId="byteCountToDisplaySize" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bbyteCountToDisplaySize\b</parameter></parameters>
+    <customMessage>Use Utils.bytesToString instead of byteCountToDisplaySize for consistency.</customMessage>
+  </check>
+
+  <check customId="pathfromuri" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">new Path\(new URI\(</parameter></parameters>
+    <customMessage><![CDATA[
+      Are you sure that this string is uri encoded? Please be careful when converting hadoop Paths
+      and URIs to and from String. If possible, please use SparkPath.
+    ]]></customMessage>
+  </check>
+
+  <check customId="URLConstructor" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">new URL\(</parameter></parameters>
+    <customMessage>Use URI.toURL or URL.of instead of URL constructors.</customMessage>
+  </check>
+
+  <check customId="configName" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">buildConf\("spark.databricks.</parameter></parameters>
+    <customMessage>Use Apache Spark config namespace.</customMessage>
+  </check>
+
+  <check customId="googleStrings" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">com\.google\.common\.base\.Strings\b</parameter></parameters>
+    <customMessage>Use Java built-in methods or SparkStringUtils instead</customMessage>
+  </check>
+
+  <check customId="hadoopioutils" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">org\.apache\.hadoop\.io\.IOUtils\b</parameter></parameters>
+    <customMessage>Use org.apache.spark.util.Utils instead.</customMessage>
+  </check>
+
+  <check customId="defaultCharset" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">Charset\.defaultCharset</parameter></parameters>
+    <customMessage>Use StandardCharsets.UTF_8 instead.</customMessage>
+  </check>
+
+  <check customId="ioutilstobytearray" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bIOUtils\.toByteArray\b</parameter></parameters>
+    <customMessage>Use Java readAllBytes instead.</customMessage>
+  </check>
+
+  <check customId="ioutilsclosequietly" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bIOUtils\.closeQuietly\b</parameter></parameters>
+    <customMessage>Use closeQuietly of SparkErrorUtils or Utils instead.</customMessage>
+  </check>
+
+  <check customId="ioutilscopy" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bIOUtils\.copy\b</parameter></parameters>
+    <customMessage>Use Java transferTo instead.</customMessage>
+  </check>
+
+  <check customId="ioutilstostring" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bIOUtils\.toString\b</parameter></parameters>
+    <customMessage>Use toString of SparkStreamUtils or Utils instead.</customMessage>
+  </check>
+
+  <check customId="charstreamstostring" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bCharStreams\.toString\b</parameter></parameters>
+    <customMessage>Use toString of SparkStreamUtils or Utils instead.</customMessage>
+  </check>
+
+  <check customId="ioutilswrite" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bIOUtils\.write\b</parameter></parameters>
+    <customMessage>Use Java `write` instead.</customMessage>
+  </check>
+
+  <check customId="bytestreamsread" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bByteStreams\.read\b</parameter></parameters>
+    <customMessage>Use Java readNBytes instead.</customMessage>
+  </check>
+
+  <check customId="bytestreamscopy" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bByteStreams\.copy\b</parameter></parameters>
+    <customMessage>Use Java transferTo instead.</customMessage>
+  </check>
+
+  <check customId="skipFully" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bByteStreams\.skipFully\b</parameter></parameters>
+    <customMessage>Use Java `skipNBytes` instead.</customMessage>
+  </check>
+
+  <check customId="readFully" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bByteStreams\.readFully\b</parameter></parameters>
+    <customMessage>Use readFully of JavaUtils/SparkStreamUtils/Utils instead.</customMessage>
+  </check>
+
+  <check customId="nullOutputStream" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bByteStreams\.nullOutputStream\b</parameter></parameters>
+    <customMessage>Use OutputStream.nullOutputStream instead.</customMessage>
+  </check>
+
+  <check customId="ImmutableMapcopyOf" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bImmutableMap\.copyOf\b</parameter></parameters>
+    <customMessage>Use Map.copyOf instead.</customMessage>
+  </check>
+
+  <check customId="ImmutableSetof" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bImmutableSet\.of\b</parameter></parameters>
+    <customMessage>Use java.util.Set.of instead.</customMessage>
+  </check>
+
+  <check customId="emptySet" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bCollections\.emptySet\b</parameter></parameters>
+    <customMessage>Use java.util.Set.of() instead.</customMessage>
+  </check>
+
+  <check customId="maputils" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">org\.apache\.commons\.collections4\.MapUtils\b</parameter></parameters>
+    <customMessage>Use org.apache.spark.util.collection.Utils instead.</customMessage>
+  </check>
+
+  <check customId="googleFiles" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">com\.google\.common\.io\.Files\b</parameter></parameters>
+    <customMessage>Use Java API or Spark's JavaUtils/SparkFileUtils/Utils instead.</customMessage>
+  </check>
+
+  <check customId="googleObjects" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">com\.google\.common\.base\.Objects\b</parameter></parameters>
+    <customMessage>Use Java APIs (like java.util.Objects) instead.</customMessage>
+  </check>
+
+  <check customId="googleJoiner" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">com\.google\.common\.base\.Joiner\b</parameter></parameters>
+    <customMessage>Use Java APIs (like String.join/StringJoiner) instead.</customMessage>
+  </check>
+
+  <check customId="googleBaseEncoding" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">com\.google\.common\.io\.BaseEncoding\b</parameter></parameters>
+    <customMessage>Use Java APIs (like java.util.Base64) instead.</customMessage>
+  </check>
+
+  <check customId="googleThrowablesGetStackTraceAsString" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bThrowables\.getStackTraceAsString\b</parameter></parameters>
+    <customMessage>Use stackTraceToString of JavaUtils/SparkFileUtils/Utils instead.</customMessage>
+  </check>
+
+  <check customId="googleThrowablesGetRootCause" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bThrowables\.getRootCause\b</parameter></parameters>
+    <customMessage>Use getRootCause of SparkErrorUtils or Utils instead</customMessage>
+  </check>
+
+  <check customId="preconditionschecknotnull" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bPreconditions\.checkNotNull\b</parameter></parameters>
+    <customMessage>Use requireNonNull of java.util.Objects instead.</customMessage>
+  </check>
+
+  <check customId="intscheckedcast" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bInts\.checkedCast\b</parameter></parameters>
+    <customMessage>Use JavaUtils.checkedCast instead.</customMessage>
+  </check>
+
+  <check customId="startsWithK8s" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bstartsWith\("k8s\b</parameter></parameters>
+    <customMessage>Use SparkMasterRegex.isK8s instead.</customMessage>
+  </check>
+</scalastyle>

--- a/src/main/scala/dev/cjfravel/ariadne/AriadneContext.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/AriadneContext.scala
@@ -1,109 +1,100 @@
 package dev.cjfravel.ariadne
 
-import org.apache.spark.sql.SparkSession
-import org.apache.spark.broadcast.Broadcast
-import org.apache.hadoop.fs.{Path, FileSystem}
-import org.apache.logging.log4j.{Logger, LogManager}
 import io.delta.tables.DeltaTable
 import org.apache.hadoop.fs.FSDataInputStream
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.logging.log4j.{LogManager, Logger}
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.sql.SparkSession
 
-/** Provides Spark session context, HDFS access, and configuration for Ariadne
-  * operations.
-  *
-  * Mix this trait into any class that needs access to Ariadne infrastructure.
-  * All configuration is read lazily from `SparkConf` properties prefixed with
-  * `spark.ariadne.*` and logged at `warn` level on first access.
-  *
-  * '''Spark configuration keys:'''
-  * {{{
-  * spark.ariadne.storagePath                 (required) Base HDFS/filesystem path for index storage
-  * spark.ariadne.largeIndexLimit             (default: 500000) Max values before a column is "large"
-  * spark.ariadne.stagingConsolidationThreshold (default: 50) Batches between staging merges
-  * spark.ariadne.indexRepartitionCount       (optional) Repartition count for index DataFrames
-  * spark.ariadne.debug                       (default: false) Enable verbose join diagnostics
-  * spark.ariadne.repartitionDataFiles        (default: false) Repartition data files during joins
-  * spark.ariadne.lockTimeout                 (default: 1800) Seconds before a lock is considered stale
-  * spark.ariadne.lockRetryInterval           (default: 60) Base seconds between lock retries
-  * spark.ariadne.lockMaxWait                 (default: 3600) Max seconds to wait for a lock
-  * spark.ariadne.lockRefreshInterval         (default: 1) Batches between lock refreshes
-  * spark.ariadne.autoCompactThreshold        (optional) Delta log file count triggering auto-compact
-  * spark.ariadne.autoBloomFpr                (default: 0.01) FPR for auto-bloom filters on large columns
-  * }}}
-  *
-  * '''Thread safety:''' Lazy vals are initialized at most once per instance and
-  * are safe for concurrent reads after initialization. However, the underlying
-  * `SparkSession` and `FileSystem` are shared resources governed by Spark's own
-  * concurrency model.
-  */
+/**
+ * Provides Spark session context, HDFS access, and configuration for Ariadne operations.
+ *
+ * Mix this trait into any class that needs access to Ariadne infrastructure. All configuration is read lazily from
+ * `SparkConf` properties prefixed with `spark.ariadne.*` and logged at `warn` level on first access.
+ *
+ * '''Spark configuration keys:'''
+ * {{{
+ * spark.ariadne.storagePath                 (required) Base HDFS/filesystem path for index storage
+ * spark.ariadne.largeIndexLimit             (default: 500000) Max values before a column is "large"
+ * spark.ariadne.stagingConsolidationThreshold (default: 50) Batches between staging merges
+ * spark.ariadne.indexRepartitionCount       (optional) Repartition count for index DataFrames
+ * spark.ariadne.debug                       (default: false) Enable verbose join diagnostics
+ * spark.ariadne.repartitionDataFiles        (default: false) Repartition data files during joins
+ * spark.ariadne.lockTimeout                 (default: 1800) Seconds before a lock is considered stale
+ * spark.ariadne.lockRetryInterval           (default: 60) Base seconds between lock retries
+ * spark.ariadne.lockMaxWait                 (default: 3600) Max seconds to wait for a lock
+ * spark.ariadne.lockRefreshInterval         (default: 1) Batches between lock refreshes
+ * spark.ariadne.autoCompactThreshold        (optional) Delta log file count triggering auto-compact
+ * spark.ariadne.autoBloomFpr                (default: 0.01) FPR for auto-bloom filters on large columns
+ * }}}
+ *
+ * '''Thread safety:''' Lazy vals are initialized at most once per instance and are safe for concurrent reads after
+ * initialization. However, the underlying `SparkSession` and `FileSystem` are shared resources governed by Spark's own
+ * concurrency model.
+ */
 trait AriadneContextUser {
 
-  /** Log4j logger shared by all Ariadne components. Uses the "ariadne" logger
-    * name. Marked `@transient lazy` so that `Index` (a case class) remains
-    * serializable across Spark stages — Log4j loggers are not `Serializable`.
-    */
+  /**
+   * Log4j logger shared by all Ariadne components. Uses the "ariadne" logger name. Marked `@transient lazy` so that
+   * `Index` (a case class) remains serializable across Spark stages — Log4j loggers are not `Serializable`.
+   */
   @transient lazy val logger: Logger = LogManager.getLogger("ariadne")
 
   /** Implicit SparkSession that must be provided by the mixing class. */
   implicit def spark: SparkSession
 
-  /** Base path on the Hadoop-compatible filesystem where all Ariadne index data
-    * is stored. Each index creates a subdirectory under this path.
-    *
-    * Reads from `spark.ariadne.storagePath` (required — no default).
-    *
-    * @throws IllegalArgumentException
-    *   if the configuration key is not set
-    */
+  /**
+   * Base path on the Hadoop-compatible filesystem where all Ariadne index data is stored. Each index creates a
+   * subdirectory under this path.
+   *
+   * Reads from `spark.ariadne.storagePath` (required — no default).
+   *
+   * @throws IllegalArgumentException
+   *   if the configuration key is not set
+   */
   lazy val storagePath: Path = {
-    val pathStr = spark.conf
-      .getOption("spark.ariadne.storagePath")
-      .getOrElse(
-        throw new IllegalArgumentException(
-          "Spark configuration 'spark.ariadne.storagePath' must be set. " +
-            "Set it via spark.conf.set(\"spark.ariadne.storagePath\", \"/path/to/storage\")"
-        )
-      )
+    val pathStr =
+      spark.conf
+        .getOption("spark.ariadne.storagePath")
+        .getOrElse(throw new IllegalArgumentException("Spark configuration 'spark.ariadne.storagePath' must be set. " +
+          "Set it via spark.conf.set(\"spark.ariadne.storagePath\", \"/path/to/storage\")"))
     val path = new Path(pathStr)
     logger.warn(s"storagePath initialized: $path")
     path
   }
 
-  /** Maximum number of distinct values per file before an index column is
-    * promoted to a "large index" (stored in a separate exploded Delta table).
-    * Reads from `spark.ariadne.largeIndexLimit` (default: 500000).
-    *
-    * If the configured value is not a valid positive number, a warning is
-    * logged and the default of 500,000 is used.
-    */
+  /**
+   * Maximum number of distinct values per file before an index column is promoted to a "large index" (stored in a
+   * separate exploded Delta table). Reads from `spark.ariadne.largeIndexLimit` (default: 500000).
+   *
+   * If the configured value is not a valid positive number, a warning is logged and the default of 500,000 is used.
+   */
   lazy val largeIndexLimit: Long = {
     val limit =
       try {
         spark.conf.get("spark.ariadne.largeIndexLimit", "500000").toLong
       } catch {
         case e: NumberFormatException =>
-          logger.warn(
-            s"Invalid spark.ariadne.largeIndexLimit value, using default 500000: ${e.getMessage}"
-          )
+          logger.warn(s"Invalid spark.ariadne.largeIndexLimit value, using default 500000: ${e.getMessage}")
           500000L
       }
-    val validated = if (limit <= 0) {
-      logger.warn(
-        s"spark.ariadne.largeIndexLimit must be positive (got $limit), using default 500000"
-      )
-      500000L
-    } else {
-      limit
-    }
+    val validated =
+      if (limit <= 0) {
+        logger.warn(s"spark.ariadne.largeIndexLimit must be positive (got $limit), using default 500000")
+        500000L
+      } else {
+        limit
+      }
     logger.warn(s"largeIndexLimit initialized: $validated")
     validated
   }
 
-  /** Number of batches to process before consolidating staged data into the
-    * main index. This provides fault tolerance for large index builds - if a
-    * job fails, work is preserved up to the last consolidation point. Reads
-    * from spark.ariadne.stagingConsolidationThreshold configuration (default:
-    * 50).
-    */
+  /**
+   * Number of batches to process before consolidating staged data into the main index. This provides fault tolerance
+   * for large index builds - if a job fails, work is preserved up to the last consolidation point. Reads from
+   * spark.ariadne.stagingConsolidationThreshold configuration (default: 50).
+   */
   lazy val stagingConsolidationThreshold: Int = {
     val threshold =
       try {
@@ -112,45 +103,38 @@ trait AriadneContextUser {
           .toInt
       } catch {
         case e: NumberFormatException =>
-          logger.warn(
-            s"Invalid spark.ariadne.stagingConsolidationThreshold value, using default 50: ${e.getMessage}"
-          )
+          logger.warn(s"Invalid spark.ariadne.stagingConsolidationThreshold value, using default 50: ${e.getMessage}")
           50
       }
-    val validated = if (threshold <= 0) {
-      logger.warn(
-        s"spark.ariadne.stagingConsolidationThreshold must be positive (got $threshold), using default 50"
-      )
-      50
-    } else threshold
+    val validated =
+      if (threshold <= 0) {
+        logger.warn(s"spark.ariadne.stagingConsolidationThreshold must be positive (got $threshold), using default 50")
+        50
+      } else threshold
     logger.warn(s"stagingConsolidationThreshold initialized: $validated")
     validated
   }
 
-  /** Optional number of partitions to use when repartitioning the index
-    * DataFrame during joins. When set, the index DataFrame is repartitioned
-    * before expensive operations like explode to reduce per-executor memory
-    * pressure and avoid FetchFailedExceptions on large indexes. Reads from
-    * spark.ariadne.indexRepartitionCount configuration (default: not set).
-    */
+  /**
+   * Optional number of partitions to use when repartitioning the index DataFrame during joins. When set, the index
+   * DataFrame is repartitioned before expensive operations like explode to reduce per-executor memory pressure and
+   * avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepartitionCount configuration
+   * (default: not set).
+   */
   lazy val indexRepartitionCount: Option[Int] = {
     val count =
       spark.conf.getOption("spark.ariadne.indexRepartitionCount").flatMap { v =>
         try {
           val parsed = v.toInt
           if (parsed <= 0) {
-            logger.warn(
-              s"spark.ariadne.indexRepartitionCount must be positive (got $parsed), ignoring"
-            )
+            logger.warn(s"spark.ariadne.indexRepartitionCount must be positive (got $parsed), ignoring")
             None
           } else {
             Some(parsed)
           }
         } catch {
           case e: NumberFormatException =>
-            logger.warn(
-              s"Invalid spark.ariadne.indexRepartitionCount value, ignoring: ${e.getMessage}"
-            )
+            logger.warn(s"Invalid spark.ariadne.indexRepartitionCount value, ignoring: ${e.getMessage}")
             None
         }
       }
@@ -158,235 +142,216 @@ trait AriadneContextUser {
     count
   }
 
-  /** When true, logs detailed diagnostics during join operations including
-    * partition counts, physical plans, and per-phase timing. Reads from
-    * spark.ariadne.debug configuration (default: false).
-    */
+  /**
+   * When true, logs detailed diagnostics during join operations including partition counts, physical plans, and
+   * per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
+   */
   lazy val debugEnabled: Boolean = {
     val enabled =
       try {
         spark.conf.get("spark.ariadne.debug", "false").toBoolean
       } catch {
         case e: IllegalArgumentException =>
-          logger.warn(
-            s"Invalid spark.ariadne.debug value, using default false: ${e.getMessage}"
-          )
+          logger.warn(s"Invalid spark.ariadne.debug value, using default false: ${e.getMessage}")
           false
       }
     if (enabled) logger.warn("Debug mode enabled")
     enabled
   }
 
-  /** When true, applies indexRepartitionCount repartitioning to the data files
-    * read during joinDf. When false, data files keep their natural parquet
-    * partitioning. Disable when column selection significantly reduces data
-    * volume, making the repartition shuffle more expensive than useful. Reads
-    * from spark.ariadne.repartitionDataFiles configuration (default: false).
-    */
+  /**
+   * When true, applies indexRepartitionCount repartitioning to the data files read during joinDf. When false, data
+   * files keep their natural parquet partitioning. Disable when column selection significantly reduces data volume,
+   * making the repartition shuffle more expensive than useful. Reads from spark.ariadne.repartitionDataFiles
+   * configuration (default: false).
+   */
   lazy val repartitionDataFiles: Boolean = {
     val enabled =
       try {
         spark.conf.get("spark.ariadne.repartitionDataFiles", "false").toBoolean
       } catch {
         case e: IllegalArgumentException =>
-          logger.warn(
-            s"Invalid spark.ariadne.repartitionDataFiles value, using default false: ${e.getMessage}"
-          )
+          logger.warn(s"Invalid spark.ariadne.repartitionDataFiles value, using default false: ${e.getMessage}")
           false
       }
     if (enabled)
-      logger.warn(
-        "repartitionDataFiles enabled — data files will be repartitioned"
-      )
+      logger.warn("repartitionDataFiles enabled — data files will be repartitioned")
     enabled
   }
 
-  /** Hadoop `FileSystem` instance resolved from the [[storagePath]] URI and the
-    * Spark Hadoop configuration. Used for all filesystem operations (existence
-    * checks, reads, deletes, lock files).
-    */
+  /**
+   * Hadoop `FileSystem` instance resolved from the [[storagePath]] URI and the Spark Hadoop configuration. Used for all
+   * filesystem operations (existence checks, reads, deletes, lock files).
+   */
   lazy val fs: FileSystem = {
     val fsUri = Option(storagePath.getParent).getOrElse(storagePath).toUri
-    val filesystem = FileSystem.get(
-      fsUri,
-      spark.sparkContext.hadoopConfiguration
-    )
+    val filesystem = FileSystem.get(fsUri, spark.sparkContext.hadoopConfiguration)
     logger.warn(s"FileSystem initialized for: $storagePath")
     filesystem
   }
 
-  /** Checks if a path exists on the filesystem.
-    *
-    * @param path
-    *   The Hadoop Path to check
-    * @return
-    *   true if the path exists
-    * @throws IllegalArgumentException
-    *   if path is null
-    * @throws java.io.IOException
-    *   if the filesystem operation fails
-    */
+  /**
+   * Checks if a path exists on the filesystem.
+   *
+   * @param path
+   *   The Hadoop Path to check
+   * @return
+   *   true if the path exists
+   * @throws IllegalArgumentException
+   *   if path is null
+   * @throws java.io.IOException
+   *   if the filesystem operation fails
+   */
   def exists(path: Path): Boolean = {
     require(path != null, "path must not be null")
     fs.exists(path)
   }
 
-  /** Deletes a path recursively from the filesystem.
-    *
-    * @param path
-    *   The Hadoop Path to delete
-    * @return
-    *   true if the path was successfully deleted
-    * @throws IllegalArgumentException
-    *   if path is null
-    * @throws java.io.IOException
-    *   if the filesystem operation fails
-    */
+  /**
+   * Deletes a path recursively from the filesystem.
+   *
+   * @param path
+   *   The Hadoop Path to delete
+   * @return
+   *   true if the path was successfully deleted
+   * @throws IllegalArgumentException
+   *   if path is null
+   * @throws java.io.IOException
+   *   if the filesystem operation fails
+   */
   def delete(path: Path): Boolean = {
     require(path != null, "path must not be null")
     fs.delete(path, true)
   }
 
-  /** Opens an input stream to read from a path on the filesystem.
-    *
-    * @param path
-    *   The Hadoop Path to open for reading
-    * @return
-    *   An FSDataInputStream for reading the file contents
-    * @throws IllegalArgumentException
-    *   if path is null
-    * @throws java.io.IOException
-    *   if the file does not exist or cannot be opened
-    */
+  /**
+   * Opens an input stream to read from a path on the filesystem.
+   *
+   * @param path
+   *   The Hadoop Path to open for reading
+   * @return
+   *   An FSDataInputStream for reading the file contents
+   * @throws IllegalArgumentException
+   *   if path is null
+   * @throws java.io.IOException
+   *   if the file does not exist or cannot be opened
+   */
   def open(path: Path): FSDataInputStream = {
     require(path != null, "path must not be null")
     fs.open(path)
   }
 
-  /** Returns a [[io.delta.tables.DeltaTable]] if the path exists and contains
-    * valid Delta metadata.
-    *
-    * If the path exists but is ''not'' a valid Delta table (e.g., leftover
-    * partial write), the directory is deleted and `None` is returned so it can
-    * be recreated cleanly on the next write.
-    *
-    * @param path
-    *   The Hadoop Path to check for a Delta table
-    * @return
-    *   `Some(DeltaTable)` if a valid Delta table exists, `None` otherwise
-    */
-  def delta(path: Path): Option[DeltaTable] = {
+  /**
+   * Returns a [[io.delta.tables.DeltaTable]] if the path exists and contains valid Delta metadata.
+   *
+   * If the path exists but is ''not'' a valid Delta table (e.g., leftover partial write), the directory is deleted and
+   * `None` is returned so it can be recreated cleanly on the next write.
+   *
+   * @param path
+   *   The Hadoop Path to check for a Delta table
+   * @return
+   *   `Some(DeltaTable)` if a valid Delta table exists, `None` otherwise
+   */
+  def delta(path: Path): Option[DeltaTable] =
     if (exists(path)) {
       if (DeltaTable.isDeltaTable(spark, path.toString)) {
         Some(DeltaTable.forPath(spark, path.toString))
       } else {
-        logger.warn(
-          s"Path $path exists but is not a Delta table — deleting to allow re-creation"
-        )
+        logger.warn(s"Path $path exists but is not a Delta table — deleting to allow re-creation")
         delete(path)
         None
       }
     } else {
       None
     }
-  }
 
-  /** Seconds since `lastRefreshedAt` before a lock is considered stale and
-    * eligible for auto-heal (forcible acquisition by another process). Reads
-    * from `spark.ariadne.lockTimeout` (default: 1800).
-    */
+  /**
+   * Seconds since `lastRefreshedAt` before a lock is considered stale and eligible for auto-heal (forcible acquisition
+   * by another process). Reads from `spark.ariadne.lockTimeout` (default: 1800).
+   */
   lazy val lockTimeout: Long = {
     val value =
       try {
         spark.conf.get("spark.ariadne.lockTimeout", "1800").toLong
       } catch {
         case e: NumberFormatException =>
-          logger.warn(
-            s"Invalid spark.ariadne.lockTimeout value, using default 1800: ${e.getMessage}"
-          )
+          logger.warn(s"Invalid spark.ariadne.lockTimeout value, using default 1800: ${e.getMessage}")
           1800L
       }
-    val validated = if (value <= 0) {
-      logger.warn(
-        s"spark.ariadne.lockTimeout must be positive (got $value), using default 1800"
-      )
-      1800L
-    } else value
+    val validated =
+      if (value <= 0) {
+        logger.warn(s"spark.ariadne.lockTimeout must be positive (got $value), using default 1800")
+        1800L
+      } else value
     logger.warn(s"lockTimeout initialized: $validated")
     validated
   }
 
-  /** Base interval in seconds between lock acquisition retries (exponential
-    * backoff applied). Reads from spark.ariadne.lockRetryInterval configuration
-    * (default: 60).
-    */
+  /**
+   * Base interval in seconds between lock acquisition retries (exponential backoff applied). Reads from
+   * spark.ariadne.lockRetryInterval configuration (default: 60).
+   */
   lazy val lockRetryInterval: Long = {
     val value =
       try {
         spark.conf.get("spark.ariadne.lockRetryInterval", "60").toLong
       } catch {
         case e: NumberFormatException =>
-          logger.warn(
-            s"Invalid spark.ariadne.lockRetryInterval value, using default 60: ${e.getMessage}"
-          )
+          logger.warn(s"Invalid spark.ariadne.lockRetryInterval value, using default 60: ${e.getMessage}")
           60L
       }
-    val validated = if (value <= 0) {
-      logger.warn(
-        s"spark.ariadne.lockRetryInterval must be positive (got $value), using default 60"
-      )
-      60L
-    } else value
+    val validated =
+      if (value <= 0) {
+        logger.warn(s"spark.ariadne.lockRetryInterval must be positive (got $value), using default 60")
+        60L
+      } else value
     logger.warn(s"lockRetryInterval initialized: $validated")
     validated
   }
 
-  /** Maximum total time in seconds to wait for lock acquisition before failing.
-    * Reads from spark.ariadne.lockMaxWait configuration (default: 3600).
-    *
-    * @note
-    *   Unlike `lockTimeout` and `lockRetryInterval`, non-positive values are
-    *   not validated — a value of 0 causes immediate timeout on first retry.
-    *   Configure with care.
-    */
+  /**
+   * Maximum total time in seconds to wait for lock acquisition before failing. Reads from spark.ariadne.lockMaxWait
+   * configuration (default: 3600).
+   *
+   * @note
+   *   Unlike `lockTimeout` and `lockRetryInterval`, non-positive values are not validated — a value of 0 causes
+   *   immediate timeout on first retry. Configure with care.
+   */
   lazy val lockMaxWait: Long = {
     val value =
       try {
         spark.conf.get("spark.ariadne.lockMaxWait", "3600").toLong
       } catch {
         case e: NumberFormatException =>
-          logger.warn(
-            s"Invalid spark.ariadne.lockMaxWait value, using default 3600: ${e.getMessage}"
-          )
+          logger.warn(s"Invalid spark.ariadne.lockMaxWait value, using default 3600: ${e.getMessage}")
           3600L
       }
     logger.warn(s"lockMaxWait initialized: $value")
     value
   }
 
-  /** Refresh the update lock every N batches during updateBatched. Reads from
-    * spark.ariadne.lockRefreshInterval configuration (default: 1).
-    */
+  /**
+   * Refresh the update lock every N batches during updateBatched. Reads from spark.ariadne.lockRefreshInterval
+   * configuration (default: 1).
+   */
   lazy val lockRefreshInterval: Int = {
     val value =
       try {
         spark.conf.get("spark.ariadne.lockRefreshInterval", "1").toInt
       } catch {
         case e: NumberFormatException =>
-          logger.warn(
-            s"Invalid spark.ariadne.lockRefreshInterval value, using default 1: ${e.getMessage}"
-          )
+          logger.warn(s"Invalid spark.ariadne.lockRefreshInterval value, using default 1: ${e.getMessage}")
           1
       }
     logger.warn(s"lockRefreshInterval initialized: $value")
     value
   }
 
-  /** Optional threshold for auto-compaction. When set, the main index Delta
-    * table is compacted after an update if the number of Delta log JSON files
-    * meets or exceeds this value. Reads from spark.ariadne.autoCompactThreshold
-    * configuration (default: not set).
-    */
+  /**
+   * Optional threshold for auto-compaction. When set, the main index Delta table is compacted after an update if the
+   * number of Delta log JSON files meets or exceeds this value. Reads from spark.ariadne.autoCompactThreshold
+   * configuration (default: not set).
+   */
   lazy val autoCompactThreshold: Option[Int] = {
     val value =
       spark.conf.getOption("spark.ariadne.autoCompactThreshold").flatMap { v =>
@@ -394,9 +359,7 @@ trait AriadneContextUser {
           Some(v.toInt)
         } catch {
           case e: NumberFormatException =>
-            logger.warn(
-              s"Invalid spark.ariadne.autoCompactThreshold value, ignoring: ${e.getMessage}"
-            )
+            logger.warn(s"Invalid spark.ariadne.autoCompactThreshold value, ignoring: ${e.getMessage}")
             None
         }
       }
@@ -404,17 +367,16 @@ trait AriadneContextUser {
     value
   }
 
-  /** Safely destroys a broadcast variable, logging but swallowing any
-    * exception.
-    *
-    * Intended for use inside `finally` blocks where a cleanup failure must not
-    * mask the original exception propagating out of the `try` block. Tolerates
-    * a null broadcast.
-    *
-    * @param broadcast
-    *   the broadcast to destroy; may be null
-    */
-  protected def safeDestroyBroadcast(broadcast: Broadcast[_]): Unit = {
+  /**
+   * Safely destroys a broadcast variable, logging but swallowing any exception.
+   *
+   * Intended for use inside `finally` blocks where a cleanup failure must not mask the original exception propagating
+   * out of the `try` block. Tolerates a null broadcast.
+   *
+   * @param broadcast
+   *   the broadcast to destroy; may be null
+   */
+  protected def safeDestroyBroadcast(broadcast: Broadcast[_]): Unit =
     if (broadcast != null) {
       try broadcast.destroy()
       catch {
@@ -422,32 +384,28 @@ trait AriadneContextUser {
           logger.warn(s"Failed to destroy broadcast variable: ${e.getMessage}")
       }
     }
-  }
 
-  /** False positive rate for auto-bloom filters on large index columns. When a
-    * column exceeds largeIndexLimit, an auto-bloom filter is built with this
-    * FPR to enable file pruning at query time. Reads from
-    * spark.ariadne.autoBloomFpr configuration (default: 0.01).
-    */
+  /**
+   * False positive rate for auto-bloom filters on large index columns. When a column exceeds largeIndexLimit, an
+   * auto-bloom filter is built with this FPR to enable file pruning at query time. Reads from
+   * spark.ariadne.autoBloomFpr configuration (default: 0.01).
+   */
   lazy val autoBloomFpr: Double = {
     val value =
       try {
         spark.conf.get("spark.ariadne.autoBloomFpr", "0.01").toDouble
       } catch {
         case e: NumberFormatException =>
-          logger.warn(
-            s"Invalid spark.ariadne.autoBloomFpr value, using default 0.01: ${e.getMessage}"
-          )
+          logger.warn(s"Invalid spark.ariadne.autoBloomFpr value, using default 0.01: ${e.getMessage}")
           0.01
       }
-    val validated = if (value <= 0.0 || value >= 1.0) {
-      logger.warn(
-        s"autoBloomFpr value $value is out of valid range (0, 1), using default 0.01"
-      )
-      0.01
-    } else {
-      value
-    }
+    val validated =
+      if (value <= 0.0 || value >= 1.0) {
+        logger.warn(s"autoBloomFpr value $value is out of valid range (0, 1), using default 0.01")
+        0.01
+      } else {
+        value
+      }
     logger.warn(s"autoBloomFpr initialized: $validated")
     validated
   }

--- a/src/main/scala/dev/cjfravel/ariadne/BloomFilterOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/BloomFilterOperations.scala
@@ -1,110 +1,104 @@
 package dev.cjfravel.ariadne
 
-import com.google.common.hash.{BloomFilter, Funnels}
-import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.functions._
-import org.apache.spark.sql.expressions.UserDefinedFunction
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 import java.nio.charset.StandardCharsets
+
 import scala.collection.JavaConverters._
 
-/** Trait providing bloom filter operations for [[Index]] instances.
-  *
-  * Bloom filters are probabilistic data structures used to test set membership.
-  * This trait handles the full lifecycle of bloom filter indexes:
-  *
-  * '''Building''': During index updates, bloom filters are created per file per
-  * configured column via [[buildBloomFilterIndexes]]. Values are hashed into a
-  * Guava `BloomFilter[CharSequence]` and serialized to `Array[Byte]` for
-  * storage in the Delta index table.
-  *
-  * '''Querying''': At query time, [[locateFilesWithBloom]] and
-  * [[locateFilesWithBloomFromDataFrame]] deserialize stored bloom filters and
-  * test candidate values, returning the set of files that might contain
-  * matches.
-  *
-  * '''Serialization''': Bloom filters are serialized/deserialized via Guava's
-  * `writeTo`/`readFrom` methods using a `StringFunnel` with UTF-8 encoding. All
-  * indexed values are converted to strings before hashing.
-  *
-  * Bloom filters provide:
-  *   - Guaranteed no false negatives (if filter says "no", value is definitely
-  *     absent)
-  *   - Configurable false positive rate (if filter says "yes", value might be
-  *     present)
-  *   - Space-efficient storage (approximately 10 bits per element at 1% FPR)
-  *
-  * UDF mechanics: Bloom filter creation and querying are performed inside Spark
-  * UDFs ([[createBloomFilterUdf]] and [[bloomContainsUdf]]) so they can execute
-  * on worker nodes. The false positive rate is captured as a local `Double` to
-  * ensure serializability across the Spark closure boundary.
-  *
-  * @see
-  *   [[BloomIndexConfig]] for per-column configuration
-  * @see
-  *   [[IndexBuildOperations]] for the build pipeline that invokes these
-  *   operations
-  */
+import com.google.common.hash.{BloomFilter, Funnels}
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.functions._
+
+/**
+ * Trait providing bloom filter operations for [[Index]] instances.
+ *
+ * Bloom filters are probabilistic data structures used to test set membership. This trait handles the full lifecycle of
+ * bloom filter indexes:
+ *
+ * '''Building''': During index updates, bloom filters are created per file per configured column via
+ * [[buildBloomFilterIndexes]]. Values are hashed into a Guava `BloomFilter[CharSequence]` and serialized to
+ * `Array[Byte]` for storage in the Delta index table.
+ *
+ * '''Querying''': At query time, [[locateFilesWithBloom]] and [[locateFilesWithBloomFromDataFrame]] deserialize stored
+ * bloom filters and test candidate values, returning the set of files that might contain matches.
+ *
+ * '''Serialization''': Bloom filters are serialized/deserialized via Guava's `writeTo`/`readFrom` methods using a
+ * `StringFunnel` with UTF-8 encoding. All indexed values are converted to strings before hashing.
+ *
+ * Bloom filters provide:
+ *   - Guaranteed no false negatives (if filter says "no", value is definitely absent)
+ *   - Configurable false positive rate (if filter says "yes", value might be present)
+ *   - Space-efficient storage (approximately 10 bits per element at 1% FPR)
+ *
+ * UDF mechanics: Bloom filter creation and querying are performed inside Spark UDFs ([[createBloomFilterUdf]] and
+ * [[bloomContainsUdf]]) so they can execute on worker nodes. The false positive rate is captured as a local `Double` to
+ * ensure serializability across the Spark closure boundary.
+ *
+ * @see
+ *   [[BloomIndexConfig]] for per-column configuration
+ * @see
+ *   [[IndexBuildOperations]] for the build pipeline that invokes these operations
+ */
 trait BloomFilterOperations extends IndexFileOperations {
   self: Index =>
 
-  /** Column name prefix used when storing bloom filter binary data in the index
-    * Delta table.
-    */
+  /**
+   * Column name prefix used when storing bloom filter binary data in the index Delta table.
+   */
   protected val bloomColumnPrefix = "bloom_"
 
-  /** Returns the bloom index configurations from the current index metadata.
-    *
-    * @return
-    *   sequence of [[BloomIndexConfig]] objects, one per bloom-indexed column
-    */
+  /**
+   * Returns the bloom index configurations from the current index metadata.
+   *
+   * @return
+   *   sequence of [[BloomIndexConfig]] objects, one per bloom-indexed column
+   */
   protected def bloomIndexConfigs: Seq[BloomIndexConfig] =
     metadata.bloom_indexes.asScala.toSeq
 
-  /** Returns the set of source column names that have bloom indexes configured.
-    *
-    * @return
-    *   set of column names (without the `bloom_` prefix)
-    */
+  /**
+   * Returns the set of source column names that have bloom indexes configured.
+   *
+   * @return
+   *   set of column names (without the `bloom_` prefix)
+   */
   protected def bloomColumns: Set[String] =
     metadata.bloom_indexes.asScala.map(_.column).toSet
 
-  /** Returns the set of storage column names used for bloom filter binary data.
-    *
-    * Each name is the source column name prefixed with [[bloomColumnPrefix]].
-    *
-    * @return
-    *   set of prefixed column names (e.g., `bloom_user_id`)
-    */
+  /**
+   * Returns the set of storage column names used for bloom filter binary data.
+   *
+   * Each name is the source column name prefixed with [[bloomColumnPrefix]].
+   *
+   * @return
+   *   set of prefixed column names (e.g., `bloom_user_id`)
+   */
   protected def bloomStorageColumns: Set[String] =
     metadata.bloom_indexes.asScala.map(c => bloomColumnPrefix + c.column).toSet
 
-  /** Builds bloom filter indexes for all configured bloom columns.
-    *
-    * For each [[BloomIndexConfig]], this method:
-    *   1. Groups the input data by filename 2. Collects distinct values per
-    *      file into a set 3. Creates a bloom filter from the collected values
-    *      using [[createBloomFilterUdf]] 4. Joins the resulting bloom column
-    *      back onto the accumulating DataFrame
-    *
-    * If no bloom indexes are configured, returns a distinct filename-only
-    * DataFrame.
-    *
-    * @param df
-    *   DataFrame containing a `filename` column and all bloom-indexed source
-    *   columns
-    * @return
-    *   DataFrame with `filename` plus one `bloom_{column}` binary column per
-    *   configured bloom index
-    */
+  /**
+   * Builds bloom filter indexes for all configured bloom columns.
+   *
+   * For each [[BloomIndexConfig]], this method:
+   *   1. Groups the input data by filename 2. Collects distinct values per file into a set 3. Creates a bloom filter
+   *      from the collected values using [[createBloomFilterUdf]] 4. Joins the resulting bloom column back onto the
+   *      accumulating DataFrame
+   *
+   * If no bloom indexes are configured, returns a distinct filename-only DataFrame.
+   *
+   * @param df
+   *   DataFrame containing a `filename` column and all bloom-indexed source columns
+   * @return
+   *   DataFrame with `filename` plus one `bloom_{column}` binary column per configured bloom index
+   */
   protected def buildBloomFilterIndexes(df: DataFrame): DataFrame = {
     val configs = bloomIndexConfigs
     if (configs.isEmpty) {
       df.select("filename").distinct()
     } else {
       logger.debug(
-        s"Building bloom filter indexes for ${configs.size} columns: ${configs.map(_.column).mkString(", ")}"
-      )
+        s"Building bloom filter indexes for ${configs.size} columns: ${configs.map(_.column).mkString(", ")}")
 
       // For each bloom column, create aggregation that produces binary bloom filter
       configs.foldLeft(df.select("filename").distinct) { (accumDf, config) =>
@@ -113,44 +107,40 @@ trait BloomFilterOperations extends IndexFileOperations {
 
         // Get distinct values per file and create bloom filter
         val bloomUdf = createBloomFilterUdf(fprValue)
-        val bloomData = df
-          .select("filename", config.column)
-          .groupBy("filename")
-          .agg(
-            bloomUdf(collect_set(col(config.column))).alias(bloomColumn)
-          )
+        val bloomData =
+          df
+            .select("filename", config.column)
+            .groupBy("filename")
+            .agg(bloomUdf(collect_set(col(config.column))).alias(bloomColumn))
 
         accumDf.join(bloomData, Seq("filename"), "left")
       }
     }
   }
 
-  /** Creates a Spark UDF that converts a collected set of values into a
-    * serialized bloom filter.
-    *
-    * The UDF is designed for use inside `agg(bloomUdf(collect_set(...)))`. It:
-    *   1. Filters out null values from the input sequence 2. Creates a Guava
-    *      `BloomFilter` sized for the actual number of non-null elements 3.
-    *      Inserts each value (converted to `String`) into the filter 4.
-    *      Serializes the filter to `Array[Byte]` via `ByteArrayOutputStream`
-    *
-    * The `fprValue` parameter is captured as a local `val` to ensure it is
-    * serializable when the UDF closure is shipped to Spark executors.
-    *
-    * @param fprValue
-    *   the desired false positive rate (e.g., 0.01 for 1%); must be strictly
-    *   between 0 and 1 (exclusive)
-    * @return
-    *   a UDF that accepts `Seq[Any]` (from `collect_set`) and returns
-    *   `Array[Byte]`, or `null` if the input is null or contains only nulls
-    * @throws IllegalArgumentException
-    *   if `fprValue` is not in the range (0, 1)
-    */
+  /**
+   * Creates a Spark UDF that converts a collected set of values into a serialized bloom filter.
+   *
+   * The UDF is designed for use inside `agg(bloomUdf(collect_set(...)))`. It:
+   *   1. Filters out null values from the input sequence 2. Creates a Guava `BloomFilter` sized for the actual number
+   *      of non-null elements 3. Inserts each value (converted to `String`) into the filter 4. Serializes the filter to
+   *      `Array[Byte]` via `ByteArrayOutputStream`
+   *
+   * The `fprValue` parameter is captured as a local `val` to ensure it is serializable when the UDF closure is shipped
+   * to Spark executors.
+   *
+   * @param fprValue
+   *   the desired false positive rate (e.g., 0.01 for 1%); must be strictly between 0 and 1 (exclusive)
+   * @return
+   *   a UDF that accepts `Seq[Any]` (from `collect_set`) and returns `Array[Byte]`, or `null` if the input is null or
+   *   contains only nulls
+   * @throws IllegalArgumentException
+   *   if `fprValue` is not in the range (0, 1)
+   */
   protected def createBloomFilterUdf(fprValue: Double): UserDefinedFunction = {
     require(
       fprValue > 0.0 && fprValue < 1.0,
-      s"False positive rate must be between 0 and 1 (exclusive), got: $fprValue"
-    )
+      s"False positive rate must be between 0 and 1 (exclusive), got: $fprValue")
     // Capture the FPR as a local constant to ensure it's serializable
     val fpr: Double = fprValue
 
@@ -164,11 +154,7 @@ trait BloomFilterOperations extends IndexFileOperations {
         } else {
           // Create bloom filter sized for the actual number of elements
           val expectedInsertions = math.max(nonNullValues.size, 1)
-          val bf = BloomFilter.create(
-            Funnels.stringFunnel(StandardCharsets.UTF_8),
-            expectedInsertions.toLong,
-            fpr
-          )
+          val bf = BloomFilter.create(Funnels.stringFunnel(StandardCharsets.UTF_8), expectedInsertions.toLong, fpr)
 
           // Add all values (convert to string for universal hashing)
           nonNullValues.foreach(v => bf.put(v.toString))
@@ -186,21 +172,20 @@ trait BloomFilterOperations extends IndexFileOperations {
     }
   }
 
-  /** Deserializes a Guava bloom filter from its byte representation.
-    *
-    * Uses `BloomFilter.readFrom` with a UTF-8 `StringFunnel`, which must match
-    * the funnel used during creation in [[createBloomFilterUdf]].
-    *
-    * @param bytes
-    *   serialized bloom filter bytes (produced by `BloomFilter.writeTo`)
-    * @return
-    *   a `BloomFilter[CharSequence]` instance ready for membership queries
-    * @throws java.io.IOException
-    *   if the byte array is malformed or corrupted
-    */
-  protected def deserializeBloomFilter(
-      bytes: Array[Byte]
-  ): BloomFilter[CharSequence] = {
+  /**
+   * Deserializes a Guava bloom filter from its byte representation.
+   *
+   * Uses `BloomFilter.readFrom` with a UTF-8 `StringFunnel`, which must match the funnel used during creation in
+   * [[createBloomFilterUdf]].
+   *
+   * @param bytes
+   *   serialized bloom filter bytes (produced by `BloomFilter.writeTo`)
+   * @return
+   *   a `BloomFilter[CharSequence]` instance ready for membership queries
+   * @throws java.io.IOException
+   *   if the byte array is malformed or corrupted
+   */
+  protected def deserializeBloomFilter(bytes: Array[Byte]): BloomFilter[CharSequence] = {
     val bais = new ByteArrayInputStream(bytes)
     try {
       BloomFilter.readFrom(bais, Funnels.stringFunnel(StandardCharsets.UTF_8))
@@ -209,40 +194,35 @@ trait BloomFilterOperations extends IndexFileOperations {
     }
   }
 
-  /** Checks if a value might be contained in a serialized bloom filter.
-    *
-    * Deserializes the bloom filter and performs a `mightContain` check. Returns
-    * `false` if either argument is `null`.
-    *
-    * @param bloomBytes
-    *   serialized bloom filter bytes
-    * @param value
-    *   the value to test for membership (converted to `String` internally)
-    * @return
-    *   `true` if the value might be present (probabilistic), `false` if
-    *   definitely absent
-    */
-  protected def bloomMightContain(
-      bloomBytes: Array[Byte],
-      value: Any
-  ): Boolean = {
+  /**
+   * Checks if a value might be contained in a serialized bloom filter.
+   *
+   * Deserializes the bloom filter and performs a `mightContain` check. Returns `false` if either argument is `null`.
+   *
+   * @param bloomBytes
+   *   serialized bloom filter bytes
+   * @param value
+   *   the value to test for membership (converted to `String` internally)
+   * @return
+   *   `true` if the value might be present (probabilistic), `false` if definitely absent
+   */
+  protected def bloomMightContain(bloomBytes: Array[Byte], value: Any): Boolean =
     if (bloomBytes == null || value == null) false
     else {
       val bf = deserializeBloomFilter(bloomBytes)
       bf.mightContain(value.toString)
     }
-  }
 
-  /** Creates a Spark UDF for checking bloom filter membership at query time.
-    *
-    * The returned UDF accepts a serialized bloom filter (`Array[Byte]`) and a
-    * candidate value (`String`), and returns `true` if the bloom filter
-    * indicates the value might be present.
-    *
-    * @return
-    *   UDF with signature `(Array[Byte], String) => Boolean`
-    */
-  protected def bloomContainsUdf: UserDefinedFunction = {
+  /**
+   * Creates a Spark UDF for checking bloom filter membership at query time.
+   *
+   * The returned UDF accepts a serialized bloom filter (`Array[Byte]`) and a candidate value (`String`), and returns
+   * `true` if the bloom filter indicates the value might be present.
+   *
+   * @return
+   *   UDF with signature `(Array[Byte], String) => Boolean`
+   */
+  protected def bloomContainsUdf: UserDefinedFunction =
     udf { (bloomBytes: Array[Byte], value: String) =>
       if (bloomBytes == null || value == null) false
       else {
@@ -250,46 +230,34 @@ trait BloomFilterOperations extends IndexFileOperations {
         bf.mightContain(value)
       }
     }
-  }
 
-  /** Locates files that might contain any of the given values using bloom
-    * filters.
-    *
-    * Collects all rows from the index, deserializes each file's bloom filter
-    * for the specified column, and tests every candidate value. A file is
-    * included in the result if any value passes the `mightContain` check.
-    *
-    * @note
-    *   This method calls `.collect()` to load all bloom filter binary data to
-    *   the driver. For indexes with millions of files, each row carries a
-    *   serialized bloom filter (potentially KBs each), which can cause driver
-    *   OOM. Consider increasing driver memory for very large indexes.
-    *
-    * @param column
-    *   the source column name (without `bloom_` prefix)
-    * @param values
-    *   array of candidate values to search for
-    * @param indexDf
-    *   the index DataFrame containing bloom filter binary columns
-    * @return
-    *   set of filenames whose bloom filters indicate a possible match; empty
-    *   set if the bloom column does not exist in the index
-    */
-  protected def locateFilesWithBloom(
-      column: String,
-      values: Array[Any],
-      indexDf: DataFrame
-  ): Set[String] = {
-    require(
-      column != null && column.trim.nonEmpty,
-      "column must not be null or blank"
-    )
+  /**
+   * Locates files that might contain any of the given values using bloom filters.
+   *
+   * Collects all rows from the index, deserializes each file's bloom filter for the specified column, and tests every
+   * candidate value. A file is included in the result if any value passes the `mightContain` check.
+   *
+   * @note
+   *   This method calls `.collect()` to load all bloom filter binary data to the driver. For indexes with millions of
+   *   files, each row carries a serialized bloom filter (potentially KBs each), which can cause driver OOM. Consider
+   *   increasing driver memory for very large indexes.
+   *
+   * @param column
+   *   the source column name (without `bloom_` prefix)
+   * @param values
+   *   array of candidate values to search for
+   * @param indexDf
+   *   the index DataFrame containing bloom filter binary columns
+   * @return
+   *   set of filenames whose bloom filters indicate a possible match; empty set if the bloom column does not exist in
+   *   the index
+   */
+  protected def locateFilesWithBloom(column: String, values: Array[Any], indexDf: DataFrame): Set[String] = {
+    require(column != null && column.trim.nonEmpty, "column must not be null or blank")
     require(values != null, "values must not be null")
     require(indexDf != null, "indexDf must not be null")
     val bloomColumn = bloomColumnPrefix + column
-    logger.warn(
-      s"Querying bloom filter for column '$column' with ${values.length} values"
-    )
+    logger.warn(s"Querying bloom filter for column '$column' with ${values.length} values")
 
     if (!indexDf.columns.contains(bloomColumn)) {
       logger.warn(s"Bloom column $bloomColumn not found in index")
@@ -298,60 +266,52 @@ trait BloomFilterOperations extends IndexFileOperations {
       // NOTE: collect() loads all bloom filter byte arrays to the driver. For very large
       // indexes with millions of files, this could cause driver OOM as each row includes
       // a serialized bloom filter (potentially KBs each).
-      val matchingFiles = indexDf
-        .select("filename", bloomColumn)
-        .collect()
-        .filter { row =>
-          val bloomBytes = row.getAs[Array[Byte]](bloomColumn)
-          if (bloomBytes == null) false
-          else {
-            // File matches if ANY value might be contained
-            values.exists(v => bloomMightContain(bloomBytes, v))
+      val matchingFiles =
+        indexDf
+          .select("filename", bloomColumn)
+          .collect()
+          .filter { row =>
+            val bloomBytes = row.getAs[Array[Byte]](bloomColumn)
+            if (bloomBytes == null) false
+            else {
+              // File matches if ANY value might be contained
+              values.exists(v => bloomMightContain(bloomBytes, v))
+            }
           }
-        }
-        .map(_.getString(0))
-        .toSet
+          .map(_.getString(0))
+          .toSet
 
-      logger.warn(
-        s"Bloom filter for '$column': ${matchingFiles.size} files matched out of total index rows"
-      )
+      logger.warn(s"Bloom filter for '$column': ${matchingFiles.size} files matched out of total index rows")
       matchingFiles
     }
   }
 
-  /** Locates files that might contain values from a DataFrame using bloom
-    * filters.
-    *
-    * Collects distinct non-null values from the specified column of `valuesDf`,
-    * then delegates to [[locateFilesWithBloom]] for the actual bloom filter
-    * check.
-    *
-    * @note
-    *   This method calls `.collect()` twice: first to gather distinct candidate
-    *   values from `valuesDf`, then indirectly via [[locateFilesWithBloom]] to
-    *   load all bloom filter binary data to the driver. Both operations can
-    *   cause driver OOM for very large DataFrames or indexes with millions of
-    *   files.
-    *
-    * @param column
-    *   the source column name (without `bloom_` prefix)
-    * @param valuesDf
-    *   DataFrame containing the candidate values to search for
-    * @param indexDf
-    *   the index DataFrame containing bloom filter binary columns
-    * @return
-    *   set of filenames whose bloom filters indicate a possible match; empty
-    *   set if no non-null values exist or the bloom column is missing
-    */
+  /**
+   * Locates files that might contain values from a DataFrame using bloom filters.
+   *
+   * Collects distinct non-null values from the specified column of `valuesDf`, then delegates to
+   * [[locateFilesWithBloom]] for the actual bloom filter check.
+   *
+   * @note
+   *   This method calls `.collect()` twice: first to gather distinct candidate values from `valuesDf`, then indirectly
+   *   via [[locateFilesWithBloom]] to load all bloom filter binary data to the driver. Both operations can cause driver
+   *   OOM for very large DataFrames or indexes with millions of files.
+   *
+   * @param column
+   *   the source column name (without `bloom_` prefix)
+   * @param valuesDf
+   *   DataFrame containing the candidate values to search for
+   * @param indexDf
+   *   the index DataFrame containing bloom filter binary columns
+   * @return
+   *   set of filenames whose bloom filters indicate a possible match; empty set if no non-null values exist or the
+   *   bloom column is missing
+   */
   protected def locateFilesWithBloomFromDataFrame(
       column: String,
       valuesDf: DataFrame,
-      indexDf: DataFrame
-  ): Set[String] = {
-    require(
-      column != null && column.trim.nonEmpty,
-      "column must not be null or blank"
-    )
+      indexDf: DataFrame): Set[String] = {
+    require(column != null && column.trim.nonEmpty, "column must not be null or blank")
     require(valuesDf != null, "valuesDf must not be null")
     require(indexDf != null, "indexDf must not be null")
     val bloomColumn = bloomColumnPrefix + column
@@ -361,18 +321,17 @@ trait BloomFilterOperations extends IndexFileOperations {
       Set.empty
     } else {
       // Collect distinct values from the query DataFrame
-      val values = valuesDf
-        .select(column)
-        .where(col(column).isNotNull)
-        .distinct()
-        .collect()
-        .map(_.get(0))
+      val values =
+        valuesDf
+          .select(column)
+          .where(col(column).isNotNull)
+          .distinct()
+          .collect()
+          .map(_.get(0))
 
       if (values.isEmpty) Set.empty
       else {
-        logger.warn(
-          s"Bloom filter query for '$column': ${values.length} distinct values from DataFrame"
-        )
+        logger.warn(s"Bloom filter query for '$column': ${values.length} distinct values from DataFrame")
         // Use the existing method with collected values
         locateFilesWithBloom(column, values, indexDf)
       }

--- a/src/main/scala/dev/cjfravel/ariadne/FileList.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/FileList.scala
@@ -1,39 +1,35 @@
 package dev.cjfravel.ariadne
 
-import dev.cjfravel.ariadne.exceptions._
-import org.apache.spark.sql.{SparkSession, DataFrame, Row}
-import org.apache.spark.sql.types._
-import org.apache.spark.sql.functions._
-import io.delta.tables.DeltaTable
-import org.apache.hadoop.fs.Path
-import org.apache.logging.log4j.{Logger, LogManager}
-import java.time.Instant
 import java.sql.Timestamp
+import java.time.Instant
 
-/** Manages a tracked list of files associated with an Ariadne index.
-  *
-  * Each file list is persisted as a Delta Lake table with two columns:
-  *   - `filename` (`StringType`, not nullable) — the file path
-  *   - `addedAt` (`TimestampType`, not nullable) — when the file was registered
-  *
-  * The DataFrame is lazily loaded and cached in memory after the first access.
-  * Mutations (add, remove) invalidate the cache so the next read re-loads from
-  * the Delta table.
-  *
-  * '''Thread safety:''' `FileList` instances are '''not''' thread-safe. The
-  * mutable `_files` cache can produce inconsistent results if accessed
-  * concurrently from multiple threads. Each thread should use its own instance,
-  * or external synchronization must be applied.
-  *
-  * @param name
-  *   the name of this file list, typically `"[ariadne_index] {indexName}"`
-  * @param spark
-  *   implicit SparkSession for Delta Lake operations
-  */
-case class FileList private (
-    name: String
-)(implicit val spark: SparkSession)
-    extends AriadneContextUser {
+import dev.cjfravel.ariadne.exceptions._
+import org.apache.hadoop.fs.Path
+import org.apache.logging.log4j.{LogManager, Logger}
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+
+/**
+ * Manages a tracked list of files associated with an Ariadne index.
+ *
+ * Each file list is persisted as a Delta Lake table with two columns:
+ *   - `filename` (`StringType`, not nullable) — the file path
+ *   - `addedAt` (`TimestampType`, not nullable) — when the file was registered
+ *
+ * The DataFrame is lazily loaded and cached in memory after the first access. Mutations (add, remove) invalidate the
+ * cache so the next read re-loads from the Delta table.
+ *
+ * '''Thread safety:''' `FileList` instances are '''not''' thread-safe. The mutable `_files` cache can produce
+ * inconsistent results if accessed concurrently from multiple threads. Each thread should use its own instance, or
+ * external synchronization must be applied.
+ *
+ * @param name
+ *   the name of this file list, typically `"[ariadne_index] {indexName}"`
+ * @param spark
+ *   implicit SparkSession for Delta Lake operations
+ */
+case class FileList private (name: String)(implicit val spark: SparkSession) extends AriadneContextUser {
   override lazy val logger: Logger = LogManager.getLogger("ariadne")
 
   override lazy val storagePath: Path = new Path(FileList.storagePath, name)
@@ -41,42 +37,35 @@ case class FileList private (
   /** Cached DataFrame of tracked files. Set to `null` to force reload. */
   private var _files: DataFrame = _
 
-  /** Loads or returns the cached file list DataFrame.
-    *
-    * On first access (or after cache invalidation), reads the Delta table at
-    * `storagePath`. If the table does not yet exist, returns an empty DataFrame
-    * with the expected schema. The loaded result is cached for subsequent
-    * calls.
-    *
-    * @param spark
-    *   the SparkSession to use for reading
-    * @return
-    *   DataFrame with columns (filename: String, addedAt: Timestamp)
-    */
+  /**
+   * Loads or returns the cached file list DataFrame.
+   *
+   * On first access (or after cache invalidation), reads the Delta table at `storagePath`. If the table does not yet
+   * exist, returns an empty DataFrame with the expected schema. The loaded result is cached for subsequent calls.
+   *
+   * @param spark
+   *   the SparkSession to use for reading
+   * @return
+   *   DataFrame with columns (filename: String, addedAt: Timestamp)
+   */
   private def files(spark: SparkSession): DataFrame = {
     if (_files == null) {
-      _files = delta(storagePath) match {
-        case Some(delta) =>
-          val df = delta.toDF
-          val count = df.count()
-          logger.warn(
-            s"Loaded file list '$name' from Delta table ($count files)"
-          )
-          df
-        case None =>
-          logger.warn(
-            s"File list '$name' not yet persisted, using empty DataFrame"
-          )
-          spark.createDataFrame(
-            spark.sparkContext.emptyRDD[Row],
-            StructType(
-              Seq(
-                StructField("filename", StringType, nullable = false),
-                StructField("addedAt", TimestampType, nullable = false)
-              )
-            )
-          )
-      }
+      _files =
+        delta(storagePath) match {
+          case Some(delta) =>
+            val df = delta.toDF
+            val count = df.count()
+            logger.warn(s"Loaded file list '$name' from Delta table ($count files)")
+            df
+          case None =>
+            logger.warn(s"File list '$name' not yet persisted, using empty DataFrame")
+            spark.createDataFrame(
+              spark.sparkContext.emptyRDD[Row],
+              StructType(
+                Seq(
+                  StructField("filename", StringType, nullable = false),
+                  StructField("addedAt", TimestampType, nullable = false))))
+        }
     } else {
       logger.debug(s"Returning cached file list '$name'")
     }
@@ -84,34 +73,29 @@ case class FileList private (
     _files
   }
 
-  /** Returns the DataFrame of tracked files with filename and addedAt columns.
-    *
-    * Lazily loaded from the Delta table on first access; subsequent calls
-    * return the cached DataFrame until the cache is invalidated by a mutation.
-    *
-    * @return
-    *   DataFrame with columns (filename: String, addedAt: Timestamp)
-    */
+  /**
+   * Returns the DataFrame of tracked files with filename and addedAt columns.
+   *
+   * Lazily loaded from the Delta table on first access; subsequent calls return the cached DataFrame until the cache is
+   * invalidated by a mutation.
+   *
+   * @return
+   *   DataFrame with columns (filename: String, addedAt: Timestamp)
+   */
   def files: DataFrame = files(spark)
 
-  /** Internal implementation for adding files to the file list.
-    *
-    * @param spark
-    *   the SparkSession to use
-    * @param fileNames
-    *   the file paths to add
-    */
+  /**
+   * Internal implementation for adding files to the file list.
+   *
+   * @param spark
+   *   the SparkSession to use
+   * @param fileNames
+   *   the file paths to add
+   */
   private def addFile(spark: SparkSession, fileNames: String*): Unit = {
     require(fileNames != null, "fileNames must not be null")
-    fileNames.foreach { fn =>
-      require(
-        fn != null && fn.trim.nonEmpty,
-        "Each fileName must be non-null and non-blank"
-      )
-    }
-    logger.warn(
-      s"addFile called on FileList '$name' with ${fileNames.size} file(s)"
-    )
+    fileNames.foreach(fn => require(fn != null && fn.trim.nonEmpty, "Each fileName must be non-null and non-blank"))
+    logger.warn(s"addFile called on FileList '$name' with ${fileNames.size} file(s)")
     import spark.implicits._
     val existing = files.select("filename").as[String].collect().toSet
     val toAdd = fileNames.toSet.diff(existing)
@@ -120,15 +104,13 @@ case class FileList private (
     } else {
       val ts = Timestamp.from(Instant.now())
       val newFilesData = toAdd.toList.map(filename => Row(filename, ts))
-      val newFiles = spark.createDataFrame(
-        spark.sparkContext.parallelize(newFilesData),
-        StructType(
-          Seq(
-            StructField("filename", StringType, nullable = false),
-            StructField("addedAt", TimestampType, nullable = false)
-          )
-        )
-      )
+      val newFiles =
+        spark.createDataFrame(
+          spark.sparkContext.parallelize(newFilesData),
+          StructType(
+            Seq(
+              StructField("filename", StringType, nullable = false),
+              StructField("addedAt", TimestampType, nullable = false))))
 
       val originalFiles = _files
       _files = _files.union(newFiles)
@@ -136,9 +118,7 @@ case class FileList private (
         write
       } catch {
         case e: Exception =>
-          logger.warn(
-            s"Failed to write FileList '$name', rolling back in-memory state: ${e.getMessage}"
-          )
+          logger.warn(s"Failed to write FileList '$name', rolling back in-memory state: ${e.getMessage}")
           _files = originalFiles
           throw e
       }
@@ -146,45 +126,36 @@ case class FileList private (
     }
   }
 
-  /** Registers new files in the file list.
-    *
-    * Files already present are silently skipped. The additions are written to
-    * the Delta table immediately; if the write fails, the in-memory cache is
-    * rolled back to its previous state.
-    *
-    * @param fileNames
-    *   one or more file paths to add
-    * @throws IllegalArgumentException
-    *   if fileNames is null or any individual file name is null or blank
-    * @note
-    *   Collects all existing filenames to the driver for duplicate detection.
-    *   May cause driver OOM for indexes tracking millions of files.
-    */
+  /**
+   * Registers new files in the file list.
+   *
+   * Files already present are silently skipped. The additions are written to the Delta table immediately; if the write
+   * fails, the in-memory cache is rolled back to its previous state.
+   *
+   * @param fileNames
+   *   one or more file paths to add
+   * @throws IllegalArgumentException
+   *   if fileNames is null or any individual file name is null or blank
+   * @note
+   *   Collects all existing filenames to the driver for duplicate detection. May cause driver OOM for indexes tracking
+   *   millions of files.
+   */
   def addFile(fileNames: String*): Unit = addFile(spark, fileNames: _*)
 
-  /** Removes files from the file list using a Delta merge-delete.
-    *
-    * After deletion, the in-memory cache is invalidated so the next read
-    * reflects the updated state.
-    *
-    * @param fileNames
-    *   one or more file paths to remove
-    * @throws IllegalArgumentException
-    *   if fileNames is null or empty, or any individual file name is null or
-    *   blank
-    */
+  /**
+   * Removes files from the file list using a Delta merge-delete.
+   *
+   * After deletion, the in-memory cache is invalidated so the next read reflects the updated state.
+   *
+   * @param fileNames
+   *   one or more file paths to remove
+   * @throws IllegalArgumentException
+   *   if fileNames is null or empty, or any individual file name is null or blank
+   */
   def removeFile(fileNames: String*): Unit = {
-    require(
-      fileNames != null && fileNames.nonEmpty,
-      "fileNames must not be null or empty"
-    )
-    require(
-      fileNames.forall(f => f != null && f.trim.nonEmpty),
-      "fileNames must not contain null or blank entries"
-    )
-    logger.warn(
-      s"removeFile called on FileList '$name' with ${fileNames.size} file(s)"
-    )
+    require(fileNames != null && fileNames.nonEmpty, "fileNames must not be null or empty")
+    require(fileNames.forall(f => f != null && f.trim.nonEmpty), "fileNames must not contain null or blank entries")
+    logger.warn(s"removeFile called on FileList '$name' with ${fileNames.size} file(s)")
     delta(storagePath) match {
       case Some(dt) =>
         import spark.implicits._
@@ -201,28 +172,27 @@ case class FileList private (
     }
   }
 
-  /** Checks if a specific file is tracked in this file list.
-    *
-    * @param fileName
-    *   the file path to check
-    * @return
-    *   true if the file exists in the list
-    * @throws IllegalArgumentException
-    *   if fileName is null or blank
-    */
+  /**
+   * Checks if a specific file is tracked in this file list.
+   *
+   * @param fileName
+   *   the file path to check
+   * @return
+   *   true if the file exists in the list
+   * @throws IllegalArgumentException
+   *   if fileName is null or blank
+   */
   def hasFile(fileName: String): Boolean = {
-    require(
-      fileName != null && fileName.trim.nonEmpty,
-      "fileName must not be null or blank"
-    )
+    require(fileName != null && fileName.trim.nonEmpty, "fileName must not be null or blank")
     !files.filter(col("filename") === fileName).isEmpty
   }
 
-  /** Persists the current in-memory file list to the Delta table.
-    *
-    * Uses a merge (upsert) if the table already exists, or a full overwrite for
-    * first-time creation. Invalidates the in-memory cache after writing.
-    */
+  /**
+   * Persists the current in-memory file list to the Delta table.
+   *
+   * Uses a merge (upsert) if the table already exists, or a full overwrite for first-time creation. Invalidates the
+   * in-memory cache after writing.
+   */
   private def write: Unit = {
     delta(storagePath) match {
       case Some(delta) =>
@@ -246,92 +216,90 @@ case class FileList private (
 
 }
 
-/** Factory and utility methods for FileList instances.
-  *
-  * Provides path resolution, existence checks, and removal operations for file
-  * lists stored as Delta tables.
-  */
+/**
+ * Factory and utility methods for FileList instances.
+ *
+ * Provides path resolution, existence checks, and removal operations for file lists stored as Delta tables.
+ */
 object FileList {
 
-  /** Returns the base storage path for all file lists.
-    *
-    * @param sparkSession
-    *   the implicit SparkSession
-    * @return
-    *   Hadoop Path to the filelists directory
-    */
+  /**
+   * Returns the base storage path for all file lists.
+   *
+   * @param sparkSession
+   *   the implicit SparkSession
+   * @return
+   *   Hadoop Path to the filelists directory
+   */
   def storagePath(implicit sparkSession: SparkSession): Path = {
-    val contextUser = new AriadneContextUser {
-      implicit def spark: SparkSession = sparkSession
-    }
+    val contextUser =
+      new AriadneContextUser {
+        implicit def spark: SparkSession = sparkSession
+      }
     new Path(contextUser.storagePath, "filelists")
   }
 
-  /** Checks if a file list with the given name exists on storage.
-    *
-    * @param name
-    *   the file list name
-    * @param sparkSession
-    *   the implicit SparkSession
-    * @return
-    *   true if the Delta table directory exists
-    * @throws IllegalArgumentException
-    *   if name is null or blank
-    */
+  /**
+   * Checks if a file list with the given name exists on storage.
+   *
+   * @param name
+   *   the file list name
+   * @param sparkSession
+   *   the implicit SparkSession
+   * @return
+   *   true if the Delta table directory exists
+   * @throws IllegalArgumentException
+   *   if name is null or blank
+   */
   def exists(name: String)(implicit sparkSession: SparkSession): Boolean = {
-    require(
-      name != null && name.trim.nonEmpty,
-      "name must not be null or blank"
-    )
-    val contextUser = new AriadneContextUser {
-      implicit def spark: SparkSession = sparkSession
-    }
+    require(name != null && name.trim.nonEmpty, "name must not be null or blank")
+    val contextUser =
+      new AriadneContextUser {
+        implicit def spark: SparkSession = sparkSession
+      }
     contextUser.exists(new Path(storagePath(sparkSession), name))
   }
 
-  /** Removes a file list's Delta table from storage.
-    *
-    * @param name
-    *   the file list name
-    * @param sparkSession
-    *   the implicit SparkSession
-    * @return
-    *   true if deletion was successful
-    * @throws FileListNotFoundException
-    *   if the file list does not exist
-    * @throws IllegalArgumentException
-    *   if name is null or blank
-    */
+  /**
+   * Removes a file list's Delta table from storage.
+   *
+   * @param name
+   *   the file list name
+   * @param sparkSession
+   *   the implicit SparkSession
+   * @return
+   *   true if deletion was successful
+   * @throws FileListNotFoundException
+   *   if the file list does not exist
+   * @throws IllegalArgumentException
+   *   if name is null or blank
+   */
   def remove(name: String)(implicit sparkSession: SparkSession): Boolean = {
-    require(
-      name != null && name.trim.nonEmpty,
-      "name must not be null or blank"
-    )
+    require(name != null && name.trim.nonEmpty, "name must not be null or blank")
     if (!exists(name)(sparkSession)) {
       throw new FileListNotFoundException(name)
     }
-    val contextUser = new AriadneContextUser {
-      implicit def spark: SparkSession = sparkSession
-    }
+    val contextUser =
+      new AriadneContextUser {
+        implicit def spark: SparkSession = sparkSession
+      }
     contextUser.delete(new Path(storagePath(sparkSession), name))
   }
 
-  /** Creates a new [[FileList]] instance for the given name.
-    *
-    * @param name
-    *   the file list name
-    * @param spark
-    *   the implicit SparkSession
-    * @return
-    *   a new FileList backed by a Delta table at `storagePath/name`
-    * @throws IllegalArgumentException
-    *   if name is null or blank
-    */
+  /**
+   * Creates a new [[FileList]] instance for the given name.
+   *
+   * @param name
+   *   the file list name
+   * @param spark
+   *   the implicit SparkSession
+   * @return
+   *   a new FileList backed by a Delta table at `storagePath/name`
+   * @throws IllegalArgumentException
+   *   if name is null or blank
+   */
   def apply(name: String)(implicit spark: SparkSession): FileList = {
-    require(
-      name != null && name.trim.nonEmpty,
-      "name must not be null or blank"
-    )
+    require(name != null && name.trim.nonEmpty, "name must not be null or blank")
     new FileList(name)(spark)
   }
 }

--- a/src/main/scala/dev/cjfravel/ariadne/Index.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/Index.scala
@@ -1,46 +1,42 @@
 package dev.cjfravel.ariadne
 
-import dev.cjfravel.ariadne.exceptions._
-import org.apache.spark.sql.{SparkSession, DataFrame}
-import org.apache.spark.sql.types._
-import org.apache.spark.sql.functions._
-import org.apache.hadoop.fs.Path
-import org.apache.logging.log4j.{Logger, LogManager}
-import dev.cjfravel.ariadne.Index.DataFrameOps
-import com.google.gson.Gson
-import scala.collection.JavaConverters._
 import java.util
-import java.util.{Collections, UUID}
+import java.util.UUID
 
-/** Represents an Index for managing metadata and file-based indexes in Apache
-  * Spark.
-  *
-  * This class provides methods to add, locate, and manage file-based indexing
-  * in Spark using Delta Lake. It supports schema enforcement, metadata
-  * persistence, and file tracking.
-  *
-  * @note
-  *   Index instances are NOT safe for concurrent use from multiple threads.
-  *   Each thread should use its own Index instance.
-  *
-  * @constructor
-  *   Private: use the factory methods in the companion object.
-  * @param spark
-  *   The SparkSession instance.
-  * @param name
-  *   The name of the index.
-  * @param schema
-  *   The optional schema of the index.
-  */
-case class Index private (
-    name: String,
-    schema: Option[StructType]
-)(implicit val spark: SparkSession)
+import scala.collection.JavaConverters._
+
+import dev.cjfravel.ariadne.exceptions._
+import org.apache.hadoop.fs.Path
+import org.apache.logging.log4j.{LogManager, Logger}
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+/**
+ * Represents an Index for managing metadata and file-based indexes in Apache Spark.
+ *
+ * This class provides methods to add, locate, and manage file-based indexing in Spark using Delta Lake. It supports
+ * schema enforcement, metadata persistence, and file tracking.
+ *
+ * @note
+ *   Index instances are NOT safe for concurrent use from multiple threads. Each thread should use its own Index
+ *   instance.
+ *
+ * @constructor
+ *   Private: use the factory methods in the companion object.
+ * @param spark
+ *   The SparkSession instance.
+ * @param name
+ *   The name of the index.
+ * @param schema
+ *   The optional schema of the index.
+ */
+case class Index private (name: String, schema: Option[StructType])(implicit val spark: SparkSession)
     extends IndexQueryOperations {
 
-  /** Selected columns for optimized reading. When set, only these columns plus
-    * join columns will be read.
-    */
+  /**
+   * Selected columns for optimized reading. When set, only these columns plus join columns will be read.
+   */
   private var selectedColumns: Option[Seq[String]] = None
 
   private def fileList: FileList = FileList(IndexPathUtils.fileListName(name))
@@ -55,91 +51,79 @@ case class Index private (
   /** Lock path for index update operations. */
   private def updateLockPath: Path = new Path(storagePath, ".update.lock")
 
-  /** Selects specific columns for optimized reading.
-    *
-    * When set, only the selected columns (plus any join columns) are read from
-    * data files, reducing I/O. Returns this Index for method chaining.
-    *
-    * @example
-    *   {{{
-    * val result = index.select("name", "email").join(df, Seq("userId"))
-    *   }}}
-    *
-    * @param columns
-    *   The column names to select
-    * @return
-    *   This Index instance for method chaining
-    * @throws IllegalArgumentException
-    *   if columns is null/empty or any column is null/blank
-    * @throws ColumnNotFoundException
-    *   if any specified column doesn't exist in the schema
-    */
+  /**
+   * Selects specific columns for optimized reading.
+   *
+   * When set, only the selected columns (plus any join columns) are read from data files, reducing I/O. Returns this
+   * Index for method chaining.
+   *
+   * @example
+   *   {{{
+   * val result = index.select("name", "email").join(df, Seq("userId"))
+   *   }}}
+   *
+   * @param columns
+   *   The column names to select
+   * @return
+   *   This Index instance for method chaining
+   * @throws IllegalArgumentException
+   *   if columns is null/empty or any column is null/blank
+   * @throws ColumnNotFoundException
+   *   if any specified column doesn't exist in the schema
+   */
   def select(columns: String*): Index = {
-    require(
-      columns != null && columns.nonEmpty,
-      "columns must not be null or empty"
-    )
-    require(
-      columns.forall(c => c != null && c.trim.nonEmpty),
-      "each column must not be null or blank"
-    )
+    require(columns != null && columns.nonEmpty, "columns must not be null or empty")
+    require(columns.forall(c => c != null && c.trim.nonEmpty), "each column must not be null or blank")
 
     // Validate that all specified columns exist in the schema
-    val invalidColumns = columns.filterNot { colName =>
-      SchemaHelper.fieldExists(storedSchema, colName)
-    }
+    val invalidColumns = columns.filterNot(colName => SchemaHelper.fieldExists(storedSchema, colName))
 
     if (invalidColumns.nonEmpty) {
-      throw new ColumnNotFoundException(
-        s"Columns not found in schema: ${invalidColumns.mkString(", ")}"
-      )
+      throw new ColumnNotFoundException(s"Columns not found in schema: ${invalidColumns.mkString(", ")}")
     }
 
     selectedColumns = Some(columns)
     this
   }
 
-  /** Gets the currently selected columns for reading.
-    * @return
-    *   the selected columns, or None if no column selection has been applied
-    */
+  /**
+   * Gets the currently selected columns for reading.
+   * @return
+   *   the selected columns, or None if no column selection has been applied
+   */
   private[ariadne] def getSelectedColumns: Option[Seq[String]] = selectedColumns
 
-  /** Checks if a file is tracked by this index's file list.
-    *
-    * @example
-    *   {{{val tracked = index.hasFile("s3a://bucket/data/file1.parquet")}}}
-    *
-    * @param fileName
-    *   The file path to check
-    * @return
-    *   true if the file is in the file list
-    */
+  /**
+   * Checks if a file is tracked by this index's file list.
+   *
+   * @example
+   *   {{{val tracked = index.hasFile("s3a://bucket/data/file1.parquet")}}}
+   *
+   * @param fileName
+   *   The file path to check
+   * @return
+   *   true if the file is in the file list
+   */
   def hasFile(fileName: String): Boolean = fileList.hasFile(fileName)
 
-  /** Adds files to the index's file list for future indexing. Acquires a file
-    * list lock to prevent concurrent modifications.
-    *
-    * @example
-    *   {{{
-    * index.addFile("/data/events/2024-01-01.parquet")
-    * index.addFile("/data/events/2024-01-02.parquet", "/data/events/2024-01-03.parquet")
-    *   }}}
-    *
-    * @param fileNames
-    *   One or more file paths to register
-    * @throws IllegalArgumentException
-    *   if fileNames is null/empty or any fileName is null/blank
-    */
+  /**
+   * Adds files to the index's file list for future indexing. Acquires a file list lock to prevent concurrent
+   * modifications.
+   *
+   * @example
+   *   {{{
+   * index.addFile("/data/events/2024-01-01.parquet")
+   * index.addFile("/data/events/2024-01-02.parquet", "/data/events/2024-01-03.parquet")
+   *   }}}
+   *
+   * @param fileNames
+   *   One or more file paths to register
+   * @throws IllegalArgumentException
+   *   if fileNames is null/empty or any fileName is null/blank
+   */
   def addFile(fileNames: String*): Unit = {
-    require(
-      fileNames != null && fileNames.nonEmpty,
-      "fileNames must not be null or empty"
-    )
-    require(
-      fileNames.forall(f => f != null && f.trim.nonEmpty),
-      "each fileName must not be null or blank"
-    )
+    require(fileNames != null && fileNames.nonEmpty, "fileNames must not be null or empty")
+    require(fileNames.forall(f => f != null && f.trim.nonEmpty), "each fileName must not be null or blank")
     val startTime = System.currentTimeMillis()
     logger.warn(s"Adding ${fileNames.size} file(s) to index '$name'")
     val lock = IndexLock(fileListLockPath, name)
@@ -150,39 +134,35 @@ case class Index private (
     } finally {
       lock.release(correlationId)
     }
-    logger.warn(
-      s"Added ${fileNames.size} file(s) to index '$name' in ${System.currentTimeMillis() - startTime}ms"
-    )
+    logger.warn(s"Added ${fileNames.size} file(s) to index '$name' in ${System.currentTimeMillis() - startTime}ms")
   }
 
-  /** Returns file paths registered via [[addFile]] that have not yet been
-    * indexed.
-    *
-    * Delegates to
-    * [[unindexedFiles(spark:org\.apache\.spark\.sql\.SparkSession)* unindexedFiles(SparkSession)]].
-    *
-    * @note
-    *   This method calls `collect()` on the driver, which can cause OOM if the
-    *   number of unindexed files is very large.
-    * @return
-    *   Set[String] of file paths not yet present in the index
-    */
+  /**
+   * Returns file paths registered via [[addFile]] that have not yet been indexed.
+   *
+   * Delegates to [[unindexedFiles(spark:org\.apache\.spark\.sql\.SparkSession)* unindexedFiles(SparkSession)]].
+   *
+   * @note
+   *   This method calls `collect()` on the driver, which can cause OOM if the number of unindexed files is very large.
+   * @return
+   *   Set[String] of file paths not yet present in the index
+   */
   private[ariadne] def unindexedFiles: Set[String] = unindexedFiles(spark)
 
-  /** Returns file paths registered via [[addFile]] that have not yet been
-    * indexed, using the provided SparkSession for implicit conversions.
-    *
-    * Performs a `left_anti` join between the file list and the existing index
-    * table to identify files that still need to be processed.
-    *
-    * @note
-    *   This method calls `collect()` on the driver, which can cause OOM if the
-    *   number of unindexed files is very large.
-    * @param spark
-    *   The SparkSession to use for implicit conversions
-    * @return
-    *   Set[String] of file paths not yet present in the index
-    */
+  /**
+   * Returns file paths registered via [[addFile]] that have not yet been indexed, using the provided SparkSession for
+   * implicit conversions.
+   *
+   * Performs a `left_anti` join between the file list and the existing index table to identify files that still need to
+   * be processed.
+   *
+   * @note
+   *   This method calls `collect()` on the driver, which can cause OOM if the number of unindexed files is very large.
+   * @param spark
+   *   The SparkSession to use for implicit conversions
+   * @return
+   *   Set[String] of file paths not yet present in the index
+   */
   private[ariadne] def unindexedFiles(spark: SparkSession): Set[String] = {
     val files = fileList.files
     if (files.isEmpty) {
@@ -202,61 +182,55 @@ case class Index private (
     }
   }
 
-  /** Identifies files already in the index that are missing data for newly
-    * added columns.
-    *
-    * Compares the columns declared in metadata against the columns present in
-    * the Delta index table schema. If any metadata columns are missing from the
-    * table, all indexed files need to be re-processed for the new columns.
-    *
-    * @return
-    *   Set[String] of filenames needing column backfill, empty if no backfill
-    *   needed
-    */
+  /**
+   * Identifies files already in the index that are missing data for newly added columns.
+   *
+   * Compares the columns declared in metadata against the columns present in the Delta index table schema. If any
+   * metadata columns are missing from the table, all indexed files need to be re-processed for the new columns.
+   *
+   * @return
+   *   Set[String] of filenames needing column backfill, empty if no backfill needed
+   */
   private[ariadne] def filesNeedingColumnUpdate: Set[String] = {
     import spark.implicits._
     index match {
       case Some(df) =>
-        val expectedCols = storageColumns ++ bloomStorageColumns ++
-          metadata.temporal_indexes.asScala.map(_.column).toSet ++
-          rangeStorageColumns ++ autoBloomStorageColumns
+        val expectedCols =
+          storageColumns ++ bloomStorageColumns ++
+            metadata.temporal_indexes.asScala.map(_.column).toSet ++
+            rangeStorageColumns ++ autoBloomStorageColumns
         val existingCols = df.columns.toSet - "filename"
         val missingCols = expectedCols -- existingCols
         if (missingCols.isEmpty) {
           Set.empty[String]
         } else {
-          logger.warn(
-            s"Detected new index columns not yet in index table: ${missingCols.mkString(", ")}"
-          )
+          logger.warn(s"Detected new index columns not yet in index table: ${missingCols.mkString(", ")}")
           df.select("filename").as[String].collect().toSet
         }
       case None => Set.empty
     }
   }
 
-  /** Adds a regular (array-of-distinct-values) index for the specified column.
-    *
-    * Idempotent: calling again with the same column is a no-op.
-    *
-    * @example
-    *   {{{
-    * val index = Index("myIndex", schema, "parquet")
-    * index.addIndex("userId")
-    *   }}}
-    *
-    * @param index
-    *   The column name to index.
-    * @throws IllegalArgumentException
-    *   if the column name is null/blank or already indexed by another type
-    *   (bloom, temporal, or range)
-    * @throws ColumnNotFoundException
-    *   if the column doesn't exist in the schema
-    */
+  /**
+   * Adds a regular (array-of-distinct-values) index for the specified column.
+   *
+   * Idempotent: calling again with the same column is a no-op.
+   *
+   * @example
+   *   {{{
+   * val index = Index("myIndex", schema, "parquet")
+   * index.addIndex("userId")
+   *   }}}
+   *
+   * @param index
+   *   The column name to index.
+   * @throws IllegalArgumentException
+   *   if the column name is null/blank or already indexed by another type (bloom, temporal, or range)
+   * @throws ColumnNotFoundException
+   *   if the column doesn't exist in the schema
+   */
   def addIndex(index: String): Unit = {
-    require(
-      index != null && index.trim.nonEmpty,
-      "index column name must not be null or blank"
-    )
+    require(index != null && index.trim.nonEmpty, "index column name must not be null or blank")
     logger.warn(s"Adding regular index on column '$index' for index '$name'")
 
     if (!metadata.indexes.contains(index)) {
@@ -264,36 +238,26 @@ case class Index private (
       if (metadata.bloom_indexes.asScala.exists(_.column == index)) {
         throw new IllegalArgumentException(
           s"Column '$index' is already a bloom index. " +
-            "A column cannot be both a regular index and a bloom index."
-        )
+            "A column cannot be both a regular index and a bloom index.")
       }
 
       // Check mutual exclusivity with temporal indexes
       if (metadata.temporal_indexes.asScala.exists(_.column == index)) {
         throw new IllegalArgumentException(
           s"Column '$index' is already a temporal index. " +
-            "A column cannot be both a regular index and a temporal index."
-        )
+            "A column cannot be both a regular index and a temporal index.")
       }
 
       // Check mutual exclusivity with range indexes
       if (metadata.range_indexes.asScala.exists(_.column == index)) {
         throw new IllegalArgumentException(
           s"Column '$index' is already a range index. " +
-            "A column cannot be both a regular index and a range index."
-        )
+            "A column cannot be both a regular index and a range index.")
       }
 
       // Validate column exists in schema (only if schema is available)
-      if (
-        metadata.schema != null && !SchemaHelper.fieldExists(
-          storedSchema,
-          index
-        )
-      ) {
-        throw new ColumnNotFoundException(
-          s"Column '$index' not found in schema"
-        )
+      if (metadata.schema != null && !SchemaHelper.fieldExists(storedSchema, index)) {
+        throw new ColumnNotFoundException(s"Column '$index' not found in schema")
       }
 
       metadata.indexes.add(index)
@@ -303,36 +267,31 @@ case class Index private (
     logger.debug(s"addIndex completed for column '$index' on index '$name'")
   }
 
-  /** Adds a bloom filter index for the specified column.
-    *
-    * Bloom filters are probabilistic data structures that provide:
-    *   - Guaranteed NO false negatives (if filter says "no", value definitely
-    *     absent)
-    *   - Configurable false positive rate (if filter says "yes", value MIGHT be
-    *     present)
-    *   - Space-efficient storage (approximately 10 bits per element at 1% FPR)
-    *
-    * @example
-    *   {{{
-    * index.addBloomIndex("sessionId")
-    * index.addBloomIndex("ipAddress", 0.001)
-    *   }}}
-    *
-    * @param column
-    *   The column name to index with a bloom filter
-    * @param fpr
-    *   False positive rate between 0.0 and 1.0 (default 0.01 = 1%)
-    * @throws IllegalArgumentException
-    *   if column is null/blank, FPR out of range, or column is already a
-    *   regular or computed index
-    * @throws ColumnNotFoundException
-    *   if column doesn't exist in schema
-    */
+  /**
+   * Adds a bloom filter index for the specified column.
+   *
+   * Bloom filters are probabilistic data structures that provide:
+   *   - Guaranteed NO false negatives (if filter says "no", value definitely absent)
+   *   - Configurable false positive rate (if filter says "yes", value MIGHT be present)
+   *   - Space-efficient storage (approximately 10 bits per element at 1% FPR)
+   *
+   * @example
+   *   {{{
+   * index.addBloomIndex("sessionId")
+   * index.addBloomIndex("ipAddress", 0.001)
+   *   }}}
+   *
+   * @param column
+   *   The column name to index with a bloom filter
+   * @param fpr
+   *   False positive rate between 0.0 and 1.0 (default 0.01 = 1%)
+   * @throws IllegalArgumentException
+   *   if column is null/blank, FPR out of range, or column is already a regular or computed index
+   * @throws ColumnNotFoundException
+   *   if column doesn't exist in schema
+   */
   def addBloomIndex(column: String, fpr: Double = 0.01): Unit = {
-    require(
-      column != null && column.trim.nonEmpty,
-      "bloom index column name must not be null or blank"
-    )
+    require(column != null && column.trim.nonEmpty, "bloom index column name must not be null or blank")
     // Validate FPR range
     require(fpr > 0 && fpr < 1, s"FPR must be between 0 and 1, got: $fpr")
     logger.warn(s"Adding bloom index on column '$column' for index '$name'")
@@ -342,143 +301,96 @@ case class Index private (
       if (metadata.indexes.contains(column)) {
         throw new IllegalArgumentException(
           s"Column '$column' is already a regular index. " +
-            "A column cannot be both a bloom index and a regular index."
-        )
+            "A column cannot be both a bloom index and a regular index.")
       }
       if (metadata.computed_indexes.containsKey(column)) {
         throw new IllegalArgumentException(
           s"Column '$column' is already a computed index. " +
-            "A column cannot be both a bloom index and a computed index."
-        )
+            "A column cannot be both a bloom index and a computed index.")
       }
       if (metadata.temporal_indexes.asScala.exists(_.column == column)) {
         throw new IllegalArgumentException(
           s"Column '$column' is already a temporal index. " +
-            "A column cannot be both a bloom index and a temporal index."
-        )
+            "A column cannot be both a bloom index and a temporal index.")
       }
       if (metadata.range_indexes.asScala.exists(_.column == column)) {
         throw new IllegalArgumentException(
           s"Column '$column' is already a range index. " +
-            "A column cannot be both a bloom index and a range index."
-        )
+            "A column cannot be both a bloom index and a range index.")
       }
 
       // Validate column exists in schema (only if schema is available)
-      if (
-        metadata.schema != null && !SchemaHelper.fieldExists(
-          storedSchema,
-          column
-        )
-      ) {
-        throw new ColumnNotFoundException(
-          s"Column '$column' not found in schema"
-        )
+      if (metadata.schema != null && !SchemaHelper.fieldExists(storedSchema, column)) {
+        throw new ColumnNotFoundException(s"Column '$column' not found in schema")
       }
 
       val config = BloomIndexConfig(column, fpr)
       metadata.bloom_indexes.add(config)
       writeMetadata(metadata)
-      logger.warn(
-        s"Added bloom index for column '$column' with FPR=$fpr to index '$name'"
-      )
+      logger.warn(s"Added bloom index for column '$column' with FPR=$fpr to index '$name'")
     }
-    logger.debug(
-      s"addBloomIndex completed for column '$column' on index '$name'"
-    )
+    logger.debug(s"addBloomIndex completed for column '$column' on index '$name'")
   }
 
-  /** Adds an exploded field index for a nested field inside an array column.
-    *
-    * During [[update]], each element of `arrayColumn` is exploded, the
-    * `fieldPath` is extracted, and the distinct values are stored under
-    * `asColumn` in the index. Joins on `asColumn` will locate files containing
-    * any matching array element. Idempotent: calling again with the same
-    * `asColumn` is a no-op.
-    *
-    * @example
-    *   {{{
-    * // Index the "id" field from each element of the "items" array column
-    * index.addExplodedFieldIndex("items", "id", "item_id")
-    *   }}}
-    *
-    * @param arrayColumn
-    *   The array column to explode.
-    * @param fieldPath
-    *   The dot-separated field path to extract from each array element (e.g.,
-    *   "id" or "profile.user_id").
-    * @param asColumn
-    *   The virtual column name exposed for joins.
-    * @throws IllegalArgumentException
-    *   if any parameter is null/blank, or `asColumn` conflicts with another
-    *   index type
-    */
-  def addExplodedFieldIndex(
-      arrayColumn: String,
-      fieldPath: String,
-      asColumn: String
-  ): Unit = {
-    require(
-      arrayColumn != null && arrayColumn.trim.nonEmpty,
-      "arrayColumn must not be null or blank"
-    )
-    require(
-      fieldPath != null && fieldPath.trim.nonEmpty,
-      "fieldPath must not be null or blank"
-    )
-    require(
-      asColumn != null && asColumn.trim.nonEmpty,
-      "asColumn must not be null or blank"
-    )
-    logger.warn(
-      s"Adding exploded field index '$asColumn' on column '$arrayColumn' for index '$name'"
-    )
+  /**
+   * Adds an exploded field index for a nested field inside an array column.
+   *
+   * During [[update]], each element of `arrayColumn` is exploded, the `fieldPath` is extracted, and the distinct values
+   * are stored under `asColumn` in the index. Joins on `asColumn` will locate files containing any matching array
+   * element. Idempotent: calling again with the same `asColumn` is a no-op.
+   *
+   * @example
+   *   {{{
+   * // Index the "id" field from each element of the "items" array column
+   * index.addExplodedFieldIndex("items", "id", "item_id")
+   *   }}}
+   *
+   * @param arrayColumn
+   *   The array column to explode.
+   * @param fieldPath
+   *   The dot-separated field path to extract from each array element (e.g., "id" or "profile.user_id").
+   * @param asColumn
+   *   The virtual column name exposed for joins.
+   * @throws IllegalArgumentException
+   *   if any parameter is null/blank, or `asColumn` conflicts with another index type
+   */
+  def addExplodedFieldIndex(arrayColumn: String, fieldPath: String, asColumn: String): Unit = {
+    require(arrayColumn != null && arrayColumn.trim.nonEmpty, "arrayColumn must not be null or blank")
+    require(fieldPath != null && fieldPath.trim.nonEmpty, "fieldPath must not be null or blank")
+    require(asColumn != null && asColumn.trim.nonEmpty, "asColumn must not be null or blank")
+    logger.warn(s"Adding exploded field index '$asColumn' on column '$arrayColumn' for index '$name'")
 
-    if (
-      !metadata.exploded_field_indexes.asScala.exists(_.as_column == asColumn)
-    ) {
+    if (!metadata.exploded_field_indexes.asScala.exists(_.as_column == asColumn)) {
       // Mutual exclusivity checks
       if (metadata.indexes.contains(asColumn)) {
         throw new IllegalArgumentException(
           s"Column '$asColumn' is already a regular index. " +
-            "A column cannot be both an exploded field index and a regular index."
-        )
+            "A column cannot be both an exploded field index and a regular index.")
       }
       if (metadata.computed_indexes.containsKey(asColumn)) {
         throw new IllegalArgumentException(
           s"Column '$asColumn' is already a computed index. " +
-            "A column cannot be both an exploded field index and a computed index."
-        )
+            "A column cannot be both an exploded field index and a computed index.")
       }
       if (metadata.bloom_indexes.asScala.exists(_.column == asColumn)) {
         throw new IllegalArgumentException(
           s"Column '$asColumn' is already a bloom index. " +
-            "A column cannot be both an exploded field index and a bloom index."
-        )
+            "A column cannot be both an exploded field index and a bloom index.")
       }
       if (metadata.temporal_indexes.asScala.exists(_.column == asColumn)) {
         throw new IllegalArgumentException(
           s"Column '$asColumn' is already a temporal index. " +
-            "A column cannot be both an exploded field index and a temporal index."
-        )
+            "A column cannot be both an exploded field index and a temporal index.")
       }
       if (metadata.range_indexes.asScala.exists(_.column == asColumn)) {
         throw new IllegalArgumentException(
           s"Column '$asColumn' is already a range index. " +
-            "A column cannot be both an exploded field index and a range index."
-        )
+            "A column cannot be both an exploded field index and a range index.")
       }
 
       // Validate array column exists in schema (only if schema is available)
-      if (
-        metadata.schema != null && !SchemaHelper.fieldExists(
-          storedSchema,
-          arrayColumn
-        )
-      ) {
-        throw new ColumnNotFoundException(
-          s"Array column '$arrayColumn' not found in schema"
-        )
+      if (metadata.schema != null && !SchemaHelper.fieldExists(storedSchema, arrayColumn)) {
+        throw new ColumnNotFoundException(s"Array column '$arrayColumn' not found in schema")
       }
 
       // Validate that the column is actually an ArrayType (only if schema is available)
@@ -487,8 +399,7 @@ case class Index private (
           if (!dt.isInstanceOf[ArrayType]) {
             throw new IllegalArgumentException(
               s"Column '$arrayColumn' is ${dt.typeName}, not ArrayType. " +
-                "addExplodedFieldIndex requires an array column."
-            )
+                "addExplodedFieldIndex requires an array column.")
           }
         }
       }
@@ -497,26 +408,22 @@ case class Index private (
         ExplodedFieldMapping(arrayColumn, fieldPath, asColumn)
       metadata.exploded_field_indexes.add(explodedFieldMapping)
       writeMetadata(metadata)
-      logger.warn(
-        s"Added exploded field index '$asColumn' (array='$arrayColumn', path='$fieldPath') to index '$name'"
-      )
+      logger.warn(s"Added exploded field index '$asColumn' (array='$arrayColumn', path='$fieldPath') to index '$name'")
     }
-    logger.debug(
-      s"addExplodedFieldIndex completed for column '$asColumn' on index '$name'"
-    )
+    logger.debug(s"addExplodedFieldIndex completed for column '$asColumn' on index '$name'")
   }
 
-  /** Returns all column names that can be used in joins across all index types.
-    *
-    * Includes regular, computed, exploded field, bloom, temporal, and range
-    * index columns.
-    *
-    * @example
-    *   {{{val allIndexedColumns: Set[String] = index.indexes}}}
-    *
-    * @return
-    *   the union of all indexed column names across every index type
-    */
+  /**
+   * Returns all column names that can be used in joins across all index types.
+   *
+   * Includes regular, computed, exploded field, bloom, temporal, and range index columns.
+   *
+   * @example
+   *   {{{val allIndexedColumns: Set[String] = index.indexes}}}
+   *
+   * @return
+   *   the union of all indexed column names across every index type
+   */
   def indexes: Set[String] =
     metadata.indexes.asScala.toSet ++
       metadata.computed_indexes.keySet().asScala ++
@@ -525,34 +432,27 @@ case class Index private (
       metadata.temporal_indexes.asScala.map(_.column).toSet ++
       metadata.range_indexes.asScala.map(_.column).toSet
 
-  /** Adds a computed index derived from a SQL expression.
-    *
-    * The expression is evaluated during [[update]] to produce a virtual column
-    * whose distinct values are stored in the index. Idempotent: calling again
-    * with the same name is a no-op.
-    *
-    * @example
-    *   {{{
-    * index.addComputedIndex("yearMonth", "date_format(event_date, 'yyyy-MM')")
-    *   }}}
-    *
-    * @param name
-    *   The alias name for the computed column
-    * @param sql_expression
-    *   A Spark SQL expression evaluated against each data file
-    * @throws IllegalArgumentException
-    *   if name or sql_expression is null/blank, or name conflicts with another
-    *   index type
-    */
+  /**
+   * Adds a computed index derived from a SQL expression.
+   *
+   * The expression is evaluated during [[update]] to produce a virtual column whose distinct values are stored in the
+   * index. Idempotent: calling again with the same name is a no-op.
+   *
+   * @example
+   *   {{{
+   * index.addComputedIndex("yearMonth", "date_format(event_date, 'yyyy-MM')")
+   *   }}}
+   *
+   * @param name
+   *   The alias name for the computed column
+   * @param sql_expression
+   *   A Spark SQL expression evaluated against each data file
+   * @throws IllegalArgumentException
+   *   if name or sql_expression is null/blank, or name conflicts with another index type
+   */
   def addComputedIndex(name: String, sql_expression: String): Unit = {
-    require(
-      name != null && name.trim.nonEmpty,
-      "computed index name must not be null or blank"
-    )
-    require(
-      sql_expression != null && sql_expression.trim.nonEmpty,
-      "sql_expression must not be null or blank"
-    )
+    require(name != null && name.trim.nonEmpty, "computed index name must not be null or blank")
+    require(sql_expression != null && sql_expression.trim.nonEmpty, "sql_expression must not be null or blank")
     logger.warn(s"Adding computed index '$name' for index '${this.name}'")
 
     if (!metadata.computed_indexes.containsKey(name)) {
@@ -560,76 +460,59 @@ case class Index private (
       if (metadata.indexes.contains(name)) {
         throw new IllegalArgumentException(
           s"Column '$name' is already a regular index. " +
-            "A column cannot be both a computed index and a regular index."
-        )
+            "A column cannot be both a computed index and a regular index.")
       }
       if (metadata.bloom_indexes.asScala.exists(_.column == name)) {
         throw new IllegalArgumentException(
           s"Column '$name' is already a bloom index. " +
-            "A column cannot be both a computed index and a bloom index."
-        )
+            "A column cannot be both a computed index and a bloom index.")
       }
       if (metadata.temporal_indexes.asScala.exists(_.column == name)) {
         throw new IllegalArgumentException(
           s"Column '$name' is already a temporal index. " +
-            "A column cannot be both a computed index and a temporal index."
-        )
+            "A column cannot be both a computed index and a temporal index.")
       }
       if (metadata.range_indexes.asScala.exists(_.column == name)) {
         throw new IllegalArgumentException(
           s"Column '$name' is already a range index. " +
-            "A column cannot be both a computed index and a range index."
-        )
+            "A column cannot be both a computed index and a range index.")
       }
       if (metadata.exploded_field_indexes.asScala.exists(_.as_column == name)) {
         throw new IllegalArgumentException(
           s"Column '$name' is already an exploded field index. " +
-            "A column cannot be both a computed index and an exploded field index."
-        )
+            "A column cannot be both a computed index and an exploded field index.")
       }
 
       metadata.computed_indexes.put(name, sql_expression)
       writeMetadata(metadata)
-      logger.warn(
-        s"Added computed index '$name' with expression to index '${this.name}'"
-      )
+      logger.warn(s"Added computed index '$name' with expression to index '${this.name}'")
     }
-    logger.debug(
-      s"addComputedIndex completed for column '$name' on index '${this.name}'"
-    )
+    logger.debug(s"addComputedIndex completed for column '$name' on index '${this.name}'")
   }
 
-  /** Adds a temporal index for the specified column using a timestamp for
-    * versioning.
-    *
-    * When joining on a temporal index column, only the latest version (by
-    * timestamp) of each value is returned. This is useful when multiple files
-    * contain the same entity at different points in time.
-    *
-    * @example
-    *   {{{
-    * index.addTemporalIndex("userId", "updated_at")
-    *   }}}
-    *
-    * @param column
-    *   The value column to index on (e.g., "user_id")
-    * @param timestampColumn
-    *   The timestamp column for ordering versions (e.g., "updated_at")
-    * @throws IllegalArgumentException
-    *   if column or timestampColumn is null/blank, or column is already indexed
-    *   by another type
-    * @throws ColumnNotFoundException
-    *   if either column doesn't exist in schema
-    */
+  /**
+   * Adds a temporal index for the specified column using a timestamp for versioning.
+   *
+   * When joining on a temporal index column, only the latest version (by timestamp) of each value is returned. This is
+   * useful when multiple files contain the same entity at different points in time.
+   *
+   * @example
+   *   {{{
+   * index.addTemporalIndex("userId", "updated_at")
+   *   }}}
+   *
+   * @param column
+   *   The value column to index on (e.g., "user_id")
+   * @param timestampColumn
+   *   The timestamp column for ordering versions (e.g., "updated_at")
+   * @throws IllegalArgumentException
+   *   if column or timestampColumn is null/blank, or column is already indexed by another type
+   * @throws ColumnNotFoundException
+   *   if either column doesn't exist in schema
+   */
   def addTemporalIndex(column: String, timestampColumn: String): Unit = {
-    require(
-      column != null && column.trim.nonEmpty,
-      "temporal index column must not be null or blank"
-    )
-    require(
-      timestampColumn != null && timestampColumn.trim.nonEmpty,
-      "timestampColumn must not be null or blank"
-    )
+    require(column != null && column.trim.nonEmpty, "temporal index column must not be null or blank")
+    require(timestampColumn != null && timestampColumn.trim.nonEmpty, "timestampColumn must not be null or blank")
     logger.warn(s"Adding temporal index on column '$column' for index '$name'")
 
     if (!metadata.temporal_indexes.asScala.exists(_.column == column)) {
@@ -637,77 +520,62 @@ case class Index private (
       if (metadata.indexes.contains(column)) {
         throw new IllegalArgumentException(
           s"Column '$column' is already a regular index. " +
-            "A column cannot be both a temporal index and a regular index."
-        )
+            "A column cannot be both a temporal index and a regular index.")
       }
       if (metadata.computed_indexes.containsKey(column)) {
         throw new IllegalArgumentException(
           s"Column '$column' is already a computed index. " +
-            "A column cannot be both a temporal index and a computed index."
-        )
+            "A column cannot be both a temporal index and a computed index.")
       }
       if (metadata.bloom_indexes.asScala.exists(_.column == column)) {
         throw new IllegalArgumentException(
           s"Column '$column' is already a bloom index. " +
-            "A column cannot be both a temporal index and a bloom index."
-        )
+            "A column cannot be both a temporal index and a bloom index.")
       }
       if (metadata.range_indexes.asScala.exists(_.column == column)) {
         throw new IllegalArgumentException(
           s"Column '$column' is already a range index. " +
-            "A column cannot be both a temporal index and a range index."
-        )
+            "A column cannot be both a temporal index and a range index.")
       }
 
       // Validate both columns exist in schema (only if schema is available)
       if (metadata.schema != null) {
         if (!SchemaHelper.fieldExists(storedSchema, column)) {
-          throw new ColumnNotFoundException(
-            s"Column '$column' not found in schema"
-          )
+          throw new ColumnNotFoundException(s"Column '$column' not found in schema")
         }
         if (!SchemaHelper.fieldExists(storedSchema, timestampColumn)) {
-          throw new ColumnNotFoundException(
-            s"Timestamp column '$timestampColumn' not found in schema"
-          )
+          throw new ColumnNotFoundException(s"Timestamp column '$timestampColumn' not found in schema")
         }
       }
 
       val config = TemporalIndexConfig(column, timestampColumn)
       metadata.temporal_indexes.add(config)
       writeMetadata(metadata)
-      logger.warn(
-        s"Added temporal index for column '$column' (timestamp='$timestampColumn') to index '$name'"
-      )
+      logger.warn(s"Added temporal index for column '$column' (timestamp='$timestampColumn') to index '$name'")
     }
-    logger.debug(
-      s"addTemporalIndex completed for column '$column' on index '$name'"
-    )
+    logger.debug(s"addTemporalIndex completed for column '$column' on index '$name'")
   }
 
-  /** Adds a range index for the specified column.
-    *
-    * Range indexes store min/max values per file, enabling file pruning at
-    * query time. Files whose [min, max] range does not overlap with the queried
-    * values are skipped.
-    *
-    * @example
-    *   {{{
-    * index.addRangeIndex("timestamp")
-    *   }}}
-    *
-    * @param column
-    *   The column to index with min/max range
-    * @throws IllegalArgumentException
-    *   if column is null/blank or already indexed by another type
-    * @throws ColumnNotFoundException
-    *   if column doesn't exist in schema
-    */
+  /**
+   * Adds a range index for the specified column.
+   *
+   * Range indexes store min/max values per file, enabling file pruning at query time. Files whose [min, max] range does
+   * not overlap with the queried values are skipped.
+   *
+   * @example
+   *   {{{
+   * index.addRangeIndex("timestamp")
+   *   }}}
+   *
+   * @param column
+   *   The column to index with min/max range
+   * @throws IllegalArgumentException
+   *   if column is null/blank or already indexed by another type
+   * @throws ColumnNotFoundException
+   *   if column doesn't exist in schema
+   */
   def addRangeIndex(column: String): Unit = {
-    require(
-      column != null && column.trim.nonEmpty,
-      "range index column must not be null or blank"
-    )
+    require(column != null && column.trim.nonEmpty, "range index column must not be null or blank")
     logger.warn(s"Adding range index on column '$column' for index '$name'")
 
     if (!metadata.range_indexes.asScala.exists(_.column == column)) {
@@ -715,38 +583,27 @@ case class Index private (
       if (metadata.indexes.contains(column)) {
         throw new IllegalArgumentException(
           s"Column '$column' is already a regular index. " +
-            "A column cannot be both a range index and a regular index."
-        )
+            "A column cannot be both a range index and a regular index.")
       }
       if (metadata.computed_indexes.containsKey(column)) {
         throw new IllegalArgumentException(
           s"Column '$column' is already a computed index. " +
-            "A column cannot be both a range index and a computed index."
-        )
+            "A column cannot be both a range index and a computed index.")
       }
       if (metadata.bloom_indexes.asScala.exists(_.column == column)) {
         throw new IllegalArgumentException(
           s"Column '$column' is already a bloom index. " +
-            "A column cannot be both a range index and a bloom index."
-        )
+            "A column cannot be both a range index and a bloom index.")
       }
       if (metadata.temporal_indexes.asScala.exists(_.column == column)) {
         throw new IllegalArgumentException(
           s"Column '$column' is already a temporal index. " +
-            "A column cannot be both a range index and a temporal index."
-        )
+            "A column cannot be both a range index and a temporal index.")
       }
 
       // Validate column exists in schema (only if schema is available)
-      if (
-        metadata.schema != null && !SchemaHelper.fieldExists(
-          storedSchema,
-          column
-        )
-      ) {
-        throw new ColumnNotFoundException(
-          s"Column '$column' not found in schema"
-        )
+      if (metadata.schema != null && !SchemaHelper.fieldExists(storedSchema, column)) {
+        throw new ColumnNotFoundException(s"Column '$column' not found in schema")
       }
 
       val config = RangeIndexConfig(column)
@@ -754,40 +611,31 @@ case class Index private (
       writeMetadata(metadata)
       logger.warn(s"Added range index for column '$column' to index '$name'")
     }
-    logger.debug(
-      s"addRangeIndex completed for column '$column' on index '$name'"
-    )
+    logger.debug(s"addRangeIndex completed for column '$column' on index '$name'")
   }
 
-  /** Deletes the specified files from the index, large index tables, and file
-    * list.
-    *
-    * Acquires the update lock, removes matching rows from the main index Delta
-    * table, all large index Delta tables, and the FileList. If a filename
-    * doesn't exist in the index, it is silently ignored.
-    *
-    * @example
-    *   {{{
-    * index.deleteFiles("/data/events/2024-01-01.parquet")
-    * index.deleteFiles("/data/old1.parquet", "/data/old2.parquet")
-    *   }}}
-    *
-    * @param filenames
-    *   One or more filenames to remove from the index.
-    * @throws IllegalArgumentException
-    *   if filenames is null/empty or contains null/blank entries
-    * @throws IndexLockException
-    *   if the update lock cannot be acquired within the configured timeout
-    */
+  /**
+   * Deletes the specified files from the index, large index tables, and file list.
+   *
+   * Acquires the update lock, removes matching rows from the main index Delta table, all large index Delta tables, and
+   * the FileList. If a filename doesn't exist in the index, it is silently ignored.
+   *
+   * @example
+   *   {{{
+   * index.deleteFiles("/data/events/2024-01-01.parquet")
+   * index.deleteFiles("/data/old1.parquet", "/data/old2.parquet")
+   *   }}}
+   *
+   * @param filenames
+   *   One or more filenames to remove from the index.
+   * @throws IllegalArgumentException
+   *   if filenames is null/empty or contains null/blank entries
+   * @throws IndexLockException
+   *   if the update lock cannot be acquired within the configured timeout
+   */
   def deleteFiles(filenames: String*): Unit = {
-    require(
-      filenames != null && filenames.nonEmpty,
-      "filenames must not be null or empty"
-    )
-    require(
-      filenames.forall(f => f != null && f.trim.nonEmpty),
-      "filenames must not contain null or blank entries"
-    )
+    require(filenames != null && filenames.nonEmpty, "filenames must not be null or empty")
+    require(filenames.forall(f => f != null && f.trim.nonEmpty), "filenames must not contain null or blank entries")
     val startTime = System.currentTimeMillis()
     logger.warn(s"Deleting ${filenames.size} file(s) from index '$name'")
     val lock = IndexLock(updateLockPath, name)
@@ -798,18 +646,20 @@ case class Index private (
       val toDelete = filenames.toDF("filename")
 
       // Read file sizes before deleting (to update total)
-      val deletedFileSize = delta(indexFilePath)
-        .map { dt =>
-          val indexDf = dt.toDF
-          if (indexDf.columns.contains("file_size")) {
-            val result = indexDf
-              .join(toDelete, Seq("filename"), "inner")
-              .agg(sum("file_size"))
-              .head()
-            if (result.isNullAt(0)) 0L else result.getLong(0)
-          } else 0L
-        }
-        .getOrElse(0L)
+      val deletedFileSize =
+        delta(indexFilePath)
+          .map { dt =>
+            val indexDf = dt.toDF
+            if (indexDf.columns.contains("file_size")) {
+              val result =
+                indexDf
+                  .join(toDelete, Seq("filename"), "inner")
+                  .agg(sum("file_size"))
+                  .head()
+              if (result.isNullAt(0)) 0L else result.getLong(0)
+            } else 0L
+          }
+          .getOrElse(0L)
 
       // Remove from main index
       delta(indexFilePath).foreach { dt =>
@@ -818,9 +668,7 @@ case class Index private (
           .whenMatched()
           .delete()
           .execute()
-        logger.warn(
-          s"Deleted ${filenames.size} file(s) from main index in ${System.currentTimeMillis() - startTime}ms"
-        )
+        logger.warn(s"Deleted ${filenames.size} file(s) from main index in ${System.currentTimeMillis() - startTime}ms")
       }
 
       // Remove from all large index tables
@@ -859,10 +707,8 @@ case class Index private (
 
       // Remove from file list
       fileList.removeFile(filenames: _*)
-      logger.warn(
-        s"Successfully deleted ${filenames.size} file(s) from index '$name' in ${System
-            .currentTimeMillis() - startTime}ms"
-      )
+      logger.warn(s"Successfully deleted ${filenames.size} file(s) from index '$name' in ${System
+          .currentTimeMillis() - startTime}ms")
     } catch {
       case e: Throwable =>
         logger.warn(s"deleteFiles failed for index '$name': ${e.getMessage}", e)
@@ -872,23 +718,23 @@ case class Index private (
     }
   }
 
-  /** Updates the index with new files and backfills newly added columns.
-    *
-    * Processes all unindexed files registered via [[addFile]], using
-    * intelligent batching based on pre-flight analysis. Also backfills existing
-    * files when new index columns have been added since the last update.
-    *
-    * @example
-    *   {{{
-    * val index = Index("myIndex", schema, "parquet")
-    * index.addIndex("userId")
-    * index.addFile("/data/events/2024-01-01.parquet")
-    * index.update
-    *   }}}
-    *
-    * @throws IndexLockException
-    *   if the update lock cannot be acquired within the configured timeout
-    */
+  /**
+   * Updates the index with new files and backfills newly added columns.
+   *
+   * Processes all unindexed files registered via [[addFile]], using intelligent batching based on pre-flight analysis.
+   * Also backfills existing files when new index columns have been added since the last update.
+   *
+   * @example
+   *   {{{
+   * val index = Index("myIndex", schema, "parquet")
+   * index.addIndex("userId")
+   * index.addFile("/data/events/2024-01-01.parquet")
+   * index.update
+   *   }}}
+   *
+   * @throws IndexLockException
+   *   if the update lock cannot be acquired within the configured timeout
+   */
   def update: Unit = {
     logger.warn(s"Starting index update for '$name'")
     batchesSinceCompact = metadata.batches_since_compact
@@ -906,12 +752,8 @@ case class Index private (
       // file_size to null for all existing rows; the merge below populates it.
       delta(indexFilePath).foreach { dt =>
         if (!dt.toDF.columns.contains("file_size")) {
-          logger.warn(
-            s"Index '$name' predates file_size tracking; adding file_size column to its schema"
-          )
-          spark.sql(
-            s"ALTER TABLE delta.`${indexFilePath.toString}` ADD COLUMNS (file_size BIGINT)"
-          )
+          logger.warn(s"Index '$name' predates file_size tracking; adding file_size column to its schema")
+          spark.sql(s"ALTER TABLE delta.`${indexFilePath.toString}` ADD COLUMNS (file_size BIGINT)")
         }
       }
 
@@ -919,33 +761,28 @@ case class Index private (
       // table is re-fetched here so the snapshot reflects any schema change
       // applied above.
       delta(indexFilePath).foreach { dt =>
-        val nullSizeFiles = dt.toDF
-          .where(col("file_size").isNull)
-          .select("filename")
-          .collect()
-          .map(_.getString(0))
-          .toSet
+        val nullSizeFiles =
+          dt.toDF
+            .where(col("file_size").isNull)
+            .select("filename")
+            .collect()
+            .map(_.getString(0))
+            .toSet
         if (nullSizeFiles.nonEmpty) {
-          logger.warn(
-            s"Backfilling file sizes for ${nullSizeFiles.size} files"
-          )
+          logger.warn(s"Backfilling file sizes for ${nullSizeFiles.size} files")
           val sizes = getFileSizes(nullSizeFiles)
           val sizesBroadcast = spark.sparkContext.broadcast(sizes)
           try {
-            val sizeUdf = udf((filename: String) =>
-              sizesBroadcast.value.getOrElse(filename, 0L)
-            )
+            val sizeUdf = udf((filename: String) => sizesBroadcast.value.getOrElse(filename, 0L))
 
             import spark.implicits._
-            val updateDf = nullSizeFiles.toSeq
-              .toDF("filename")
-              .withColumn("file_size", sizeUdf(col("filename")))
+            val updateDf =
+              nullSizeFiles.toSeq
+                .toDF("filename")
+                .withColumn("file_size", sizeUdf(col("filename")))
 
             dt.as("target")
-              .merge(
-                updateDf.as("source"),
-                "target.filename = source.filename"
-              )
+              .merge(updateDf.as("source"), "target.filename = source.filename")
               .whenMatched()
               .update(Map("file_size" -> col("source.file_size")))
               .execute()
@@ -958,9 +795,7 @@ case class Index private (
           } finally {
             safeDestroyBroadcast(sizesBroadcast)
           }
-          logger.warn(
-            s"Backfilled file sizes for ${nullSizeFiles.size} files"
-          )
+          logger.warn(s"Backfilled file sizes for ${nullSizeFiles.size} files")
         }
       }
 
@@ -968,15 +803,11 @@ case class Index private (
       // is complete before processing new files
       val needsColumnUpdate = filesNeedingColumnUpdate
       if (needsColumnUpdate.nonEmpty) {
-        logger.warn(
-          s"Backfilling ${needsColumnUpdate.size} files for new index columns"
-        )
+        logger.warn(s"Backfilling ${needsColumnUpdate.size} files for new index columns")
         updateBatched(needsColumnUpdate, lock, correlationId, isBackfill = true)
       }
       val unindexed = unindexedFiles
-      logger.warn(
-        s"Found ${unindexed.size} unindexed file(s) for index '$name'"
-      )
+      logger.warn(s"Found ${unindexed.size} unindexed file(s) for index '$name'")
       if (unindexed.nonEmpty) {
         updateBatched(unindexed, lock, correlationId, isBackfill = false)
       }
@@ -984,17 +815,16 @@ case class Index private (
       // Recalculate total file size if it was unknown (migration from older version)
       if (metadata.total_indexed_file_size < 0) {
         delta(indexFilePath).foreach { dt =>
-          val totalSize = if (dt.toDF.columns.contains("file_size")) {
-            val result = dt.toDF.agg(sum("file_size")).head()
-            if (result.isNullAt(0)) 0L else result.getLong(0)
-          } else {
-            0L
-          }
+          val totalSize =
+            if (dt.toDF.columns.contains("file_size")) {
+              val result = dt.toDF.agg(sum("file_size")).head()
+              if (result.isNullAt(0)) 0L else result.getLong(0)
+            } else {
+              0L
+            }
           metadata.total_indexed_file_size = totalSize
           writeMetadata(metadata)
-          logger.warn(
-            f"Recalculated total indexed file size: ${totalSize / (1024.0 * 1024.0 * 1024.0)}%.2f GB"
-          )
+          logger.warn(f"Recalculated total indexed file size: ${totalSize / (1024.0 * 1024.0 * 1024.0)}%.2f GB")
         }
       }
       // Persist batch counter for cross-job auto-compaction
@@ -1005,13 +835,10 @@ case class Index private (
       if (autoCompactThreshold.isEmpty && batchesSinceCompact >= 50) {
         logger.warn(
           s"Index '$name' has accumulated $batchesSinceCompact update batches without compaction. " +
-            "Consider running index.compact() or setting spark.ariadne.autoCompactThreshold to enable auto-compaction."
-        )
+            "Consider running index.compact() or setting spark.ariadne.autoCompactThreshold to enable auto-compaction.")
       }
 
-      logger.warn(
-        s"Update complete for index '$name' in ${System.currentTimeMillis() - startTime}ms"
-      )
+      logger.warn(s"Update complete for index '$name' in ${System.currentTimeMillis() - startTime}ms")
     } catch {
       case e: Throwable =>
         logger.warn(s"update failed for index '$name': ${e.getMessage}", e)
@@ -1021,17 +848,18 @@ case class Index private (
     }
   }
 
-  /** Compacts all Delta tables belonging to this index using OPTIMIZE. Acquires
-    * the update lock to prevent concurrent modifications.
-    *
-    * @example
-    *   {{{
-    * index.compact()
-    *   }}}
-    *
-    * @throws IndexLockException
-    *   if the update lock cannot be acquired within the configured timeout
-    */
+  /**
+   * Compacts all Delta tables belonging to this index using OPTIMIZE. Acquires the update lock to prevent concurrent
+   * modifications.
+   *
+   * @example
+   *   {{{
+   * index.compact()
+   *   }}}
+   *
+   * @throws IndexLockException
+   *   if the update lock cannot be acquired within the configured timeout
+   */
   def compact(): Unit = {
     val startTime = System.currentTimeMillis()
     logger.warn(s"Starting compaction for index '$name'")
@@ -1043,9 +871,7 @@ case class Index private (
       batchesSinceCompact = 0
       metadata.batches_since_compact = 0
       writeMetadata(metadata)
-      logger.warn(
-        s"Compaction complete in ${System.currentTimeMillis() - startTime}ms"
-      )
+      logger.warn(s"Compaction complete in ${System.currentTimeMillis() - startTime}ms")
     } catch {
       case e: Throwable =>
         logger.warn(s"compact failed for index '$name': ${e.getMessage}", e)
@@ -1055,20 +881,21 @@ case class Index private (
     }
   }
 
-  /** Vacuums all Delta tables belonging to this index to remove old files.
-    * Acquires the update lock to prevent concurrent modifications.
-    *
-    * @example
-    *   {{{
-    * index.vacuum()          // default 7 days retention
-    * index.vacuum(24)        // 1 day retention
-    *   }}}
-    *
-    * @param retentionHours
-    *   number of hours of history to retain (default 168 = 7 days)
-    * @throws IndexLockException
-    *   if the update lock cannot be acquired within the configured timeout
-    */
+  /**
+   * Vacuums all Delta tables belonging to this index to remove old files. Acquires the update lock to prevent
+   * concurrent modifications.
+   *
+   * @example
+   *   {{{
+   * index.vacuum()          // default 7 days retention
+   * index.vacuum(24)        // 1 day retention
+   *   }}}
+   *
+   * @param retentionHours
+   *   number of hours of history to retain (default 168 = 7 days)
+   * @throws IndexLockException
+   *   if the update lock cannot be acquired within the configured timeout
+   */
   def vacuum(retentionHours: Int = 168): Unit = {
     val startTime = System.currentTimeMillis()
     logger.warn(s"Vacuuming index '$name' with retention=$retentionHours hours")
@@ -1077,9 +904,7 @@ case class Index private (
     lock.acquire(correlationId)
     try {
       vacuumDeltaTables(retentionHours)
-      logger.warn(
-        s"Vacuum complete for index '$name' in ${System.currentTimeMillis() - startTime}ms"
-      )
+      logger.warn(s"Vacuum complete for index '$name' in ${System.currentTimeMillis() - startTime}ms")
     } catch {
       case e: Throwable =>
         logger.warn(s"vacuum failed for index '$name': ${e.getMessage}", e)
@@ -1089,24 +914,24 @@ case class Index private (
     }
   }
 
-  /** Updates the index using intelligent batching based on pre-flight analysis.
-    *
-    * @param files
-    *   Set of files to process
-    * @param lock
-    *   The update lock to refresh during processing
-    * @param correlationId
-    *   The correlation ID for lock refresh
-    * @param isBackfill
-    *   When true, indicates this is a column backfill rather than new file
-    *   indexing; file sizes will not be re-counted toward the total
-    */
+  /**
+   * Updates the index using intelligent batching based on pre-flight analysis.
+   *
+   * @param files
+   *   Set of files to process
+   * @param lock
+   *   The update lock to refresh during processing
+   * @param correlationId
+   *   The correlation ID for lock refresh
+   * @param isBackfill
+   *   When true, indicates this is a column backfill rather than new file indexing; file sizes will not be re-counted
+   *   toward the total
+   */
   private def updateBatched(
       files: Set[String],
       lock: IndexLock,
       correlationId: String,
-      isBackfill: Boolean = false
-  ): Unit = {
+      isBackfill: Boolean = false): Unit = {
     val updateBatchedStart = System.currentTimeMillis()
     logger.warn(s"Using intelligent batched update for ${files.size} files")
 
@@ -1114,22 +939,16 @@ case class Index private (
     val fileAnalyses = analyzeFiles(files)
     val batches = createOptimalBatches(fileAnalyses)
 
-    logger.warn(
-      s"Processing ${batches.size} batches with consolidation threshold of $stagingConsolidationThreshold"
-    )
+    logger.warn(s"Processing ${batches.size} batches with consolidation threshold of $stagingConsolidationThreshold")
 
     var batchesSinceConsolidation = 0
     var batchesSinceRefresh = 0
 
     batches.zipWithIndex.foreach { case (batch, idx) =>
       val batchStart = System.currentTimeMillis()
-      logger.warn(
-        s"Processing batch ${idx + 1}/${batches.size} with ${batch.size} files"
-      )
+      logger.warn(s"Processing batch ${idx + 1}/${batches.size} with ${batch.size} files")
       updateSingleBatch(batch, isBackfill)
-      logger.warn(
-        s"Batch ${idx + 1}/${batches.size} completed in ${System.currentTimeMillis() - batchStart}ms"
-      )
+      logger.warn(s"Batch ${idx + 1}/${batches.size} completed in ${System.currentTimeMillis() - batchStart}ms")
       batchesSinceConsolidation += 1
       batchesSinceRefresh += 1
       batchesSinceCompact += 1
@@ -1142,9 +961,7 @@ case class Index private (
 
       // Periodic consolidation for fault tolerance
       if (batchesSinceConsolidation >= stagingConsolidationThreshold) {
-        logger.warn(
-          s"Reached consolidation threshold ($stagingConsolidationThreshold batches), consolidating..."
-        )
+        logger.warn(s"Reached consolidation threshold ($stagingConsolidationThreshold batches), consolidating...")
         consolidateStaging()
         maybeAutoCompact()
         batchesSinceConsolidation = 0
@@ -1158,24 +975,20 @@ case class Index private (
       maybeAutoCompact()
     }
 
-    logger.warn(
-      s"Completed batched update of ${files.size} files in ${batches.size} batches in ${System
-          .currentTimeMillis() - updateBatchedStart}ms"
-    )
+    logger.warn(s"Completed batched update of ${files.size} files in ${batches.size} batches in ${System
+        .currentTimeMillis() - updateBatchedStart}ms")
   }
 
-  /** Updates the index with a single batch of files.
-    *
-    * @param files
-    *   Set of files to process in this batch
-    * @param isBackfill
-    *   When true, indicates this is a column backfill rather than new file
-    *   indexing; file sizes will not be re-counted toward the total
-    */
-  private def updateSingleBatch(
-      files: Set[String],
-      isBackfill: Boolean = false
-  ): Unit = {
+  /**
+   * Updates the index with a single batch of files.
+   *
+   * @param files
+   *   Set of files to process in this batch
+   * @param isBackfill
+   *   When true, indicates this is a column backfill rather than new file indexing; file sizes will not be re-counted
+   *   toward the total
+   */
+  private def updateSingleBatch(files: Set[String], isBackfill: Boolean = false): Unit = {
     val singleBatchStart = System.currentTimeMillis()
     logger.warn(s"Processing single batch of ${files.size} files")
     val baseDf = createBaseDataFrame(files)
@@ -1186,9 +999,7 @@ case class Index private (
     val fileSizes = getFileSizes(files)
     val fileSizesBroadcast = spark.sparkContext.broadcast(fileSizes)
     try {
-      val fileSizeUdf = udf((filename: String) =>
-        fileSizesBroadcast.value.getOrElse(filename, 0L)
-      )
+      val fileSizeUdf = udf((filename: String) => fileSizesBroadcast.value.getOrElse(filename, 0L))
 
       // Build regular indexes
       val regularIndexesDf = buildRegularIndexes(withFilename)
@@ -1250,8 +1061,7 @@ case class Index private (
       // Persist any metadata changes (e.g., auto-bloom column detection) after data is safely staged
       writeMetadata(metadata)
       logger.warn(
-        s"Single batch of ${files.size} files completed in ${System.currentTimeMillis() - singleBatchStart}ms"
-      )
+        s"Single batch of ${files.size} files completed in ${System.currentTimeMillis() - singleBatchStart}ms")
     } finally {
       // Clean up cached DataFrame from auto-bloom processing
       lastAutoBloomCache.foreach(_.unpersist())
@@ -1260,274 +1070,248 @@ case class Index private (
     }
   }
 
-  /** Joins the indexed data with the provided DataFrame.
-    *
-    * Locates relevant data files via the index, reads them, applies temporal
-    * deduplication if configured, and joins the result with the provided
-    * DataFrame.
-    *
-    * @example
-    *   {{{
-    * val lookupDf = spark.read.parquet("/data/lookups")
-    * val result = index.join(lookupDf, Seq("userId"))
-    * val leftResult = index.join(lookupDf, Seq("userId"), "left_outer")
-    *   }}}
-    *
-    * @param df
-    *   The DataFrame to join against indexed data
-    * @param usingColumns
-    *   The column names to join on (must be indexed columns)
-    * @param joinType
-    *   The Spark join type (default: "inner")
-    * @return
-    *   The joined DataFrame
-    * @throws IllegalArgumentException
-    *   if df is null or usingColumns is null/empty
-    */
-  override def join(
-      df: DataFrame,
-      usingColumns: Seq[String],
-      joinType: String = "inner"
-  ): DataFrame = {
+  /**
+   * Joins the indexed data with the provided DataFrame.
+   *
+   * Locates relevant data files via the index, reads them, applies temporal deduplication if configured, and joins the
+   * result with the provided DataFrame.
+   *
+   * @example
+   *   {{{
+   * val lookupDf = spark.read.parquet("/data/lookups")
+   * val result = index.join(lookupDf, Seq("userId"))
+   * val leftResult = index.join(lookupDf, Seq("userId"), "left_outer")
+   *   }}}
+   *
+   * @param df
+   *   The DataFrame to join against indexed data
+   * @param usingColumns
+   *   The column names to join on (must be indexed columns)
+   * @param joinType
+   *   The Spark join type (default: "inner")
+   * @return
+   *   The joined DataFrame
+   * @throws IllegalArgumentException
+   *   if df is null or usingColumns is null/empty
+   */
+  override def join(df: DataFrame, usingColumns: Seq[String], joinType: String = "inner"): DataFrame = {
     require(df != null, "DataFrame must not be null")
-    require(
-      usingColumns != null && usingColumns.nonEmpty,
-      "usingColumns must not be null or empty"
-    )
+    require(usingColumns != null && usingColumns.nonEmpty, "usingColumns must not be null or empty")
     super.join(df, usingColumns, joinType)
   }
 }
 
-/** Companion object for the Index class.
-  *
-  * Provides factory methods for creating or reconnecting to indexes, as well as
-  * utility methods for checking existence and removing indexes.
-  */
+/**
+ * Companion object for the Index class.
+ *
+ * Provides factory methods for creating or reconnecting to indexes, as well as utility methods for checking existence
+ * and removing indexes.
+ */
 object Index {
   private val logger: Logger = LogManager.getLogger("ariadne")
 
-  /** Returns the file list name for an index.
-    *
-    * @example
-    *   {{{val listName = Index.fileListName("orders") // "[ariadne_index] orders"}}}
-    *
-    * @param name
-    *   The index name
-    * @return
-    *   The file list identifier
-    */
+  /**
+   * Returns the file list name for an index.
+   *
+   * @example
+   *   {{{val listName = Index.fileListName("orders") // "[ariadne_index] orders"}}}
+   *
+   * @param name
+   *   The index name
+   * @return
+   *   The file list identifier
+   */
   def fileListName(name: String): String = IndexPathUtils.fileListName(name)
 
-  /** Checks if an index exists.
-    *
-    * @example
-    *   {{{if (Index.exists("orders")) println("Index found")}}}
-    *
-    * @param name
-    *   The index name
-    * @return
-    *   true if the index exists
-    */
+  /**
+   * Checks if an index exists.
+   *
+   * @example
+   *   {{{if (Index.exists("orders")) println("Index found")}}}
+   *
+   * @param name
+   *   The index name
+   * @return
+   *   true if the index exists
+   */
   def exists(name: String)(implicit spark: SparkSession): Boolean =
     IndexPathUtils.exists(name)
 
-  /** Removes an index and its associated data.
-    *
-    * @example
-    *   {{{Index.remove("orders")}}}
-    *
-    * @param name
-    *   The index name
-    * @return
-    *   true if removal was successful
-    * @throws IndexNotFoundException
-    *   if the index does not exist
-    */
+  /**
+   * Removes an index and its associated data.
+   *
+   * @example
+   *   {{{Index.remove("orders")}}}
+   *
+   * @param name
+   *   The index name
+   * @return
+   *   true if removal was successful
+   * @throws IndexNotFoundException
+   *   if the index does not exist
+   */
   def remove(name: String)(implicit spark: SparkSession): Boolean =
     IndexPathUtils.remove(name)
 
-  /** Convenience factory: creates or reconnects with schema, format, and no
-    * schema mismatch.
-    *
-    * @example
-    *   {{{
-    * val index = Index("orders", ordersSchema, "parquet")
-    *   }}}
-    *
-    * @param name
-    *   Unique index name
-    * @param schema
-    *   Spark schema of the data files
-    * @param format
-    *   Data file format (e.g., "parquet")
-    * @return
-    *   A fully initialized Index instance
-    * @see
-    *   [[apply(name:String,schema:Option[StructType],format:Option[String],allowSchemaMismatch:Boolean,readOptions:Option[Map[String,String]])*]]
-    */
-  def apply(
-      name: String,
-      schema: StructType,
-      format: String
-  )(implicit spark: SparkSession): Index =
+  /**
+   * Convenience factory: creates or reconnects with schema, format, and no schema mismatch.
+   *
+   * @example
+   *   {{{
+   * val index = Index("orders", ordersSchema, "parquet")
+   *   }}}
+   *
+   * @param name
+   *   Unique index name
+   * @param schema
+   *   Spark schema of the data files
+   * @param format
+   *   Data file format (e.g., "parquet")
+   * @return
+   *   A fully initialized Index instance
+   * @see
+   *   [[apply]]
+   */
+  def apply(name: String, schema: StructType, format: String)(implicit spark: SparkSession): Index =
     apply(name, Some(schema), Some(format), false)
 
-  /** Convenience factory: creates or reconnects with optional schema mismatch
-    * tolerance.
-    *
-    * @param name
-    *   Unique index name
-    * @param schema
-    *   Spark schema of the data files
-    * @param format
-    *   Data file format (e.g., "parquet")
-    * @param allowSchemaMismatch
-    *   When true, allows updating the stored schema
-    * @return
-    *   A fully initialized Index instance
-    * @see
-    *   [[apply(name:String,schema:Option[StructType],format:Option[String],allowSchemaMismatch:Boolean,readOptions:Option[Map[String,String]])*]]
-    */
-  def apply(
-      name: String,
-      schema: StructType,
-      format: String,
-      allowSchemaMismatch: Boolean
-  )(implicit spark: SparkSession): Index =
+  /**
+   * Convenience factory: creates or reconnects with optional schema mismatch tolerance.
+   *
+   * @param name
+   *   Unique index name
+   * @param schema
+   *   Spark schema of the data files
+   * @param format
+   *   Data file format (e.g., "parquet")
+   * @param allowSchemaMismatch
+   *   When true, allows updating the stored schema
+   * @return
+   *   A fully initialized Index instance
+   * @see
+   *   [[apply]]
+   */
+  def apply(name: String, schema: StructType, format: String, allowSchemaMismatch: Boolean)(implicit
+      spark: SparkSession): Index =
     apply(name, Some(schema), Some(format), allowSchemaMismatch)
 
-  /** Convenience factory: creates or reconnects with read options.
-    *
-    * @param name
-    *   Unique index name
-    * @param schema
-    *   Spark schema of the data files
-    * @param format
-    *   Data file format (e.g., "parquet")
-    * @param readOptions
-    *   Format-specific read options (e.g., CSV delimiter)
-    * @return
-    *   A fully initialized Index instance
-    * @see
-    *   [[apply(name:String,schema:Option[StructType],format:Option[String],allowSchemaMismatch:Boolean,readOptions:Option[Map[String,String]])*]]
-    */
-  def apply(
-      name: String,
-      schema: StructType,
-      format: String,
-      readOptions: Map[String, String]
-  )(implicit spark: SparkSession): Index =
+  /**
+   * Convenience factory: creates or reconnects with read options.
+   *
+   * @param name
+   *   Unique index name
+   * @param schema
+   *   Spark schema of the data files
+   * @param format
+   *   Data file format (e.g., "parquet")
+   * @param readOptions
+   *   Format-specific read options (e.g., CSV delimiter)
+   * @return
+   *   A fully initialized Index instance
+   * @see
+   *   [[apply]]
+   */
+  def apply(name: String, schema: StructType, format: String, readOptions: Map[String, String])(implicit
+      spark: SparkSession): Index =
     apply(name, Some(schema), Some(format), false, Some(readOptions))
 
-  /** Convenience factory: creates or reconnects with schema mismatch tolerance
-    * and read options.
-    *
-    * @param name
-    *   Unique index name
-    * @param schema
-    *   Spark schema of the data files
-    * @param format
-    *   Data file format (e.g., "parquet")
-    * @param allowSchemaMismatch
-    *   When true, allows updating the stored schema
-    * @param readOptions
-    *   Format-specific read options (e.g., CSV delimiter)
-    * @return
-    *   A fully initialized Index instance
-    * @see
-    *   [[apply(name:String,schema:Option[StructType],format:Option[String],allowSchemaMismatch:Boolean,readOptions:Option[Map[String,String]])*]]
-    */
+  /**
+   * Convenience factory: creates or reconnects with schema mismatch tolerance and read options.
+   *
+   * @param name
+   *   Unique index name
+   * @param schema
+   *   Spark schema of the data files
+   * @param format
+   *   Data file format (e.g., "parquet")
+   * @param allowSchemaMismatch
+   *   When true, allows updating the stored schema
+   * @param readOptions
+   *   Format-specific read options (e.g., CSV delimiter)
+   * @return
+   *   A fully initialized Index instance
+   * @see
+   *   [[apply]]
+   */
   def apply(
       name: String,
       schema: StructType,
       format: String,
       allowSchemaMismatch: Boolean,
-      readOptions: Map[String, String]
-  )(implicit spark: SparkSession): Index = apply(
-    name,
-    Some(schema),
-    Some(format),
-    allowSchemaMismatch,
-    Some(readOptions)
-  )
+      readOptions: Map[String, String])(implicit spark: SparkSession): Index =
+    apply(name, Some(schema), Some(format), allowSchemaMismatch, Some(readOptions))
 
-  /** Primary factory method to create or reconnect to an Index instance.
-    *
-    * If metadata exists at the storage path, reconnects to the existing index
-    * and validates schema/format compatibility. If metadata does not exist,
-    * creates a new index with the provided schema and format.
-    *
-    * @example
-    *   {{{
-    * // Reconnect to an existing index (no schema/format needed)
-    * val index = Index("orders")
-    *
-    * // Create a new index
-    * val newIndex = Index("orders", Some(schema), Some("parquet"))
-    *
-    * // Reconnect with schema evolution
-    * val evolved = Index("orders", Some(newSchema), allowSchemaMismatch = true)
-    *   }}}
-    *
-    * @param name
-    *   Unique index name (must be a valid Hadoop path component).
-    * @param schema
-    *   Optional Spark schema of the data files. Required for new indexes.
-    * @param format
-    *   Optional data file format (e.g., "parquet", "csv"). Required for new
-    *   indexes.
-    * @param allowSchemaMismatch
-    *   When true and metadata exists, allows updating the stored schema.
-    *   Validates that all existing index columns still exist in the new schema
-    *   before applying the change.
-    * @param readOptions
-    *   Optional map of read options for format-specific configuration (e.g.,
-    *   CSV delimiter).
-    * @return
-    *   A fully initialized Index instance.
-    * @throws SchemaMismatchException
-    *   if schema differs and allowSchemaMismatch is false
-    * @throws FormatMismatchException
-    *   if format differs from stored format
-    * @throws SchemaNotProvidedException
-    *   if creating a new index without a schema
-    * @throws MissingFormatException
-    *   if creating a new index without a format
-    * @throws IndexNotFoundInNewSchemaException
-    *   if allowSchemaMismatch is true but an indexed column is missing
-    */
+  /**
+   * Primary factory method to create or reconnect to an Index instance.
+   *
+   * If metadata exists at the storage path, reconnects to the existing index and validates schema/format compatibility.
+   * If metadata does not exist, creates a new index with the provided schema and format.
+   *
+   * @example
+   *   {{{
+   * // Reconnect to an existing index (no schema/format needed)
+   * val index = Index("orders")
+   *
+   * // Create a new index
+   * val newIndex = Index("orders", Some(schema), Some("parquet"))
+   *
+   * // Reconnect with schema evolution
+   * val evolved = Index("orders", Some(newSchema), allowSchemaMismatch = true)
+   *   }}}
+   *
+   * @param name
+   *   Unique index name (must be a valid Hadoop path component).
+   * @param schema
+   *   Optional Spark schema of the data files. Required for new indexes.
+   * @param format
+   *   Optional data file format (e.g., "parquet", "csv"). Required for new indexes.
+   * @param allowSchemaMismatch
+   *   When true and metadata exists, allows updating the stored schema. Validates that all existing index columns still
+   *   exist in the new schema before applying the change.
+   * @param readOptions
+   *   Optional map of read options for format-specific configuration (e.g., CSV delimiter).
+   * @return
+   *   A fully initialized Index instance.
+   * @throws SchemaMismatchException
+   *   if schema differs and allowSchemaMismatch is false
+   * @throws FormatMismatchException
+   *   if format differs from stored format
+   * @throws SchemaNotProvidedException
+   *   if creating a new index without a schema
+   * @throws MissingFormatException
+   *   if creating a new index without a format
+   * @throws IndexNotFoundInNewSchemaException
+   *   if allowSchemaMismatch is true but an indexed column is missing
+   */
   def apply(
       name: String,
       schema: Option[StructType] = None,
       format: Option[String] = None,
       allowSchemaMismatch: Boolean = false,
-      readOptions: Option[Map[String, String]] = None
-  )(implicit spark: SparkSession): Index = {
+      readOptions: Option[Map[String, String]] = None)(implicit spark: SparkSession): Index = {
     IndexPathUtils.validateIndexName(name)
     val index = Index(name, schema)(spark)
 
     val metadataExists = index.metadataExists
-    logger.warn(
-      s"Index '$name': ${if (metadataExists) "reconnecting" else "creating new"}"
-    )
-    val metadata = if (metadataExists) {
-      index.metadata
-    } else {
-      IndexMetadata(
-        null,
-        null,
-        new util.ArrayList[String](),
-        new util.HashMap[String, String](),
-        new util.ArrayList[ExplodedFieldMapping](),
-        new util.ArrayList[BloomIndexConfig](),
-        new util.ArrayList[TemporalIndexConfig](),
-        new util.HashMap[String, String](),
-        new util.ArrayList[RangeIndexConfig](),
-        new util.ArrayList[String](),
-        -1L,
-        0
-      )
-    }
+    logger.warn(s"Index '$name': ${if (metadataExists) "reconnecting" else "creating new"}")
+    val metadata =
+      if (metadataExists) {
+        index.metadata
+      } else {
+        IndexMetadata(
+          null,
+          null,
+          new util.ArrayList[String](),
+          new util.HashMap[String, String](),
+          new util.ArrayList[ExplodedFieldMapping](),
+          new util.ArrayList[BloomIndexConfig](),
+          new util.ArrayList[TemporalIndexConfig](),
+          new util.HashMap[String, String](),
+          new util.ArrayList[RangeIndexConfig](),
+          new util.ArrayList[String](),
+          -1L,
+          0)
+      }
 
     schema match {
       case Some(s) =>
@@ -1552,9 +1336,7 @@ object Index {
                   throw new IndexNotFoundInNewSchemaException(ti.column)
                 }
                 if (!SchemaHelper.fieldExists(s, ti.timestamp_column)) {
-                  throw new IndexNotFoundInNewSchemaException(
-                    ti.timestamp_column
-                  )
+                  throw new IndexNotFoundInNewSchemaException(ti.timestamp_column)
                 }
               }
               // Validate range indexes
@@ -1564,14 +1346,12 @@ object Index {
                 }
               }
               // Validate computed indexes
-              metadata.computed_indexes.keySet().asScala.foreach { ci =>
+              metadata.computed_indexes.keySet().asScala.foreach { _ =>
                 // Computed indexes use SQL expressions, not schema fields directly
                 // We validate the output column name exists conceptually but
                 // cannot validate the expression references without executing it
               }
-              logger.warn(
-                s"Index '$name': schema evolved (allowSchemaMismatch=true)"
-              )
+              logger.warn(s"Index '$name': schema evolved (allowSchemaMismatch=true)")
             }
             metadata.schema = s.json
           } else if (metadata.schema != s.json) {
@@ -1621,49 +1401,43 @@ object Index {
     index
   }
 
-  /** Implicit enrichment enabling `df.join(index, columns, joinType)` syntax.
-    *
-    * This provides the reverse join direction compared to [[Index.join]]: the
-    * driving DataFrame is on the left and the index-located data is on the
-    * right.
-    *
-    * Usage:
-    * {{{
-    * import dev.cjfravel.ariadne.Index.DataFrameOps
-    * val result = myDataFrame.join(index, Seq("user_id"), "inner")
-    * }}}
-    *
-    * @param df
-    *   The DataFrame to enrich with implicit join capability
-    */
+  /**
+   * Implicit enrichment enabling `df.join(index, columns, joinType)` syntax.
+   *
+   * This provides the reverse join direction compared to [[Index.join]]: the driving DataFrame is on the left and the
+   * index-located data is on the right.
+   *
+   * Usage:
+   * {{{
+   * import dev.cjfravel.ariadne.Index.DataFrameOps
+   * val result = myDataFrame.join(index, Seq("user_id"), "inner")
+   * }}}
+   *
+   * @param df
+   *   The DataFrame to enrich with implicit join capability
+   */
   implicit class DataFrameOps(df: DataFrame) {
 
-    /** Joins this DataFrame with the data files identified by the Index.
-      *
-      * Locates relevant data files via the index, reads them, applies temporal
-      * deduplication if configured, and joins the result with this DataFrame.
-      *
-      * @param index
-      *   The Index instance to join against
-      * @param usingColumns
-      *   Column names to join on (must be indexed columns)
-      * @param joinType
-      *   Spark join type: "inner", "left_outer", etc. (default "inner")
-      * @return
-      *   The joined DataFrame
-      * @throws ColumnNotFoundException
-      *   if join columns are not in the schema or indexes
-      */
-    def join(
-        index: Index,
-        usingColumns: Seq[String],
-        joinType: String = "inner"
-    ): DataFrame = {
+    /**
+     * Joins this DataFrame with the data files identified by the Index.
+     *
+     * Locates relevant data files via the index, reads them, applies temporal deduplication if configured, and joins
+     * the result with this DataFrame.
+     *
+     * @param index
+     *   The Index instance to join against
+     * @param usingColumns
+     *   Column names to join on (must be indexed columns)
+     * @param joinType
+     *   Spark join type: "inner", "left_outer", etc. (default "inner")
+     * @return
+     *   The joined DataFrame
+     * @throws ColumnNotFoundException
+     *   if join columns are not in the schema or indexes
+     */
+    def join(index: Index, usingColumns: Seq[String], joinType: String = "inner"): DataFrame = {
       require(index != null, "index must not be null")
-      require(
-        usingColumns != null && usingColumns.nonEmpty,
-        "usingColumns must not be null or empty"
-      )
+      require(usingColumns != null && usingColumns.nonEmpty, "usingColumns must not be null or empty")
       logger.warn(s"DataFrameOps.join: $joinType join on columns ${usingColumns
           .mkString(", ")} against index '${index.name}'")
       val indexDf = index.joinDf(df, usingColumns)

--- a/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
@@ -1,72 +1,60 @@
 package dev.cjfravel.ariadne
 
-import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.functions._
-import org.apache.hadoop.fs.Path
 import scala.collection.JavaConverters._
 
-/** Trait providing index building and maintenance operations for [[Index]]
-  * instances.
-  *
-  * This trait implements the core data pipeline for building and maintaining
-  * file-level indexes. It is mixed into [[Index]] via the trait hierarchy and
-  * handles the complete update lifecycle:
-  *
-  * Update pipeline (data flow):
-  *   1. [[analyzeFiles]] — Pre-flight scan that computes per-file distinct
-  *      value counts for all indexed columns. This information drives batching
-  *      decisions. 2. [[createOptimalBatches]] — Groups files into batches so
-  *      that the sum of `maxDistinctCount` per batch stays below
-  *      `largeIndexLimit`. Files that individually exceed the limit are
-  *      isolated into single-file batches. 3. Per-batch processing (in
-  *      `updateSingleBatch`):
-  *      - Read source files, apply computed indexes, add filename column
-  *      - Build regular indexes (array aggregation per file)
-  *      - Build exploded field, bloom filter, temporal, and range indexes
-  *      - Build auto-bloom filters for columns exceeding `largeIndexLimit`
-  *      - [[appendToStaging]] (small columns to staging Delta table)
-  *      - [[appendToLargeIndex]] (large columns to per-column Delta tables) 4.
-  *        Periodic consolidation — Every `stagingConsolidationThreshold`
-  *        batches, [[consolidateStaging]] merges staging into the main index
-  *        via Delta MERGE (upsert on filename). Auto-compaction may follow via
-  *        [[maybeAutoCompact]]. 5. Final consolidation — After all batches
-  *        complete, any remaining staged data is consolidated and the staging
-  *        table is deleted.
-  *
-  * Batching strategy: Files are sorted by `maxDistinctCount` (largest first)
-  * and packed sequentially into batches. This greedy approach keeps each batch
-  * under the large index limit while maximizing batch sizes for efficiency.
-  *
-  * Staging: Each batch is appended to a transient staging Delta table. Periodic
-  * consolidation merges staged rows into the main index, providing fault
-  * tolerance (partially processed updates can be recovered).
-  *
-  * Large index handling: Columns whose array size exceeds `largeIndexLimit` for
-  * any file are stored in separate Delta tables under `large_indexes/{column}/`
-  * as exploded (one row per value) rather than array-per-file. Auto-bloom
-  * filters are built for these columns in the main index to enable
-  * pre-filtering at query time.
-  *
-  * @see
-  *   [[BloomFilterOperations]] for bloom filter creation and querying
-  * @see
-  *   [[Index.update]] for the public entry point
-  */
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.functions._
+
+/**
+ * Trait providing index building and maintenance operations for [[Index]] instances.
+ *
+ * This trait implements the core data pipeline for building and maintaining file-level indexes. It is mixed into
+ * [[Index]] via the trait hierarchy and handles the complete update lifecycle:
+ *
+ * Update pipeline (data flow):
+ *   1. [[analyzeFiles]] — Pre-flight scan that computes per-file distinct value counts for all indexed columns. This
+ *      information drives batching decisions. 2. [[createOptimalBatches]] — Groups files into batches so that the sum
+ *      of `maxDistinctCount` per batch stays below `largeIndexLimit`. Files that individually exceed the limit are
+ *      isolated into single-file batches. 3. Per-batch processing (in `updateSingleBatch`):
+ *      - Read source files, apply computed indexes, add filename column
+ *      - Build regular indexes (array aggregation per file)
+ *      - Build exploded field, bloom filter, temporal, and range indexes
+ *      - Build auto-bloom filters for columns exceeding `largeIndexLimit`
+ *      - [[appendToStaging]] (small columns to staging Delta table)
+ *      - [[appendToLargeIndex]] (large columns to per-column Delta tables) 4. Periodic consolidation — Every
+ *        `stagingConsolidationThreshold` batches, [[consolidateStaging]] merges staging into the main index via Delta
+ *        MERGE (upsert on filename). Auto-compaction may follow via [[maybeAutoCompact]]. 5. Final consolidation —
+ *        After all batches complete, any remaining staged data is consolidated and the staging table is deleted.
+ *
+ * Batching strategy: Files are sorted by `maxDistinctCount` (largest first) and packed sequentially into batches. This
+ * greedy approach keeps each batch under the large index limit while maximizing batch sizes for efficiency.
+ *
+ * Staging: Each batch is appended to a transient staging Delta table. Periodic consolidation merges staged rows into
+ * the main index, providing fault tolerance (partially processed updates can be recovered).
+ *
+ * Large index handling: Columns whose array size exceeds `largeIndexLimit` for any file are stored in separate Delta
+ * tables under `large_indexes/{column}/` as exploded (one row per value) rather than array-per-file. Auto-bloom filters
+ * are built for these columns in the main index to enable pre-filtering at query time.
+ *
+ * @see
+ *   [[BloomFilterOperations]] for bloom filter creation and querying
+ * @see
+ *   [[Index.update]] for the public entry point
+ */
 trait IndexBuildOperations extends BloomFilterOperations {
   self: Index =>
 
-  /** Computes file sizes in bytes for the given files using the Hadoop
-    * FileSystem.
-    *
-    * Files that cannot be found or read are silently skipped with a warning
-    * log.
-    *
-    * @param files
-    *   set of fully-qualified file paths to measure
-    * @return
-    *   map from file path to size in bytes; missing/unreadable files are
-    *   omitted
-    */
+  /**
+   * Computes file sizes in bytes for the given files using the Hadoop FileSystem.
+   *
+   * Files that cannot be found or read are silently skipped with a warning log.
+   *
+   * @param files
+   *   set of fully-qualified file paths to measure
+   * @return
+   *   map from file path to size in bytes; missing/unreadable files are omitted
+   */
   protected def getFileSizes(files: Set[String]): Map[String, Long] = {
     logger.warn(s"Computing file sizes for ${files.size} files")
     files.toSeq.flatMap { f =>
@@ -78,53 +66,48 @@ trait IndexBuildOperations extends BloomFilterOperations {
           logger.warn(s"File not found when computing size, skipping: $f")
           None
         case e: java.io.IOException =>
-          logger.warn(
-            s"I/O error computing file size for $f: ${e.getMessage}, skipping"
-          )
+          logger.warn(s"I/O error computing file size for $f: ${e.getMessage}, skipping")
           None
         case e: Exception =>
-          logger.warn(
-            s"Unexpected error computing file size for $f: ${e.getMessage}",
-            e
-          )
+          logger.warn(s"Unexpected error computing file size for $f: ${e.getMessage}", e)
           None
       }
     }.toMap
   }
 
-  /** Hadoop root path for large index Delta tables
-    * (`{storagePath}/large_indexes/`).
-    */
+  /**
+   * Hadoop root path for large index Delta tables (`{storagePath}/large_indexes/`).
+   */
   protected def largeIndexesFilePath: Path =
     new Path(storagePath, "large_indexes")
 
   /** Hadoop path for the main index Delta table (`{storagePath}/index/`). */
   protected def indexFilePath: Path = new Path(storagePath, "index")
 
-  /** Hadoop path for the staging Delta table (`{storagePath}/staging/`).
-    *
-    * The staging table accumulates batch results during [[Index.update update]]
-    * and is merged into the main index by [[consolidateStaging]].
-    */
+  /**
+   * Hadoop path for the staging Delta table (`{storagePath}/staging/`).
+   *
+   * The staging table accumulates batch results during [[Index.update update]] and is merged into the main index by
+   * [[consolidateStaging]].
+   */
   protected def stagingFilePath: Path = new Path(storagePath, "staging")
 
-  /** Tracks whether the exploded field column migration has already been
-    * checked.
-    */
+  /**
+   * Tracks whether the exploded field column migration has already been checked.
+   */
   @transient private var _explodedMigrationChecked: Boolean = false
 
-  /** Migrates pre-0.1.1 indexes that stored exploded field columns under
-    * `array_column` names to the current `as_column` naming convention.
-    *
-    * Detection: reads the main index Delta table schema and checks whether any
-    * `ExplodedFieldMapping.array_column` appears as a column while the
-    * corresponding `as_column` does not. When this pattern is found, the table
-    * is rewritten with renamed columns, and any large-index directories named
-    * by `array_column` are similarly migrated.
-    *
-    * This method is idempotent and fast when no migration is needed (single
-    * schema check). It is called automatically on the first index read.
-    */
+  /**
+   * Migrates pre-0.1.1 indexes that stored exploded field columns under `array_column` names to the current `as_column`
+   * naming convention.
+   *
+   * Detection: reads the main index Delta table schema and checks whether any `ExplodedFieldMapping.array_column`
+   * appears as a column while the corresponding `as_column` does not. When this pattern is found, the table is
+   * rewritten with renamed columns, and any large-index directories named by `array_column` are similarly migrated.
+   *
+   * This method is idempotent and fast when no migration is needed (single schema check). It is called automatically on
+   * the first index read.
+   */
   protected def migrateExplodedFieldColumns(): Unit = {
     if (_explodedMigrationChecked) return
     _explodedMigrationChecked = true
@@ -136,24 +119,19 @@ trait IndexBuildOperations extends BloomFilterOperations {
       case None => // No index table yet, nothing to migrate
       case Some(dt) =>
         val schema = dt.toDF.schema.fieldNames.toSet
-        val columnsToRename = mappings.filter { m =>
-          schema.contains(m.array_column) && !schema.contains(m.as_column)
-        }
+        val columnsToRename = mappings.filter(m => schema.contains(m.array_column) && !schema.contains(m.as_column))
         if (columnsToRename.isEmpty) return
 
         logger.warn(
           s"Migrating exploded field columns for index '$name': " +
             columnsToRename
               .map(m => s"${m.array_column} -> ${m.as_column}")
-              .mkString(", ")
-        )
+              .mkString(", "))
         val startTime = System.currentTimeMillis()
 
         // Rewrite main index with renamed columns
         var df = dt.toDF
-        columnsToRename.foreach { m =>
-          df = df.withColumnRenamed(m.array_column, m.as_column)
-        }
+        columnsToRename.foreach { m => df = df.withColumnRenamed(m.array_column, m.as_column) }
         df.write
           .format("delta")
           .option("overwriteSchema", "true")
@@ -165,84 +143,73 @@ trait IndexBuildOperations extends BloomFilterOperations {
           val oldPath = new Path(largeIndexesFilePath, m.array_column)
           val newPath = new Path(largeIndexesFilePath, m.as_column)
           if (exists(oldPath) && !exists(newPath)) {
-            logger.warn(
-              s"Renaming large index directory: ${m.array_column} -> ${m.as_column}"
-            )
+            logger.warn(s"Renaming large index directory: ${m.array_column} -> ${m.as_column}")
             fs.rename(oldPath, newPath)
           }
         }
 
         logger.warn(
-          s"Exploded field migration completed for index '$name' in ${System.currentTimeMillis() - startTime}ms"
-        )
+          s"Exploded field migration completed for index '$name' in ${System.currentTimeMillis() - startTime}ms")
     }
   }
 
-  /** Returns the set of all storage column names across regular, computed,
-    * exploded-field, and temporal index types.
-    *
-    * This is used internally to determine which columns to check for
-    * large-index separation and to build aggregation expressions.
-    *
-    * @return
-    *   set of column names used for index storage (excludes bloom, range, and
-    *   auto-bloom)
-    */
+  /**
+   * Returns the set of all storage column names across regular, computed, exploded-field, and temporal index types.
+   *
+   * This is used internally to determine which columns to check for large-index separation and to build aggregation
+   * expressions.
+   *
+   * @return
+   *   set of column names used for index storage (excludes bloom, range, and auto-bloom)
+   */
   protected def storageColumns: Set[String] =
     metadata.indexes.asScala.toSet ++
       metadata.computed_indexes.keySet().asScala ++
       metadata.exploded_field_indexes.asScala.map(_.as_column).toSet ++
       metadata.temporal_indexes.asScala.map(_.column).toSet
 
-  /** Returns the set of range index storage column names (each prefixed with
-    * `range_`).
-    *
-    * @return
-    *   set of prefixed column names (e.g., `range_event_date`)
-    */
+  /**
+   * Returns the set of range index storage column names (each prefixed with `range_`).
+   *
+   * @return
+   *   set of prefixed column names (e.g., `range_event_date`)
+   */
   protected def rangeStorageColumns: Set[String] =
     metadata.range_indexes.asScala.map(c => s"range_${c.column}").toSet
 
-  /** Case class to hold file analysis results for batching decisions.
-    *
-    * @param filename
-    *   The name of the file
-    * @param distinctCounts
-    *   Map of column name to distinct value count for that file
-    * @param maxDistinctCount
-    *   Maximum distinct count across all indexed columns
-    */
-  case class FileAnalysis(
-      filename: String,
-      distinctCounts: Map[String, Long],
-      maxDistinctCount: Long
-  )
+  /**
+   * Case class to hold file analysis results for batching decisions.
+   *
+   * @param filename
+   *   The name of the file
+   * @param distinctCounts
+   *   Map of column name to distinct value count for that file
+   * @param maxDistinctCount
+   *   Maximum distinct count across all indexed columns
+   */
+  case class FileAnalysis(filename: String, distinctCounts: Map[String, Long], maxDistinctCount: Long)
 
-  /** Performs pre-flight analysis on unindexed files to determine optimal
-    * batching strategy.
-    *
-    * Reads the source files, applies computed indexes, and counts distinct
-    * values per indexed column per file. The resulting [[FileAnalysis]] objects
-    * are used by [[createOptimalBatches]] to group files into batches that stay
-    * under the `largeIndexLimit`.
-    *
-    * If no storage columns are configured (e.g., only bloom or range indexes),
-    * returns trivial analyses with zero distinct counts.
-    *
-    * @note
-    *   This method calls `.collect()` to bring per-file distinct counts to the
-    *   driver. For indexes covering millions of files with many indexed
-    *   columns, the collected result set can be large enough to cause driver
-    *   OOM. Consider limiting the number of files analyzed per call or
-    *   increasing driver memory.
-    *
-    * @param files
-    *   set of file paths to analyze
-    * @return
-    *   sequence of [[FileAnalysis]] objects with per-column distinct counts;
-    *   empty if `files` is empty
-    */
-  protected def analyzeFiles(files: Set[String]): Seq[FileAnalysis] = {
+  /**
+   * Performs pre-flight analysis on unindexed files to determine optimal batching strategy.
+   *
+   * Reads the source files, applies computed indexes, and counts distinct values per indexed column per file. The
+   * resulting [[FileAnalysis]] objects are used by [[createOptimalBatches]] to group files into batches that stay under
+   * the `largeIndexLimit`.
+   *
+   * If no storage columns are configured (e.g., only bloom or range indexes), returns trivial analyses with zero
+   * distinct counts.
+   *
+   * @note
+   *   This method calls `.collect()` to bring per-file distinct counts to the driver. For indexes covering millions of
+   *   files with many indexed columns, the collected result set can be large enough to cause driver OOM. Consider
+   *   limiting the number of files analyzed per call or increasing driver memory.
+   *
+   * @param files
+   *   set of file paths to analyze
+   * @return
+   *   sequence of [[FileAnalysis]] objects with per-column distinct counts; empty if `files` is empty
+   */
+  protected def analyzeFiles(files: Set[String]): Seq[FileAnalysis] =
     if (files.isEmpty) Seq.empty
     else {
       val startTime = System.currentTimeMillis()
@@ -260,66 +227,57 @@ trait IndexBuildOperations extends BloomFilterOperations {
 
         // For each file, count distinct values per indexed column
         val analysisColumns = allStorageColumns.toSeq
-        val distinctCountExprs = analysisColumns.map { colName =>
-          countDistinct(col(colName)).alias(s"${colName}_distinct")
-        }
+        val distinctCountExprs =
+          analysisColumns.map(colName => countDistinct(col(colName)).alias(s"${colName}_distinct"))
 
         if (distinctCountExprs.isEmpty) {
           files.map(f => FileAnalysis(f, Map.empty, 0L)).toSeq
         } else {
-          val fileAnalysisDf = withFilename
-            .groupBy("filename")
-            .agg(distinctCountExprs.head, distinctCountExprs.tail: _*)
+          val fileAnalysisDf =
+            withFilename
+              .groupBy("filename")
+              .agg(distinctCountExprs.head, distinctCountExprs.tail: _*)
 
           val analysisResults = fileAnalysisDf.collect()
 
-          val results = analysisResults.map { row =>
-            val filename = row.getAs[String]("filename")
-            val distinctCounts = analysisColumns.map { colName =>
-              colName -> row.getAs[Long](s"${colName}_distinct")
-            }.toMap
-            val maxCount =
-              if (distinctCounts.nonEmpty) distinctCounts.values.max else 0L
+          val results =
+            analysisResults.map { row =>
+              val filename = row.getAs[String]("filename")
+              val distinctCounts =
+                analysisColumns.map(colName => colName -> row.getAs[Long](s"${colName}_distinct")).toMap
+              val maxCount =
+                if (distinctCounts.nonEmpty) distinctCounts.values.max else 0L
 
-            FileAnalysis(filename, distinctCounts, maxCount)
-          }.toSeq
+              FileAnalysis(filename, distinctCounts, maxCount)
+            }.toSeq
 
           logger.warn(
-            s"Pre-flight analysis of ${files.size} files completed in ${System.currentTimeMillis() - startTime}ms"
-          )
+            s"Pre-flight analysis of ${files.size} files completed in ${System.currentTimeMillis() - startTime}ms")
           results
         }
       }
     }
-  }
 
-  /** Groups files into batches whose aggregate `maxDistinctCount` stays below
-    * `largeIndexLimit`.
-    *
-    * The algorithm sorts files by `maxDistinctCount` (largest first) and packs
-    * them sequentially into batches. When adding a file would push the batch
-    * total past the limit, a new batch is started. Files that individually
-    * exceed the limit are placed into single-file batches to guarantee
-    * progress.
-    *
-    * @param fileAnalyses
-    *   sequence of [[FileAnalysis]] objects from [[analyzeFiles]]
-    * @return
-    *   sequence of file batches (each a `Set[String]` of filenames); empty if
-    *   `fileAnalyses` is empty
-    */
-  protected def createOptimalBatches(
-      fileAnalyses: Seq[FileAnalysis]
-  ): Seq[Set[String]] = {
+  /**
+   * Groups files into batches whose aggregate `maxDistinctCount` stays below `largeIndexLimit`.
+   *
+   * The algorithm sorts files by `maxDistinctCount` (largest first) and packs them sequentially into batches. When
+   * adding a file would push the batch total past the limit, a new batch is started. Files that individually exceed the
+   * limit are placed into single-file batches to guarantee progress.
+   *
+   * @param fileAnalyses
+   *   sequence of [[FileAnalysis]] objects from [[analyzeFiles]]
+   * @return
+   *   sequence of file batches (each a `Set[String]` of filenames); empty if `fileAnalyses` is empty
+   */
+  protected def createOptimalBatches(fileAnalyses: Seq[FileAnalysis]): Seq[Set[String]] =
     if (fileAnalyses.isEmpty) Seq.empty
     else {
       val allStorageColumns = storageColumns
       if (allStorageColumns.isEmpty) {
         Seq(fileAnalyses.map(_.filename).toSet)
       } else {
-        logger.warn(
-          s"Creating optimal batches for ${fileAnalyses.size} files with largeIndexLimit=$largeIndexLimit"
-        )
+        logger.warn(s"Creating optimal batches for ${fileAnalyses.size} files with largeIndexLimit=$largeIndexLimit")
 
         // Separate files that individually exceed the limit (will be processed individually)
         val (largeFiles, regularFiles) =
@@ -327,8 +285,7 @@ trait IndexBuildOperations extends BloomFilterOperations {
 
         if (largeFiles.nonEmpty) {
           logger.warn(
-            s"Found ${largeFiles.size} files that individually exceed largeIndexLimit and will be processed separately"
-          )
+            s"Found ${largeFiles.size} files that individually exceed largeIndexLimit and will be processed separately")
         }
 
         val batches = scala.collection.mutable.ListBuffer[Set[String]]()
@@ -369,41 +326,35 @@ trait IndexBuildOperations extends BloomFilterOperations {
 
         val allBatches = batches.toSeq ++ largeBatches
         logger.warn(
-          s"Created ${allBatches.size} batches: ${batches.size} regular batches + ${largeBatches.size} large file batches"
-        )
+          s"Created ${allBatches.size} batches: ${batches.size} regular batches + " +
+            s"${largeBatches.size} large file batches")
 
         allBatches
       }
     }
-  }
 
-  /** Builds regular (array-aggregated) indexes for all configured regular and
-    * computed columns.
-    *
-    * Groups the input data by filename and collects distinct values into arrays
-    * via `collect_set`. If no regular or computed indexes are configured,
-    * returns a distinct filename-only DataFrame.
-    *
-    * @param df
-    *   the base DataFrame with `filename` column and all indexed source columns
-    * @return
-    *   DataFrame with `filename` plus one array column per regular/computed
-    *   index
-    */
+  /**
+   * Builds regular (array-aggregated) indexes for all configured regular and computed columns.
+   *
+   * Groups the input data by filename and collects distinct values into arrays via `collect_set`. If no regular or
+   * computed indexes are configured, returns a distinct filename-only DataFrame.
+   *
+   * @param df
+   *   the base DataFrame with `filename` column and all indexed source columns
+   * @return
+   *   DataFrame with `filename` plus one array column per regular/computed index
+   */
   protected def buildRegularIndexes(df: DataFrame): DataFrame = {
-    val regularIndexes = metadata.indexes.asScala.toSet ++
-      metadata.computed_indexes.keySet().asScala
+    val regularIndexes =
+      metadata.indexes.asScala.toSet ++
+        metadata.computed_indexes.keySet().asScala
 
-    logger.debug(
-      s"Building regular indexes for ${regularIndexes.size} columns: ${regularIndexes.mkString(", ")}"
-    )
+    logger.debug(s"Building regular indexes for ${regularIndexes.size} columns: ${regularIndexes.mkString(", ")}")
 
     if (regularIndexes.nonEmpty) {
       val regularCols = (regularIndexes + "filename").toList
       val selectedDf = df.select(regularCols.map(col): _*).distinct
-      val aggExprs = regularIndexes.toList.map(colName =>
-        collect_set(col(colName)).alias(colName)
-      )
+      val aggExprs = regularIndexes.toList.map(colName => collect_set(col(colName)).alias(colName))
       // Safe: regularIndexes.nonEmpty guard above guarantees aggExprs.nonEmpty
       selectedDf.groupBy("filename").agg(aggExprs.head, aggExprs.tail: _*)
     } else {
@@ -411,170 +362,147 @@ trait IndexBuildOperations extends BloomFilterOperations {
     }
   }
 
-  /** Builds exploded field indexes and joins them onto the result DataFrame.
-    *
-    * For each configured exploded field index, extracts the nested field path
-    * from the array column, explodes it, collects distinct values back into an
-    * array per file, and joins the result onto `resultDf`.
-    *
-    * @param baseData
-    *   the full base DataFrame with all source columns
-    * @param resultDf
-    *   the accumulating result DataFrame to join with (must have `filename`)
-    * @return
-    *   DataFrame with exploded field index columns joined via `full_outer`
-    */
-  protected def buildExplodedFieldIndexes(
-      baseData: DataFrame,
-      resultDf: DataFrame
-  ): DataFrame = {
+  /**
+   * Builds exploded field indexes and joins them onto the result DataFrame.
+   *
+   * For each configured exploded field index, extracts the nested field path from the array column, explodes it,
+   * collects distinct values back into an array per file, and joins the result onto `resultDf`.
+   *
+   * @param baseData
+   *   the full base DataFrame with all source columns
+   * @param resultDf
+   *   the accumulating result DataFrame to join with (must have `filename`)
+   * @return
+   *   DataFrame with exploded field index columns joined via `full_outer`
+   */
+  protected def buildExplodedFieldIndexes(baseData: DataFrame, resultDf: DataFrame): DataFrame = {
     val explodedFieldMappings = metadata.exploded_field_indexes.asScala.toSeq
 
-    logger.debug(
-      s"Building exploded field indexes for ${explodedFieldMappings.size} mapping(s)"
-    )
+    logger.debug(s"Building exploded field indexes for ${explodedFieldMappings.size} mapping(s)")
 
     explodedFieldMappings.foldLeft(resultDf) { (accumDf, explodedField) =>
-      val explodedDf = baseData
-        .select("filename", explodedField.array_column)
-        .withColumn(
-          "temp_exploded",
-          explode(
-            col(s"${explodedField.array_column}.${explodedField.field_path}")
-          )
-        )
-        .groupBy("filename")
-        .agg(collect_set(col("temp_exploded")).alias(explodedField.as_column))
+      val explodedDf =
+        baseData
+          .select("filename", explodedField.array_column)
+          .withColumn("temp_exploded", explode(col(s"${explodedField.array_column}.${explodedField.field_path}")))
+          .groupBy("filename")
+          .agg(collect_set(col("temp_exploded")).alias(explodedField.as_column))
 
       accumDf.join(explodedDf, Seq("filename"), "full_outer")
     }
   }
 
-  /** Builds temporal indexes storing `Array[Struct(value, max_ts)]` per file.
-    *
-    * For each temporal index configuration, groups by `(filename,
-    * value_column)` to find the maximum timestamp per value per file, then
-    * collects the `(value, max_ts)` structs into an array per file. This
-    * enables temporal deduplication at query time.
-    *
-    * @param df
-    *   the base DataFrame with `filename`, value, and timestamp columns
-    * @return
-    *   DataFrame with `filename` plus one struct-array column per temporal
-    *   index; filename-only DataFrame if no temporal indexes are configured
-    */
+  /**
+   * Builds temporal indexes storing `Array[Struct(value, max_ts)]` per file.
+   *
+   * For each temporal index configuration, groups by `(filename, value_column)` to find the maximum timestamp per value
+   * per file, then collects the `(value, max_ts)` structs into an array per file. This enables temporal deduplication
+   * at query time.
+   *
+   * @param df
+   *   the base DataFrame with `filename`, value, and timestamp columns
+   * @return
+   *   DataFrame with `filename` plus one struct-array column per temporal index; filename-only DataFrame if no temporal
+   *   indexes are configured
+   */
   protected def buildTemporalIndexes(df: DataFrame): DataFrame = {
     val temporalConfigs = metadata.temporal_indexes.asScala.toSeq
     if (temporalConfigs.isEmpty) {
       df.select("filename").distinct()
     } else {
       logger.debug(
-        s"Building temporal indexes for ${temporalConfigs.size} columns: ${temporalConfigs.map(_.column).mkString(", ")}"
-      )
+        s"Building temporal indexes for ${temporalConfigs.size} columns: " +
+          s"${temporalConfigs.map(_.column).mkString(", ")}")
 
-      temporalConfigs.foldLeft(df.select("filename").distinct()) {
-        (accumDf, config) =>
-          val perFilePerValue = df
+      temporalConfigs.foldLeft(df.select("filename").distinct()) { (accumDf, config) =>
+        val perFilePerValue =
+          df
             .select("filename", config.column, config.timestamp_column)
             .groupBy("filename", config.column)
             .agg(max(col(config.timestamp_column)).alias("_ariadne_max_ts"))
 
-          val structPerFile = perFilePerValue
-            .withColumn(
-              "_struct",
-              struct(
-                col(config.column).as("value"),
-                col("_ariadne_max_ts").as("max_ts")
-              )
-            )
+        val structPerFile =
+          perFilePerValue
+            .withColumn("_struct", struct(col(config.column).as("value"), col("_ariadne_max_ts").as("max_ts")))
             .groupBy("filename")
             .agg(collect_set(col("_struct")).alias(config.column))
 
-          accumDf.join(structPerFile, Seq("filename"), "full_outer")
+        accumDf.join(structPerFile, Seq("filename"), "full_outer")
       }
     }
   }
 
-  /** Builds range indexes storing `Struct(min, max)` per file.
-    *
-    * For each range index configuration, groups by `filename` and computes the
-    * `min` and `max` of the column per file. The result is a struct column
-    * named `range_{column}`.
-    *
-    * @param df
-    *   the base DataFrame with `filename` column and range-indexed source
-    *   columns
-    * @return
-    *   DataFrame with `filename` plus one range struct column per configured
-    *   range index; filename-only DataFrame if no range indexes are configured
-    */
+  /**
+   * Builds range indexes storing `Struct(min, max)` per file.
+   *
+   * For each range index configuration, groups by `filename` and computes the `min` and `max` of the column per file.
+   * The result is a struct column named `range_{column}`.
+   *
+   * @param df
+   *   the base DataFrame with `filename` column and range-indexed source columns
+   * @return
+   *   DataFrame with `filename` plus one range struct column per configured range index; filename-only DataFrame if no
+   *   range indexes are configured
+   */
   protected def buildRangeIndexes(df: DataFrame): DataFrame = {
     val rangeConfigs = metadata.range_indexes.asScala.toSeq
     if (rangeConfigs.isEmpty) df.select("filename").distinct()
     else {
       logger.warn(
-        s"Building range indexes for ${rangeConfigs.size} columns: ${rangeConfigs.map(_.column).mkString(", ")}"
-      )
+        s"Building range indexes for ${rangeConfigs.size} columns: ${rangeConfigs.map(_.column).mkString(", ")}")
 
-      rangeConfigs.foldLeft(df.select("filename").distinct()) {
-        (accumDf, config) =>
-          val rangeCol = s"range_${config.column}"
-          val perFile = df
+      rangeConfigs.foldLeft(df.select("filename").distinct()) { (accumDf, config) =>
+        val rangeCol = s"range_${config.column}"
+        val perFile =
+          df
             .select("filename", config.column)
             .groupBy("filename")
-            .agg(
-              struct(
-                min(col(config.column)).alias("min"),
-                max(col(config.column)).alias("max")
-              ).alias(rangeCol)
-            )
-          accumDf.join(perFile, Seq("filename"), "full_outer")
+            .agg(struct(min(col(config.column)).alias("min"), max(col(config.column)).alias("max")).alias(rangeCol))
+        accumDf.join(perFile, Seq("filename"), "full_outer")
       }
     }
   }
 
-  /** Checks all storage columns for arrays exceeding `largeIndexLimit` and
-    * delegates to [[appendToLargeIndex]] for separation.
-    *
-    * @param df
-    *   the combined index DataFrame with array columns
-    */
+  /**
+   * Checks all storage columns for arrays exceeding `largeIndexLimit` and delegates to [[appendToLargeIndex]] for
+   * separation.
+   *
+   * @param df
+   *   the combined index DataFrame with array columns
+   */
   protected def handleLargeIndexes(df: DataFrame): Unit = {
     val allStorageColumns = storageColumns
     if (allStorageColumns.nonEmpty) {
-      logger.warn(
-        s"Checking ${allStorageColumns.size} columns for large index separation (limit=$largeIndexLimit)"
-      )
+      logger.warn(s"Checking ${allStorageColumns.size} columns for large index separation (limit=$largeIndexLimit)")
       appendToLargeIndex(df)
     }
   }
 
-  /** Appends the processed DataFrame to the staging Delta table.
-    *
-    * Before writing, any column whose array size meets or exceeds
-    * `largeIndexLimit` is nulled out (those values are stored separately via
-    * [[appendToLargeIndex]]). The DataFrame is written in append mode with
-    * schema merge enabled.
-    *
-    * @param df
-    *   the combined index DataFrame to stage
-    */
+  /**
+   * Appends the processed DataFrame to the staging Delta table.
+   *
+   * Before writing, any column whose array size meets or exceeds `largeIndexLimit` is nulled out (those values are
+   * stored separately via [[appendToLargeIndex]]). The DataFrame is written in append mode with schema merge enabled.
+   *
+   * @param df
+   *   the combined index DataFrame to stage
+   */
   protected def appendToStaging(df: DataFrame): Unit = {
     val startTime = System.currentTimeMillis()
     val allStorageColumns = storageColumns
 
     // Create small grouped DataFrame (filter out large indexes)
-    val smallGroupedDf = if (allStorageColumns.nonEmpty) {
-      allStorageColumns.foldLeft(df) { case (accumDf, colName) =>
-        accumDf.withColumn(
-          colName,
-          when(size(col(colName)) >= largeIndexLimit, null)
-            .otherwise(col(colName))
-        )
+    val smallGroupedDf =
+      if (allStorageColumns.nonEmpty) {
+        allStorageColumns.foldLeft(df) { case (accumDf, colName) =>
+          accumDf.withColumn(
+            colName,
+            when(size(col(colName)) >= largeIndexLimit, null)
+              .otherwise(col(colName)))
+        }
+      } else {
+        df
       }
-    } else {
-      df
-    }
 
     val rowCount = smallGroupedDf.count()
     logger.warn(s"Appending $rowCount rows to staging at $stagingFilePath")
@@ -584,72 +512,62 @@ trait IndexBuildOperations extends BloomFilterOperations {
       .option("mergeSchema", "true")
       .mode("append")
       .save(stagingFilePath.toString)
-    logger.warn(
-      s"Staging append completed for '$name' ($rowCount rows) in ${System.currentTimeMillis() - startTime}ms"
-    )
+    logger.warn(s"Staging append completed for '$name' ($rowCount rows) in ${System.currentTimeMillis() - startTime}ms")
   }
 
-  /** Appends large index data to per-column Delta tables under
-    * `large_indexes/`.
-    *
-    * For each storage column, identifies rows where the array size meets or
-    * exceeds `largeIndexLimit`, explodes those arrays into individual rows, and
-    * writes them to `large_indexes/{column}/`. Before appending, any existing
-    * rows for the same filenames are removed via Delta MERGE to prevent
-    * duplicates (important during column backfill or re-indexing).
-    *
-    * @note
-    *   The `count()` call before the write is intentional: it materializes the
-    *   DataFrame to determine whether any large-index rows exist for this
-    *   column, avoiding the overhead of a Delta MERGE + write when no rows
-    *   qualify. This results in a double computation (count + write), but the
-    *   alternative—writing unconditionally—would create empty Delta commits and
-    *   unnecessary MERGE operations for columns that are within the limit.
-    *
-    * @param df
-    *   the combined index DataFrame with array columns
-    */
+  /**
+   * Appends large index data to per-column Delta tables under `large_indexes/`.
+   *
+   * For each storage column, identifies rows where the array size meets or exceeds `largeIndexLimit`, explodes those
+   * arrays into individual rows, and writes them to `large_indexes/{column}/`. Before appending, any existing rows for
+   * the same filenames are removed via Delta MERGE to prevent duplicates (important during column backfill or
+   * re-indexing).
+   *
+   * @note
+   *   The `count()` call before the write is intentional: it materializes the DataFrame to determine whether any
+   *   large-index rows exist for this column, avoiding the overhead of a Delta MERGE + write when no rows qualify. This
+   *   results in a double computation (count + write), but the alternative—writing unconditionally—would create empty
+   *   Delta commits and unnecessary MERGE operations for columns that are within the limit.
+   *
+   * @param df
+   *   the combined index DataFrame with array columns
+   */
   protected def appendToLargeIndex(df: DataFrame): Unit = {
     val startTime = System.currentTimeMillis()
     val allStorageColumns = storageColumns
     if (allStorageColumns.nonEmpty) {
 
-      val largeGroupedDf = allStorageColumns.foldLeft(df) {
-        case (accumDf, colName) =>
+      val largeGroupedDf =
+        allStorageColumns.foldLeft(df) { case (accumDf, colName) =>
           accumDf.withColumn(
             colName,
             when(size(col(colName)) < largeIndexLimit, null)
-              .otherwise(col(colName))
-          )
-      }
+              .otherwise(col(colName)))
+        }
 
       // Collect filenames being processed for dedup
       val processedFiles = df.select("filename").distinct()
 
       allStorageColumns.foreach { colName =>
-        val columnData = largeGroupedDf
-          .select("filename", colName)
-          .where(col(colName).isNotNull)
-          .withColumn(colName, explode(col(colName)))
-          .filter(col(colName).isNotNull)
-          .distinct()
+        val columnData =
+          largeGroupedDf
+            .select("filename", colName)
+            .where(col(colName).isNotNull)
+            .withColumn(colName, explode(col(colName)))
+            .filter(col(colName).isNotNull)
+            .distinct()
 
         val count = columnData.count()
         if (count > 0) {
           val columnPath = new Path(largeIndexesFilePath, colName)
-          logger.warn(
-            s"Appending $count rows to large index for column '$colName' at $columnPath"
-          )
+          logger.warn(s"Appending $count rows to large index for column '$colName' at $columnPath")
 
           // Remove existing rows for these files to prevent duplicates during re-indexing
           delta(columnPath) match {
             case Some(deltaTable) =>
               deltaTable
                 .as("target")
-                .merge(
-                  processedFiles.as("source"),
-                  "target.filename = source.filename"
-                )
+                .merge(processedFiles.as("source"), "target.filename = source.filename")
                 .whenMatched()
                 .delete()
                 .execute()
@@ -663,69 +581,66 @@ trait IndexBuildOperations extends BloomFilterOperations {
             .save(columnPath.toString)
         }
       }
-      logger.warn(
-        s"Large index append completed for '$name' (${allStorageColumns.size} columns) in ${System
-            .currentTimeMillis() - startTime}ms"
-      )
+      logger.warn(s"Large index append completed for '$name' (${allStorageColumns.size} columns) in ${System
+          .currentTimeMillis() - startTime}ms")
     }
   }
 
-  /** Column name prefix for auto-bloom filter storage in the main index table.
-    */
+  /**
+   * Column name prefix for auto-bloom filter storage in the main index table.
+   */
   protected val autoBloomColumnPrefix = "auto_bloom_"
 
-  /** Returns the set of auto-bloom storage column names (each prefixed with
-    * `auto_bloom_`).
-    *
-    * @return
-    *   set of prefixed column names (e.g., `auto_bloom_user_id`)
-    */
+  /**
+   * Returns the set of auto-bloom storage column names (each prefixed with `auto_bloom_`).
+   *
+   * @return
+   *   set of prefixed column names (e.g., `auto_bloom_user_id`)
+   */
   protected def autoBloomStorageColumns: Set[String] =
     metadata.auto_bloom_indexes.asScala
       .map(c => autoBloomColumnPrefix + c)
       .toSet
 
-  /** Returns the set of columns eligible for auto-bloom filtering.
-    *
-    * Eligible columns are regular, computed, and exploded-field indexes.
-    * Temporal indexes are excluded because they use struct arrays rather than
-    * simple value arrays.
-    *
-    * @return
-    *   set of eligible column names
-    */
+  /**
+   * Returns the set of columns eligible for auto-bloom filtering.
+   *
+   * Eligible columns are regular, computed, and exploded-field indexes. Temporal indexes are excluded because they use
+   * struct arrays rather than simple value arrays.
+   *
+   * @return
+   *   set of eligible column names
+   */
   private def autoBloomEligibleColumns: Set[String] =
     metadata.indexes.asScala.toSet ++
       metadata.computed_indexes.keySet().asScala ++
       metadata.exploded_field_indexes.asScala.map(_.as_column).toSet
 
-  /** Tracks the cached DataFrame from [[buildAutoBloomIndexes]] for deferred
-    * cleanup.
-    *
-    * Set during auto-bloom processing and unpersisted after staging is
-    * complete.
-    */
+  /**
+   * Tracks the cached DataFrame from [[buildAutoBloomIndexes]] for deferred cleanup.
+   *
+   * Set during auto-bloom processing and unpersisted after staging is complete.
+   */
   @transient protected var lastAutoBloomCache: Option[DataFrame] = None
 
-  /** Builds auto-bloom filters for columns that exceed the large index limit.
-    *
-    * Scans the combined DataFrame to identify columns with any file whose array
-    * size meets or exceeds `largeIndexLimit`. For each such column, a bloom
-    * filter is built from the full array and stored in the main index with the
-    * `auto_bloom_` prefix. At query time, these bloom filters enable fast
-    * pre-filtering to determine which files need to load large index data.
-    *
-    * The input DataFrame is cached during processing to avoid redundant
-    * computation; the cache reference is stored in [[lastAutoBloomCache]] for
-    * deferred cleanup. If an exception occurs during processing, the cached
-    * DataFrame is unpersisted before the exception is rethrown.
-    *
-    * @param combinedDf
-    *   the combined index DataFrame with array columns
-    * @return
-    *   DataFrame with `auto_bloom_{column}` binary columns added for columns
-    *   exceeding the limit; unchanged DataFrame if no columns qualify
-    */
+  /**
+   * Builds auto-bloom filters for columns that exceed the large index limit.
+   *
+   * Scans the combined DataFrame to identify columns with any file whose array size meets or exceeds `largeIndexLimit`.
+   * For each such column, a bloom filter is built from the full array and stored in the main index with the
+   * `auto_bloom_` prefix. At query time, these bloom filters enable fast pre-filtering to determine which files need to
+   * load large index data.
+   *
+   * The input DataFrame is cached during processing to avoid redundant computation; the cache reference is stored in
+   * [[lastAutoBloomCache]] for deferred cleanup. If an exception occurs during processing, the cached DataFrame is
+   * unpersisted before the exception is rethrown.
+   *
+   * @param combinedDf
+   *   the combined index DataFrame with array columns
+   * @return
+   *   DataFrame with `auto_bloom_{column}` binary columns added for columns exceeding the limit; unchanged DataFrame if
+   *   no columns qualify
+   */
   protected def buildAutoBloomIndexes(combinedDf: DataFrame): DataFrame = {
     val startTime = System.currentTimeMillis()
     val eligible = autoBloomEligibleColumns
@@ -736,18 +651,17 @@ trait IndexBuildOperations extends BloomFilterOperations {
       val cachedDf = combinedDf.cache()
 
       try {
-        val columnsExceedingLimit = eligible.filter { colName =>
-          cachedDf.columns.contains(colName) &&
-          cachedDf
-            .select("filename", colName)
-            .where(col(colName).isNotNull)
-            .where(size(col(colName)) >= largeIndexLimit)
-            .count() > 0
-        }
+        val columnsExceedingLimit =
+          eligible.filter { colName =>
+            cachedDf.columns.contains(colName) &&
+            cachedDf
+              .select("filename", colName)
+              .where(col(colName).isNotNull)
+              .where(size(col(colName)) >= largeIndexLimit)
+              .count() > 0
+          }
 
-        logger.warn(
-          s"Auto-bloom: checked ${eligible.size} columns, ${columnsExceedingLimit.size} exceed limit"
-        )
+        logger.warn(s"Auto-bloom: checked ${eligible.size} columns, ${columnsExceedingLimit.size} exceed limit")
 
         columnsExceedingLimit.foreach { colName =>
           if (!metadata.auto_bloom_indexes.contains(colName)) {
@@ -755,54 +669,44 @@ trait IndexBuildOperations extends BloomFilterOperations {
           }
         }
 
-        val autoBloomColumns = metadata.auto_bloom_indexes.asScala.toSet
-          .intersect(eligible)
-          .filter(cachedDf.columns.contains)
+        val autoBloomColumns =
+          metadata.auto_bloom_indexes.asScala.toSet
+            .intersect(eligible)
+            .filter(cachedDf.columns.contains)
 
         if (autoBloomColumns.isEmpty) {
           cachedDf.unpersist()
-          logger.warn(
-            s"Auto-bloom: no columns to build, completed in ${System.currentTimeMillis() - startTime}ms"
-          )
+          logger.warn(s"Auto-bloom: no columns to build, completed in ${System.currentTimeMillis() - startTime}ms")
           combinedDf
         } else {
-          logger.warn(
-            s"Building auto-bloom filters for columns: ${autoBloomColumns.mkString(", ")}"
-          )
+          logger.warn(s"Building auto-bloom filters for columns: ${autoBloomColumns.mkString(", ")}")
           val fpr = autoBloomFpr
-          val result = autoBloomColumns.foldLeft(cachedDf) { (df, colName) =>
-            logger.warn(
-              s"Auto-bloom: building filter for '$colName' with FPR=$fpr"
-            )
-            val bloomColumn = autoBloomColumnPrefix + colName
-            val bloomUdf = createBloomFilterUdf(fpr)
-            df.withColumn(bloomColumn, bloomUdf(col(colName)))
-          }
+          val result =
+            autoBloomColumns.foldLeft(cachedDf) { (df, colName) =>
+              logger.warn(s"Auto-bloom: building filter for '$colName' with FPR=$fpr")
+              val bloomColumn = autoBloomColumnPrefix + colName
+              val bloomUdf = createBloomFilterUdf(fpr)
+              df.withColumn(bloomColumn, bloomUdf(col(colName)))
+            }
           lastAutoBloomCache = Some(cachedDf)
-          logger.warn(
-            s"Auto-bloom: build completed in ${System.currentTimeMillis() - startTime}ms"
-          )
+          logger.warn(s"Auto-bloom: build completed in ${System.currentTimeMillis() - startTime}ms")
           result
         }
       } catch {
         case e: Exception =>
-          logger.warn(
-            s"Failed to build auto-bloom indexes for $name: ${e.getMessage}",
-            e
-          )
+          logger.warn(s"Failed to build auto-bloom indexes for $name: ${e.getMessage}", e)
           cachedDf.unpersist()
           throw e
       }
     }
   }
 
-  /** Compacts all Delta tables (main index and large index tables) using Delta
-    * OPTIMIZE.
-    *
-    * Runs Delta Lake's OPTIMIZE command to consolidate small files into larger
-    * ones, improving read performance. Processes the main index table first,
-    * then each large index column table.
-    */
+  /**
+   * Compacts all Delta tables (main index and large index tables) using Delta OPTIMIZE.
+   *
+   * Runs Delta Lake's OPTIMIZE command to consolidate small files into larger ones, improving read performance.
+   * Processes the main index table first, then each large index column table.
+   */
   protected def compactDeltaTables(): Unit = {
     val overallStart = System.currentTimeMillis()
     val largeIdxCols = largeIndexColumns
@@ -811,179 +715,143 @@ trait IndexBuildOperations extends BloomFilterOperations {
       val compactStart = System.currentTimeMillis()
       logger.warn(s"Compacting main index at $indexFilePath")
       dt.optimize().executeCompaction()
-      logger.warn(
-        s"Compacted main index in ${System.currentTimeMillis() - compactStart}ms"
-      )
+      logger.warn(s"Compacted main index in ${System.currentTimeMillis() - compactStart}ms")
     }
 
     largeIdxCols.foreach { colName =>
       val columnPath = new Path(largeIndexesFilePath, colName)
       delta(columnPath).foreach { dt =>
         val compactStart = System.currentTimeMillis()
-        logger.warn(
-          s"Compacting large index for column $colName at $columnPath"
-        )
+        logger.warn(s"Compacting large index for column $colName at $columnPath")
         dt.optimize().executeCompaction()
-        logger.warn(
-          s"Compacted large index '$colName' in ${System.currentTimeMillis() - compactStart}ms"
-        )
+        logger.warn(s"Compacted large index '$colName' in ${System.currentTimeMillis() - compactStart}ms")
       }
     }
 
-    logger.warn(
-      s"Compaction completed for main index and ${largeIdxCols.size} large index table(s) in ${System
-          .currentTimeMillis() - overallStart}ms"
-    )
+    logger.warn(s"Compaction completed for main index and ${largeIdxCols.size} large index table(s) in ${System
+        .currentTimeMillis() - overallStart}ms")
   }
 
-  /** Counter tracking batches processed since the last auto-compaction.
-    *
-    * Incremented after each batch in `updateBatched` and reset to zero after
-    * each compaction cycle or at the start of each [[Index.update update]] call
-    * to prevent stale counts from a previous `update` from triggering premature
-    * compaction.
-    */
+  /**
+   * Counter tracking batches processed since the last auto-compaction.
+   *
+   * Incremented after each batch in `updateBatched` and reset to zero after each compaction cycle or at the start of
+   * each [[Index.update update]] call to prevent stale counts from a previous `update` from triggering premature
+   * compaction.
+   */
   protected var batchesSinceCompact: Int = 0
 
-  /** Triggers compaction if the auto-compact threshold has been reached.
-    *
-    * Checks the [[batchesSinceCompact]] counter against the configured
-    * `autoCompactThreshold`. If the threshold is met, compacts all Delta tables
-    * and resets the counter to zero. The counter is persisted to metadata so it
-    * survives across Spark jobs.
-    */
-  protected def maybeAutoCompact(): Unit = {
+  /**
+   * Triggers compaction if the auto-compact threshold has been reached.
+   *
+   * Checks the [[batchesSinceCompact]] counter against the configured `autoCompactThreshold`. If the threshold is met,
+   * compacts all Delta tables and resets the counter to zero. The counter is persisted to metadata so it survives
+   * across Spark jobs.
+   */
+  protected def maybeAutoCompact(): Unit =
     autoCompactThreshold.foreach { threshold =>
       if (batchesSinceCompact >= threshold) {
-        logger.warn(
-          s"Auto-compact threshold reached ($batchesSinceCompact batches), compacting Delta tables"
-        )
+        logger.warn(s"Auto-compact threshold reached ($batchesSinceCompact batches), compacting Delta tables")
         compactDeltaTables()
         batchesSinceCompact = 0
         metadata.batches_since_compact = 0
         writeMetadata(metadata)
       }
     }
-  }
 
-  /** Vacuums all Delta tables (main index and large index tables) to remove old
-    * files.
-    *
-    * Uses Delta Lake's VACUUM command to delete data files no longer referenced
-    * by the transaction log. Temporarily disables the retention duration safety
-    * check when `retentionHours` is zero or negative.
-    *
-    * @note
-    *   '''Thread-safety:''' This method temporarily mutates the shared
-    *   SparkConf (`retentionDurationCheck.enabled`). Concurrent `Index`
-    *   instances sharing the same `SparkSession` may race on this setting. The
-    *   value is restored in a `finally` block, but a TOCTOU window exists
-    *   between set and restore.
-    *
-    * @param retentionHours
-    *   number of hours of history to retain (default 168 = 7 days)
-    */
+  /**
+   * Vacuums all Delta tables (main index and large index tables) to remove old files.
+   *
+   * Uses Delta Lake's VACUUM command to delete data files no longer referenced by the transaction log. Temporarily
+   * disables the retention duration safety check when `retentionHours` is zero or negative.
+   *
+   * @note
+   *   '''Thread-safety:''' This method temporarily mutates the shared SparkConf (`retentionDurationCheck.enabled`).
+   *   Concurrent `Index` instances sharing the same `SparkSession` may race on this setting. The value is restored in a
+   *   `finally` block, but a TOCTOU window exists between set and restore.
+   *
+   * @param retentionHours
+   *   number of hours of history to retain (default 168 = 7 days)
+   */
   protected def vacuumDeltaTables(retentionHours: Int = 168): Unit = {
     val overallStart = System.currentTimeMillis()
     val largeIdxCols = largeIndexColumns
-    val previousCheck = spark.conf.getOption(
-      "spark.databricks.delta.retentionDurationCheck.enabled"
-    )
+    val previousCheck = spark.conf.getOption("spark.databricks.delta.retentionDurationCheck.enabled")
     try {
       if (retentionHours <= 0) {
-        spark.conf.set(
-          "spark.databricks.delta.retentionDurationCheck.enabled",
-          "false"
-        )
+        spark.conf.set("spark.databricks.delta.retentionDurationCheck.enabled", "false")
       }
       delta(indexFilePath).foreach { dt =>
-        logger.warn(
-          s"Vacuuming main index at $indexFilePath with retention $retentionHours hours"
-        )
+        logger.warn(s"Vacuuming main index at $indexFilePath with retention $retentionHours hours")
         dt.vacuum(retentionHours.toDouble)
       }
 
       largeIdxCols.foreach { colName =>
         val columnPath = new Path(largeIndexesFilePath, colName)
         delta(columnPath).foreach { dt =>
-          logger.warn(
-            s"Vacuuming large index for column $colName at $columnPath with retention $retentionHours hours"
-          )
+          logger.warn(s"Vacuuming large index for column $colName at $columnPath with retention $retentionHours hours")
           dt.vacuum(retentionHours.toDouble)
         }
       }
 
-      logger.warn(
-        s"Vacuum completed for main index and ${largeIdxCols.size} large index table(s) in ${System
-            .currentTimeMillis() - overallStart}ms"
-      )
+      logger.warn(s"Vacuum completed for main index and ${largeIdxCols.size} large index table(s) in ${System
+          .currentTimeMillis() - overallStart}ms")
     } finally {
       previousCheck match {
         case Some(v) =>
-          spark.conf.set(
-            "spark.databricks.delta.retentionDurationCheck.enabled",
-            v
-          )
+          spark.conf.set("spark.databricks.delta.retentionDurationCheck.enabled", v)
         case None =>
-          spark.conf.unset(
-            "spark.databricks.delta.retentionDurationCheck.enabled"
-          )
+          spark.conf.unset("spark.databricks.delta.retentionDurationCheck.enabled")
       }
     }
   }
 
-  /** Consolidates staged data into the main index table.
-    *
-    * Delegates to [[consolidateMainStaging]] which performs a Delta MERGE
-    * (upsert) of all staged rows into the main index, then deletes the staging
-    * table. Logs the total time taken.
-    */
+  /**
+   * Consolidates staged data into the main index table.
+   *
+   * Delegates to [[consolidateMainStaging]] which performs a Delta MERGE (upsert) of all staged rows into the main
+   * index, then deletes the staging table. Logs the total time taken.
+   */
   protected def consolidateStaging(): Unit = {
     val startTime = System.currentTimeMillis()
     logger.warn("Starting consolidation of staged data")
     consolidateMainStaging()
 
-    logger.warn(
-      s"Consolidation complete in ${System.currentTimeMillis() - startTime}ms"
-    )
+    logger.warn(s"Consolidation complete in ${System.currentTimeMillis() - startTime}ms")
   }
 
-  /** Consolidates the main staging table into the main index via Delta MERGE.
-    *
-    * Performs an upsert (match on `filename`): existing rows are updated, new
-    * rows are inserted. Creates the main index if it does not yet exist by
-    * writing the staging data directly. Schema auto-merge is temporarily
-    * enabled to support new columns added since the index was first created.
-    *
-    * After successful merge, the staging Delta table is deleted.
-    */
-  private def consolidateMainStaging(): Unit = {
+  /**
+   * Consolidates the main staging table into the main index via Delta MERGE.
+   *
+   * Performs an upsert (match on `filename`): existing rows are updated, new rows are inserted. Creates the main index
+   * if it does not yet exist by writing the staging data directly. Schema auto-merge is temporarily enabled to support
+   * new columns added since the index was first created.
+   *
+   * After successful merge, the staging Delta table is deleted.
+   */
+  private def consolidateMainStaging(): Unit =
     if (!exists(stagingFilePath)) {
       logger.warn("No staging data to consolidate for main index")
     } else {
 
       val allStorageColumns =
         storageColumns ++ bloomStorageColumns ++ rangeStorageColumns ++ autoBloomStorageColumns
-      val stagingDf = spark.read
-        .format("delta")
-        .load(stagingFilePath.toString)
-        .dropDuplicates("filename")
+      val stagingDf =
+        spark.read
+          .format("delta")
+          .load(stagingFilePath.toString)
+          .dropDuplicates("filename")
       val stagingRowCount = stagingDf.count()
       logger.warn(s"Merging $stagingRowCount staged rows into main index")
 
       if (allStorageColumns.nonEmpty) {
         delta(indexFilePath) match {
           case Some(deltaTable) =>
-            logger.warn(
-              s"Merging staging data into main index at ${indexFilePath}"
-            )
+            logger.warn(s"Merging staging data into main index at $indexFilePath")
             // Delta 3.2+: per-merge schema evolution; no shared session config.
             deltaTable
               .as("target")
-              .merge(
-                stagingDf.as("source"),
-                "target.filename = source.filename"
-              )
+              .merge(stagingDf.as("source"), "target.filename = source.filename")
               .withSchemaEvolution()
               .whenMatched()
               .updateAll()
@@ -991,9 +859,7 @@ trait IndexBuildOperations extends BloomFilterOperations {
               .insertAll()
               .execute()
           case None =>
-            logger.warn(
-              s"Creating new main index from staging at ${indexFilePath}"
-            )
+            logger.warn(s"Creating new main index from staging at $indexFilePath")
             stagingDf.write
               .format("delta")
               .mode("overwrite")
@@ -1009,18 +875,14 @@ trait IndexBuildOperations extends BloomFilterOperations {
       // Delete staging after successful consolidation
       try {
         delete(stagingFilePath)
-        logger.warn(
-          s"Deleted main staging table after consolidation for index '$name'"
-        )
+        logger.warn(s"Deleted main staging table after consolidation for index '$name'")
       } catch {
         case e: Exception =>
           logger.warn(
             s"Failed to delete staging table after consolidation for index '$name': ${e.getMessage}. " +
               "Staging data may be re-merged on next consolidation (idempotent).",
-            e
-          )
+            e)
       }
     }
-  }
 
 }

--- a/src/main/scala/dev/cjfravel/ariadne/IndexCatalog.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexCatalog.scala
@@ -1,44 +1,42 @@
 package dev.cjfravel.ariadne
 
-import dev.cjfravel.ariadne.exceptions.{
-  IndexNotFoundException,
-  FileListNotFoundException
-}
-import org.apache.hadoop.fs.Path
-import org.apache.logging.log4j.LogManager
-import org.apache.spark.sql.{DataFrame, Row, SparkSession}
-import org.apache.spark.sql.types._
 import scala.collection.JavaConverters._
 
-/** Summary information for a single Ariadne index.
-  *
-  * Captures the index name, data format, all configured index types, tracked
-  * file count, and cumulative indexed file size. Produced by
-  * [[IndexCatalog.describe]] and [[IndexCatalog.describeAll]].
-  *
-  * @param name
-  *   unique index name
-  * @param format
-  *   data file format (e.g., "parquet", "csv", "json")
-  * @param columns
-  *   union of all indexed column names across every index type
-  * @param regularIndexes
-  *   columns with regular (array-of-values) indexes
-  * @param bloomIndexes
-  *   columns with bloom filter indexes
-  * @param computedIndexes
-  *   computed index aliases (derived via SQL expressions)
-  * @param temporalIndexes
-  *   columns with temporal (version-dedup) indexes
-  * @param rangeIndexes
-  *   columns with min/max range indexes
-  * @param explodedFieldIndexes
-  *   aliases for exploded array field indexes
-  * @param fileCount
-  *   number of files tracked by this index's file list
-  * @param totalIndexedFileSize
-  *   cumulative size in bytes of all indexed files, or -1 if unknown
-  */
+import dev.cjfravel.ariadne.exceptions.{FileListNotFoundException, IndexNotFoundException}
+import org.apache.hadoop.fs.Path
+import org.apache.logging.log4j.LogManager
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+
+/**
+ * Summary information for a single Ariadne index.
+ *
+ * Captures the index name, data format, all configured index types, tracked file count, and cumulative indexed file
+ * size. Produced by [[IndexCatalog.describe]] and [[IndexCatalog.describeAll]].
+ *
+ * @param name
+ *   unique index name
+ * @param format
+ *   data file format (e.g., "parquet", "csv", "json")
+ * @param columns
+ *   union of all indexed column names across every index type
+ * @param regularIndexes
+ *   columns with regular (array-of-values) indexes
+ * @param bloomIndexes
+ *   columns with bloom filter indexes
+ * @param computedIndexes
+ *   computed index aliases (derived via SQL expressions)
+ * @param temporalIndexes
+ *   columns with temporal (version-dedup) indexes
+ * @param rangeIndexes
+ *   columns with min/max range indexes
+ * @param explodedFieldIndexes
+ *   aliases for exploded array field indexes
+ * @param fileCount
+ *   number of files tracked by this index's file list
+ * @param totalIndexedFileSize
+ *   cumulative size in bytes of all indexed files, or -1 if unknown
+ */
 case class IndexSummary(
     name: String,
     format: String,
@@ -50,165 +48,161 @@ case class IndexSummary(
     rangeIndexes: Set[String],
     explodedFieldIndexes: Set[String],
     fileCount: Long,
-    totalIndexedFileSize: Long
-)
+    totalIndexedFileSize: Long)
 
-/** Catalog for discovering, inspecting, and managing all Ariadne indexes under
-  * the configured `spark.ariadne.storagePath`.
-  *
-  * `IndexCatalog` is stateless — every call scans the filesystem for the
-  * current set of indexes. It complements the per-index API on [[Index]] by
-  * providing a global view of the storage path.
-  *
-  * '''Usage:'''
-  * {{{
-  * import dev.cjfravel.ariadne.IndexCatalog
-  *
-  * // List all index names
-  * val names: Seq[String] = IndexCatalog.list()
-  *
-  * // Get a summary of every index
-  * val summaries: Seq[IndexSummary] = IndexCatalog.describeAll()
-  *
-  * // View all indexes as a DataFrame
-  * IndexCatalog.toDF().show()
-  *
-  * // Fetch a specific Index instance
-  * val index: Index = IndexCatalog.get("myIndex")
-  * }}}
-  */
+/**
+ * Catalog for discovering, inspecting, and managing all Ariadne indexes under the configured
+ * `spark.ariadne.storagePath`.
+ *
+ * `IndexCatalog` is stateless — every call scans the filesystem for the current set of indexes. It complements the
+ * per-index API on [[Index]] by providing a global view of the storage path.
+ *
+ * '''Usage:'''
+ * {{{
+ * import dev.cjfravel.ariadne.IndexCatalog
+ *
+ * // List all index names
+ * val names: Seq[String] = IndexCatalog.list()
+ *
+ * // Get a summary of every index
+ * val summaries: Seq[IndexSummary] = IndexCatalog.describeAll()
+ *
+ * // View all indexes as a DataFrame
+ * IndexCatalog.toDF().show()
+ *
+ * // Fetch a specific Index instance
+ * val index: Index = IndexCatalog.get("myIndex")
+ * }}}
+ */
 object IndexCatalog {
 
   private val logger = LogManager.getLogger("ariadne")
 
-  /** Lists the names of all indexes in the configured storage path.
-    *
-    * Scans the `{storagePath}/indexes/` directory for subdirectories that
-    * contain a `metadata.json` file — this distinguishes real indexes from
-    * stale or partially deleted directories.
-    *
-    * @example
-    *   {{{
-    * val indexNames: Seq[String] = IndexCatalog.list()
-    *   }}}
-    *
-    * @param spark
-    *   implicit SparkSession providing configuration
-    * @return
-    *   alphabetically sorted sequence of index names, or empty if none exist
-    */
+  /**
+   * Lists the names of all indexes in the configured storage path.
+   *
+   * Scans the `{storagePath}/indexes/` directory for subdirectories that contain a `metadata.json` file — this
+   * distinguishes real indexes from stale or partially deleted directories.
+   *
+   * @example
+   *   {{{
+   * val indexNames: Seq[String] = IndexCatalog.list()
+   *   }}}
+   *
+   * @param spark
+   *   implicit SparkSession providing configuration
+   * @return
+   *   alphabetically sorted sequence of index names, or empty if none exist
+   */
   def list()(implicit spark: SparkSession): Seq[String] = {
     val sparkSession = spark
-    val contextUser = new AriadneContextUser {
-      implicit def spark: SparkSession = sparkSession
-    }
+    val contextUser =
+      new AriadneContextUser {
+        implicit def spark: SparkSession = sparkSession
+      }
     val indexesDir = IndexPathUtils.storagePath
     if (!contextUser.exists(indexesDir)) {
-      logger.warn(
-        "IndexCatalog: indexes directory does not exist, returning empty list"
-      )
+      logger.warn("IndexCatalog: indexes directory does not exist, returning empty list")
       Seq.empty
     } else {
       val statuses = contextUser.fs.listStatus(indexesDir)
       if (statuses == null) {
         Seq.empty
       } else {
-        val result = statuses
-          .filter(_.isDirectory)
-          .filter { status =>
-            val metadataPath = new Path(status.getPath, "metadata.json")
-            contextUser.fs.exists(metadataPath)
-          }
-          .map(_.getPath.getName)
-          .sorted
-          .toSeq
+        val result =
+          statuses
+            .filter(_.isDirectory)
+            .filter { status =>
+              val metadataPath = new Path(status.getPath, "metadata.json")
+              contextUser.fs.exists(metadataPath)
+            }
+            .map(_.getPath.getName)
+            .sorted
+            .toSeq
         logger.warn(s"IndexCatalog: found ${result.size} index(es)")
         result
       }
     }
   }
 
-  /** Checks whether an index with the given name exists.
-    *
-    * An index is considered to exist if its `metadata.json` file is present in
-    * the indexes storage directory, or if its file list entry exists.
-    *
-    * @example
-    *   {{{if (IndexCatalog.exists("orders")) println("Index found")}}}
-    *
-    * @param name
-    *   the index name to check
-    * @param spark
-    *   implicit SparkSession
-    * @return
-    *   true if the index exists
-    * @throws IllegalArgumentException
-    *   if name is null or blank
-    */
+  /**
+   * Checks whether an index with the given name exists.
+   *
+   * An index is considered to exist if its `metadata.json` file is present in the indexes storage directory, or if its
+   * file list entry exists.
+   *
+   * @example
+   *   {{{if (IndexCatalog.exists("orders")) println("Index found")}}}
+   *
+   * @param name
+   *   the index name to check
+   * @param spark
+   *   implicit SparkSession
+   * @return
+   *   true if the index exists
+   * @throws IllegalArgumentException
+   *   if name is null or blank
+   */
   def exists(name: String)(implicit spark: SparkSession): Boolean = {
-    require(
-      name != null && name.trim.nonEmpty,
-      "Index name must not be null or blank"
-    )
+    require(name != null && name.trim.nonEmpty, "Index name must not be null or blank")
     val sparkSession = spark
-    val contextUser = new AriadneContextUser {
-      implicit def spark: SparkSession = sparkSession
-    }
+    val contextUser =
+      new AriadneContextUser {
+        implicit def spark: SparkSession = sparkSession
+      }
     val metadataPath =
       new Path(new Path(IndexPathUtils.storagePath, name), "metadata.json")
     contextUser.fs.exists(metadataPath) || IndexPathUtils.exists(name)
   }
 
-  /** Returns a summary of a single index.
-    *
-    * Reads the index's `metadata.json` and file list to populate an
-    * [[IndexSummary]] with all configured index types and tracked file count.
-    *
-    * @example
-    *   {{{
-    * val summary: IndexSummary = IndexCatalog.describe("myIndex")
-    * println(summary.name, summary.fileCount)
-    *   }}}
-    *
-    * @param name
-    *   the index name
-    * @param spark
-    *   implicit SparkSession
-    * @return
-    *   the index summary
-    * @throws IndexNotFoundException
-    *   if the index does not exist
-    * @throws IllegalArgumentException
-    *   if name is null or blank
-    */
+  /**
+   * Returns a summary of a single index.
+   *
+   * Reads the index's `metadata.json` and file list to populate an [[IndexSummary]] with all configured index types and
+   * tracked file count.
+   *
+   * @example
+   *   {{{
+   * val summary: IndexSummary = IndexCatalog.describe("myIndex")
+   * println(summary.name, summary.fileCount)
+   *   }}}
+   *
+   * @param name
+   *   the index name
+   * @param spark
+   *   implicit SparkSession
+   * @return
+   *   the index summary
+   * @throws IndexNotFoundException
+   *   if the index does not exist
+   * @throws IllegalArgumentException
+   *   if name is null or blank
+   */
   def describe(name: String)(implicit spark: SparkSession): IndexSummary = {
-    require(
-      name != null && name.trim.nonEmpty,
-      "name must not be null or blank"
-    )
+    require(name != null && name.trim.nonEmpty, "name must not be null or blank")
     if (!exists(name)) {
       throw new IndexNotFoundException(name)
     }
     buildSummary(name)
   }
 
-  /** Returns summaries for all indexes in the storage path.
-    *
-    * Equivalent to calling [[describe]] for each name returned by [[list]], but
-    * logs a single message for the batch operation. Indexes whose metadata
-    * cannot be read are skipped with a warning.
-    *
-    * @example
-    *   {{{
-    * val summaries: Seq[IndexSummary] = IndexCatalog.describeAll()
-    * summaries.foreach(s => println(s.name))
-    *   }}}
-    *
-    * @param spark
-    *   implicit SparkSession
-    * @return
-    *   sequence of [[IndexSummary]], one per valid index
-    */
+  /**
+   * Returns summaries for all indexes in the storage path.
+   *
+   * Equivalent to calling [[describe]] for each name returned by [[list]], but logs a single message for the batch
+   * operation. Indexes whose metadata cannot be read are skipped with a warning.
+   *
+   * @example
+   *   {{{
+   * val summaries: Seq[IndexSummary] = IndexCatalog.describeAll()
+   * summaries.foreach(s => println(s.name))
+   *   }}}
+   *
+   * @param spark
+   *   implicit SparkSession
+   * @return
+   *   sequence of [[IndexSummary]], one per valid index
+   */
   def describeAll()(implicit spark: SparkSession): Seq[IndexSummary] = {
     val names = list()
     logger.warn(s"IndexCatalog: describing ${names.size} index(es)")
@@ -223,84 +217,72 @@ object IndexCatalog {
     }
   }
 
-  /** Returns the names of all indexes that track a given file.
-    *
-    * Scans every index's file list to check whether `fileName` is present. This
-    * is useful for determining which indexes need a `deleteFiles` call when a
-    * source file has been removed from storage.
-    *
-    * @example
-    *   {{{
-    * val indexes: Seq[String] = IndexCatalog.findIndexes("/data/users/part-00000.parquet")
-    *   }}}
-    *
-    * {{{
-    * val affected: Seq[String] = IndexCatalog.findIndexes("abfss://data@mystorage.dfs.core.windows.net/file1.parquet")
-    * affected.foreach { name =>
-    *   IndexCatalog.get(name).deleteFiles("abfss://data@mystorage.dfs.core.windows.net/file1.parquet")
-    * }
-    * }}}
-    *
-    * @param fileName
-    *   the file path to search for across all indexes
-    * @param spark
-    *   implicit SparkSession
-    * @return
-    *   alphabetically sorted names of indexes that track the file, or empty if
-    *   the file is not found in any index
-    * @throws IllegalArgumentException
-    *   if fileName is null or blank
-    */
-  def findIndexes(
-      fileName: String
-  )(implicit spark: SparkSession): Seq[String] = {
-    require(
-      fileName != null && fileName.trim.nonEmpty,
-      "fileName must not be null or blank"
-    )
+  /**
+   * Returns the names of all indexes that track a given file.
+   *
+   * Scans every index's file list to check whether `fileName` is present. This is useful for determining which indexes
+   * need a `deleteFiles` call when a source file has been removed from storage.
+   *
+   * @example
+   *   {{{
+   * val indexes: Seq[String] = IndexCatalog.findIndexes("/data/users/part-00000.parquet")
+   *   }}}
+   *
+   * {{{
+   * val affected: Seq[String] = IndexCatalog.findIndexes("abfss://data@mystorage.dfs.core.windows.net/file1.parquet")
+   * affected.foreach { name =>
+   *   IndexCatalog.get(name).deleteFiles("abfss://data@mystorage.dfs.core.windows.net/file1.parquet")
+   * }
+   * }}}
+   *
+   * @param fileName
+   *   the file path to search for across all indexes
+   * @param spark
+   *   implicit SparkSession
+   * @return
+   *   alphabetically sorted names of indexes that track the file, or empty if the file is not found in any index
+   * @throws IllegalArgumentException
+   *   if fileName is null or blank
+   */
+  def findIndexes(fileName: String)(implicit spark: SparkSession): Seq[String] = {
+    require(fileName != null && fileName.trim.nonEmpty, "fileName must not be null or blank")
     val startTime = System.currentTimeMillis()
     val names = list()
-    logger.warn(
-      s"IndexCatalog: searching ${names.size} index(es) for file '$fileName'"
-    )
-    val result = names.filter { name =>
-      val fileListName = IndexPathUtils.fileListName(name)
-      FileList.exists(fileListName) && FileList(fileListName).hasFile(fileName)
-    }
-    logger.warn(
-      s"IndexCatalog: findIndexes completed for '$fileName' — found ${result.size} match(es) in ${System
-          .currentTimeMillis() - startTime}ms"
-    )
+    logger.warn(s"IndexCatalog: searching ${names.size} index(es) for file '$fileName'")
+    val result =
+      names.filter { name =>
+        val fileListName = IndexPathUtils.fileListName(name)
+        FileList.exists(fileListName) && FileList(fileListName).hasFile(fileName)
+      }
+    logger.warn(s"IndexCatalog: findIndexes completed for '$fileName' — found ${result.size} match(es) in ${System
+        .currentTimeMillis() - startTime}ms")
     result
   }
 
-  /** Fetches an [[Index]] instance by reconnecting to an existing index.
-    *
-    * This is equivalent to calling `Index(name)` directly; it is provided here
-    * for API completeness so callers can discover and fetch indexes without
-    * importing [[Index]].
-    *
-    * @example
-    *   {{{
-    * val index: Index = IndexCatalog.get("myIndex")
-    *   }}}
-    *
-    * @param name
-    *   the index name
-    * @param spark
-    *   implicit SparkSession
-    * @return
-    *   a fully initialized Index instance
-    * @throws IndexNotFoundException
-    *   if the index does not exist
-    * @throws IllegalArgumentException
-    *   if name is null or blank
-    */
+  /**
+   * Fetches an [[Index]] instance by reconnecting to an existing index.
+   *
+   * This is equivalent to calling `Index(name)` directly; it is provided here for API completeness so callers can
+   * discover and fetch indexes without importing [[Index]].
+   *
+   * @example
+   *   {{{
+   * val index: Index = IndexCatalog.get("myIndex")
+   *   }}}
+   *
+   * @param name
+   *   the index name
+   * @param spark
+   *   implicit SparkSession
+   * @return
+   *   a fully initialized Index instance
+   * @throws IndexNotFoundException
+   *   if the index does not exist
+   * @throws IllegalArgumentException
+   *   if name is null or blank
+   */
   def get(name: String)(implicit spark: SparkSession): Index = {
-    require(
-      name != null && name.trim.nonEmpty,
-      "Index name must not be null or blank"
-    )
+    require(name != null && name.trim.nonEmpty, "Index name must not be null or blank")
     if (!exists(name)) {
       throw new IndexNotFoundException(name)
     }
@@ -308,121 +290,113 @@ object IndexCatalog {
     Index(name)
   }
 
-  /** Returns a DataFrame summarizing all indexes.
-    *
-    * The returned DataFrame has one row per index with the following columns:
-    * {{{
-    * name: String
-    * format: String
-    * regular_indexes: String   (comma-separated)
-    * bloom_indexes: String     (comma-separated)
-    * computed_indexes: String   (comma-separated)
-    * temporal_indexes: String   (comma-separated)
-    * range_indexes: String      (comma-separated)
-    * exploded_field_indexes: String (comma-separated)
-    * file_count: Long
-    * total_indexed_file_size: Long
-    * }}}
-    *
-    * @example
-    *   {{{
-    * val df: DataFrame = IndexCatalog.toDF()
-    * df.show()
-    *   }}}
-    *
-    * @param spark
-    *   implicit SparkSession
-    * @return
-    *   DataFrame with one row per index, or an empty DataFrame if no indexes
-    *   exist
-    */
+  /**
+   * Returns a DataFrame summarizing all indexes.
+   *
+   * The returned DataFrame has one row per index with the following columns:
+   * {{{
+   * name: String
+   * format: String
+   * regular_indexes: String   (comma-separated)
+   * bloom_indexes: String     (comma-separated)
+   * computed_indexes: String   (comma-separated)
+   * temporal_indexes: String   (comma-separated)
+   * range_indexes: String      (comma-separated)
+   * exploded_field_indexes: String (comma-separated)
+   * file_count: Long
+   * total_indexed_file_size: Long
+   * }}}
+   *
+   * @example
+   *   {{{
+   * val df: DataFrame = IndexCatalog.toDF()
+   * df.show()
+   *   }}}
+   *
+   * @param spark
+   *   implicit SparkSession
+   * @return
+   *   DataFrame with one row per index, or an empty DataFrame if no indexes exist
+   */
   def toDF()(implicit spark: SparkSession): DataFrame = {
     val summaries = describeAll()
-    val schema = StructType(
-      Seq(
-        StructField("name", StringType, nullable = false),
-        StructField("format", StringType, nullable = false),
-        StructField("regular_indexes", StringType, nullable = false),
-        StructField("bloom_indexes", StringType, nullable = false),
-        StructField("computed_indexes", StringType, nullable = false),
-        StructField("temporal_indexes", StringType, nullable = false),
-        StructField("range_indexes", StringType, nullable = false),
-        StructField("exploded_field_indexes", StringType, nullable = false),
-        StructField("file_count", LongType, nullable = false),
-        StructField("total_indexed_file_size", LongType, nullable = false)
-      )
-    )
+    val schema =
+      StructType(
+        Seq(
+          StructField("name", StringType, nullable = false),
+          StructField("format", StringType, nullable = false),
+          StructField("regular_indexes", StringType, nullable = false),
+          StructField("bloom_indexes", StringType, nullable = false),
+          StructField("computed_indexes", StringType, nullable = false),
+          StructField("temporal_indexes", StringType, nullable = false),
+          StructField("range_indexes", StringType, nullable = false),
+          StructField("exploded_field_indexes", StringType, nullable = false),
+          StructField("file_count", LongType, nullable = false),
+          StructField("total_indexed_file_size", LongType, nullable = false)))
 
     if (summaries.isEmpty) {
-      spark.createDataFrame(
-        spark.sparkContext.emptyRDD[Row],
-        schema
-      )
+      spark.createDataFrame(spark.sparkContext.emptyRDD[Row], schema)
     } else {
 
-      val rows = summaries.map { s =>
-        Row(
-          s.name,
-          s.format,
-          s.regularIndexes.toSeq.sorted.mkString(", "),
-          s.bloomIndexes.toSeq.sorted.mkString(", "),
-          s.computedIndexes.toSeq.sorted.mkString(", "),
-          s.temporalIndexes.toSeq.sorted.mkString(", "),
-          s.rangeIndexes.toSeq.sorted.mkString(", "),
-          s.explodedFieldIndexes.toSeq.sorted.mkString(", "),
-          s.fileCount,
-          s.totalIndexedFileSize
-        )
-      }
-      spark.createDataFrame(
-        spark.sparkContext.parallelize(rows),
-        schema
-      )
+      val rows =
+        summaries.map { s =>
+          Row(
+            s.name,
+            s.format,
+            s.regularIndexes.toSeq.sorted.mkString(", "),
+            s.bloomIndexes.toSeq.sorted.mkString(", "),
+            s.computedIndexes.toSeq.sorted.mkString(", "),
+            s.temporalIndexes.toSeq.sorted.mkString(", "),
+            s.rangeIndexes.toSeq.sorted.mkString(", "),
+            s.explodedFieldIndexes.toSeq.sorted.mkString(", "),
+            s.fileCount,
+            s.totalIndexedFileSize)
+        }
+      spark.createDataFrame(spark.sparkContext.parallelize(rows), schema)
     }
   }
 
-  /** Removes an index by name.
-    *
-    * Deletes the index storage directory (containing metadata, index tables,
-    * staging, and large indexes) and the associated file list Delta table. If
-    * the file list has already been removed by another process, it is treated
-    * as a successful no-op for that resource.
-    *
-    * @example
-    *   {{{
-    * IndexCatalog.remove("oldIndex")
-    *   }}}
-    *
-    * @param name
-    *   the index name
-    * @param spark
-    *   implicit SparkSession
-    * @return
-    *   true if any resources were removed
-    * @throws IndexNotFoundException
-    *   if the index does not exist
-    * @throws IllegalArgumentException
-    *   if name is null or blank
-    */
+  /**
+   * Removes an index by name.
+   *
+   * Deletes the index storage directory (containing metadata, index tables, staging, and large indexes) and the
+   * associated file list Delta table. If the file list has already been removed by another process, it is treated as a
+   * successful no-op for that resource.
+   *
+   * @example
+   *   {{{
+   * IndexCatalog.remove("oldIndex")
+   *   }}}
+   *
+   * @param name
+   *   the index name
+   * @param spark
+   *   implicit SparkSession
+   * @return
+   *   true if any resources were removed
+   * @throws IndexNotFoundException
+   *   if the index does not exist
+   * @throws IllegalArgumentException
+   *   if name is null or blank
+   */
   def remove(name: String)(implicit spark: SparkSession): Boolean = {
-    require(
-      name != null && name.trim.nonEmpty,
-      "name must not be null or blank"
-    )
+    require(name != null && name.trim.nonEmpty, "name must not be null or blank")
     if (!exists(name)) {
       throw new IndexNotFoundException(name)
     }
     val sparkSession = spark
-    val contextUser = new AriadneContextUser {
-      implicit def spark: SparkSession = sparkSession
-    }
+    val contextUser =
+      new AriadneContextUser {
+        implicit def spark: SparkSession = sparkSession
+      }
 
     val startTime = System.currentTimeMillis()
     logger.warn(s"IndexCatalog: removing index '$name'")
     val indexDir = new Path(IndexPathUtils.storagePath, name)
-    val indexDeleted = if (contextUser.fs.exists(indexDir)) {
-      contextUser.delete(indexDir)
-    } else false
+    val indexDeleted =
+      if (contextUser.fs.exists(indexDir)) {
+        contextUser.delete(indexDir)
+      } else false
 
     val fileListName = IndexPathUtils.fileListName(name)
     val fileListDeleted =
@@ -433,27 +407,23 @@ object IndexCatalog {
       } catch {
         case e: FileListNotFoundException =>
           logger.debug(
-            s"FileList not found during removal of index '$name' — may have been already removed: ${e.getMessage}"
-          )
+            s"FileList not found during removal of index '$name' — may have been already removed: ${e.getMessage}")
           false
       }
 
     val elapsed = System.currentTimeMillis() - startTime
     logger.warn(
       s"IndexCatalog: successfully removed index '$name' in ${elapsed}ms " +
-        s"(indexDir=$indexDeleted, fileList=$fileListDeleted)"
-    )
+        s"(indexDir=$indexDeleted, fileList=$fileListDeleted)")
     indexDeleted || fileListDeleted
   }
 
   // ---- internal helpers ----
 
-  /** Builds an [[IndexSummary]] by reading metadata and file list for the given
-    * index name.
-    */
-  private def buildSummary(
-      name: String
-  )(implicit spark: SparkSession): IndexSummary = {
+  /**
+   * Builds an [[IndexSummary]] by reading metadata and file list for the given index name.
+   */
+  private def buildSummary(name: String)(implicit spark: SparkSession): IndexSummary = {
     val index = Index(name)
     val md = index.metadata
 
@@ -465,19 +435,22 @@ object IndexCatalog {
     val explodedFieldIndexes =
       md.exploded_field_indexes.asScala.map(_.as_column).toSet
 
-    val allColumns = regularIndexes ++ bloomIndexes ++ computedIndexes ++
-      temporalIndexes ++ rangeIndexes ++ explodedFieldIndexes
+    val allColumns =
+      regularIndexes ++ bloomIndexes ++ computedIndexes ++
+        temporalIndexes ++ rangeIndexes ++ explodedFieldIndexes
 
     val fileListName = IndexPathUtils.fileListName(name)
-    val fileCount = if (FileList.exists(fileListName)) {
-      FileList(fileListName).files.count()
-    } else {
-      0L
-    }
+    val fileCount =
+      if (FileList.exists(fileListName)) {
+        FileList(fileListName).files.count()
+      } else {
+        0L
+      }
 
-    val totalSize = Option(md.total_indexed_file_size)
-      .map(_.toLong)
-      .getOrElse(-1L)
+    val totalSize =
+      Option(md.total_indexed_file_size)
+        .map(_.toLong)
+        .getOrElse(-1L)
 
     IndexSummary(
       name = name,
@@ -490,7 +463,6 @@ object IndexCatalog {
       rangeIndexes = rangeIndexes,
       explodedFieldIndexes = explodedFieldIndexes,
       fileCount = fileCount,
-      totalIndexedFileSize = totalSize
-    )
+      totalIndexedFileSize = totalSize)
   }
 }

--- a/src/main/scala/dev/cjfravel/ariadne/IndexFileOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexFileOperations.scala
@@ -1,101 +1,93 @@
 package dev.cjfravel.ariadne
 
-import dev.cjfravel.ariadne.exceptions.SchemaParseException
-import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.apache.spark.sql.types.{DataType, StructType}
-import org.apache.spark.sql.functions._
 import scala.collection.JavaConverters._
 
-/** Trait providing file I/O operations for [[Index]] instances.
-  *
-  * Handles reading data files in supported formats (CSV, Parquet, JSON),
-  * applying computed indexes and exploded field transformations, and managing
-  * column selection for optimized reads.
-  *
-  * '''Read pipeline:''' [[readFiles]] orchestrates the full read path:
-  *   1. [[createBaseDataFrame]] — loads files using the stored schema, format,
-  *      and read options 2. [[applyComputedIndexes]] — adds derived columns via
-  *      Spark SQL expressions 3. [[applyExplodedFields]] — explodes nested
-  *      array fields into top-level columns 4. [[applyColumnSelection]] —
-  *      prunes to user-selected columns if specified
-  *
-  * '''Format support:''' CSV, Parquet, and JSON. The format is stored in
-  * [[IndexMetadata]] and determines which Spark reader method is used. Read
-  * options (e.g., `header`, `delimiter`) are applied from metadata.
-  *
-  * '''Filename tracking:''' [[addFilenameColumn]] uses `input_file_name()` to
-  * attach the source file path to each row. For single-file reads, a fallback
-  * literal is used because Spark may report an empty filename.
-  *
-  * @see
-  *   [[IndexMetadataOperations]] for metadata access
-  * @see
-  *   [[IndexBuildOperations]] for the build pipeline that calls these
-  *   operations
-  */
+import dev.cjfravel.ariadne.exceptions.SchemaParseException
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{DataType, StructType}
+
+/**
+ * Trait providing file I/O operations for [[Index]] instances.
+ *
+ * Handles reading data files in supported formats (CSV, Parquet, JSON), applying computed indexes and exploded field
+ * transformations, and managing column selection for optimized reads.
+ *
+ * '''Read pipeline:''' [[readFiles]] orchestrates the full read path:
+ *   1. [[createBaseDataFrame]] — loads files using the stored schema, format, and read options 2.
+ *      [[applyComputedIndexes]] — adds derived columns via Spark SQL expressions 3. [[applyExplodedFields]] — explodes
+ *      nested array fields into top-level columns 4. [[applyColumnSelection]] — prunes to user-selected columns if
+ *      specified
+ *
+ * '''Format support:''' CSV, Parquet, and JSON. The format is stored in [[IndexMetadata]] and determines which Spark
+ * reader method is used. Read options (e.g., `header`, `delimiter`) are applied from metadata.
+ *
+ * '''Filename tracking:''' [[addFilenameColumn]] uses `input_file_name()` to attach the source file path to each row.
+ * For single-file reads, a fallback literal is used because Spark may report an empty filename.
+ *
+ * @see
+ *   [[IndexMetadataOperations]] for metadata access
+ * @see
+ *   [[IndexBuildOperations]] for the build pipeline that calls these operations
+ */
 trait IndexFileOperations extends IndexMetadataOperations {
   self: Index =>
 
-  /** Returns the stored schema of the index.
-    *
-    * Parses the JSON schema string from metadata into a Spark StructType.
-    *
-    * @return
-    *   The StructType schema parsed from metadata
-    * @throws dev.cjfravel.ariadne.exceptions.MissingSchemaException
-    *   if the schema is null in metadata
-    * @throws SchemaParseException
-    *   if the schema string cannot be parsed as a StructType
-    *
-    * @example
-    *   {{{
-    * val schema = index.storedSchema
-    * schema.printTreeString()
-    *   }}}
-    */
+  /**
+   * Returns the stored schema of the index.
+   *
+   * Parses the JSON schema string from metadata into a Spark StructType.
+   *
+   * @return
+   *   The StructType schema parsed from metadata
+   * @throws dev.cjfravel.ariadne.exceptions.MissingSchemaException
+   *   if the schema is null in metadata
+   * @throws SchemaParseException
+   *   if the schema string cannot be parsed as a StructType
+   *
+   * @example
+   *   {{{
+   * val schema = index.storedSchema
+   * schema.printTreeString()
+   *   }}}
+   */
   def storedSchema: StructType = {
     if (metadata.schema == null) {
       throw new dev.cjfravel.ariadne.exceptions.MissingSchemaException()
     }
     DataType.fromJson(metadata.schema) match {
       case st: StructType => st
-      case _              => throw new SchemaParseException()
+      case _ => throw new SchemaParseException()
     }
   }
 
-  /** Reads a set of files into a DataFrame based on the specified format.
-    *
-    * Orchestrates the full read pipeline:
-    *   1. [[createBaseDataFrame]] — loads files using stored schema, format,
-    *      and read options 2. [[applyComputedIndexes]] — adds derived columns
-    *      via Spark SQL expressions 3. [[applyExplodedFields]] — explodes
-    *      nested array fields into top-level columns 4.
-    *      [[applyColumnSelection]] — prunes to user-selected columns if
-    *      specified
-    *
-    * @param files
-    *   A set of file paths to read
-    * @return
-    *   A DataFrame containing the contents of the specified files, with
-    *   computed indexes, exploded fields, and column selection applied
-    * @throws IllegalArgumentException
-    *   if the stored format is not csv, parquet, or json (propagated from
-    *   [[createBaseDataFrame]])
-    */
+  /**
+   * Reads a set of files into a DataFrame based on the specified format.
+   *
+   * Orchestrates the full read pipeline:
+   *   1. [[createBaseDataFrame]] — loads files using stored schema, format, and read options 2.
+   *      [[applyComputedIndexes]] — adds derived columns via Spark SQL expressions 3. [[applyExplodedFields]] —
+   *      explodes nested array fields into top-level columns 4. [[applyColumnSelection]] — prunes to user-selected
+   *      columns if specified
+   *
+   * @param files
+   *   A set of file paths to read
+   * @return
+   *   A DataFrame containing the contents of the specified files, with computed indexes, exploded fields, and column
+   *   selection applied
+   * @throws IllegalArgumentException
+   *   if the stored format is not csv, parquet, or json (propagated from [[createBaseDataFrame]])
+   */
   private[ariadne] def readFiles(files: Set[String]): DataFrame = {
     require(files != null, "files must not be null")
     logger.warn(s"Reading ${files.size} files in format '${metadata.format}'")
     if (debugEnabled) {
-      logger.warn(
-        s"[debug] readFiles: reading ${files.size} files, format: $format"
-      )
+      logger.warn(s"[debug] readFiles: reading ${files.size} files, format: $format")
     }
     val readStart = System.currentTimeMillis()
     val baseDf = createBaseDataFrame(files)
     if (debugEnabled) {
-      logger.warn(
-        s"[debug] readFiles: createBaseDataFrame setup in ${System.currentTimeMillis() - readStart}ms"
-      )
+      logger.warn(s"[debug] readFiles: createBaseDataFrame setup in ${System.currentTimeMillis() - readStart}ms")
     }
     val withComputedIndexes = applyComputedIndexes(baseDf)
     val withExplodedFields = applyExplodedFields(withComputedIndexes)
@@ -103,26 +95,22 @@ trait IndexFileOperations extends IndexMetadataOperations {
     // Apply column selection if specified
     val result = applyColumnSelection(withExplodedFields)
     if (debugEnabled) {
-      logger.warn(
-        s"[debug] readFiles: complete setup in ${System
-            .currentTimeMillis() - readStart}ms, columns: ${result.schema.fieldNames.length}"
-      )
+      logger.warn(s"[debug] readFiles: complete setup in ${System
+          .currentTimeMillis() - readStart}ms, columns: ${result.schema.fieldNames.length}")
     }
-    logger.warn(
-      s"readFiles complete for ${files.size} file(s) in ${System.currentTimeMillis() - readStart}ms"
-    )
+    logger.warn(s"readFiles complete for ${files.size} file(s) in ${System.currentTimeMillis() - readStart}ms")
     result
   }
 
-  /** Applies column selection if columns have been specified via select(). Only
-    * reads the explicitly selected columns.
-    *
-    * @param df
-    *   The DataFrame to apply column selection to
-    * @return
-    *   DataFrame with selected columns or original DataFrame if no selection
-    */
-  protected def applyColumnSelection(df: DataFrame): DataFrame = {
+  /**
+   * Applies column selection if columns have been specified via select(). Only reads the explicitly selected columns.
+   *
+   * @param df
+   *   The DataFrame to apply column selection to
+   * @return
+   *   DataFrame with selected columns or original DataFrame if no selection
+   */
+  protected def applyColumnSelection(df: DataFrame): DataFrame =
     getSelectedColumns match {
       case Some(selectedCols) =>
         logger.debug(s"Selecting columns: ${selectedCols.mkString(", ")}")
@@ -130,137 +118,109 @@ trait IndexFileOperations extends IndexMetadataOperations {
       case None =>
         df // No column selection specified, return full DataFrame
     }
-  }
 
-  /** Creates a base DataFrame from the provided files using the stored format
-    * and schema. Applies any read options configured in the index metadata.
-    *
-    * Returns an empty DataFrame (with the stored schema) if all file paths are
-    * blank after normalization.
-    *
-    * @param files
-    *   Set of file paths to read
-    * @return
-    *   DataFrame with data from the specified files
-    * @throws IllegalArgumentException
-    *   if the stored format is not csv, parquet, or json
-    */
+  /**
+   * Creates a base DataFrame from the provided files using the stored format and schema. Applies any read options
+   * configured in the index metadata.
+   *
+   * Returns an empty DataFrame (with the stored schema) if all file paths are blank after normalization.
+   *
+   * @param files
+   *   Set of file paths to read
+   * @return
+   *   DataFrame with data from the specified files
+   * @throws IllegalArgumentException
+   *   if the stored format is not csv, parquet, or json
+   */
   protected def createBaseDataFrame(files: Set[String]): DataFrame = {
     val normalizedFiles = files.map(_.trim).filter(_.nonEmpty)
     if (normalizedFiles.isEmpty) {
-      spark.createDataFrame(
-        spark.sparkContext.emptyRDD[org.apache.spark.sql.Row],
-        storedSchema
-      )
+      spark.createDataFrame(spark.sparkContext.emptyRDD[org.apache.spark.sql.Row], storedSchema)
     } else {
       // Apply read options
       val configuredReader =
-        metadata.read_options.asScala.foldLeft(
-          spark.read.schema(storedSchema)
-        ) { case (r, (key, value)) =>
+        metadata.read_options.asScala.foldLeft(spark.read.schema(storedSchema)) { case (r, (key, value)) =>
           r.option(key, value)
         }
 
       // Load data based on format
       format match {
-        case "csv"     => configuredReader.csv(normalizedFiles.toList: _*)
+        case "csv" => configuredReader.csv(normalizedFiles.toList: _*)
         case "parquet" => configuredReader.parquet(normalizedFiles.toList: _*)
-        case "json"    => configuredReader.json(normalizedFiles.toList: _*)
+        case "json" => configuredReader.json(normalizedFiles.toList: _*)
         case _ =>
-          logger.warn(
-            s"Unsupported format '${format}' for index — must be csv, parquet, or json"
-          )
+          logger.warn(s"Unsupported format '$format' for index — must be csv, parquet, or json")
           throw new IllegalArgumentException(s"Unsupported format: $format")
       }
     }
   }
 
-  /** Adds a stable filename column to the DataFrame.
-    *
-    * Uses `input_file_name()` to capture the source file path. For single-file
-    * reads where Spark may report an empty filename, falls back to the known
-    * file path.
-    *
-    * @param df
-    *   The DataFrame to add the filename column to
-    * @param files
-    *   The set of file paths being read
-    * @return
-    *   DataFrame with a `filename` column added
-    */
-  protected def addFilenameColumn(
-      df: DataFrame,
-      files: Set[String]
-  ): DataFrame = {
+  /**
+   * Adds a stable filename column to the DataFrame.
+   *
+   * Uses `input_file_name()` to capture the source file path. For single-file reads where Spark may report an empty
+   * filename, falls back to the known file path.
+   *
+   * @param df
+   *   The DataFrame to add the filename column to
+   * @param files
+   *   The set of file paths being read
+   * @return
+   *   DataFrame with a `filename` column added
+   */
+  protected def addFilenameColumn(df: DataFrame, files: Set[String]): DataFrame =
     if (files.size == 1) {
       val fallbackFile = files.head
       val inputFile = input_file_name()
       df.withColumn(
         "filename",
-        when(
-          inputFile.isNull || length(trim(inputFile)) === 0,
-          lit(fallbackFile)
-        )
-          .otherwise(inputFile)
-      )
+        when(inputFile.isNull || length(trim(inputFile)) === 0, lit(fallbackFile))
+          .otherwise(inputFile))
     } else {
       df.withColumn("filename", input_file_name())
     }
-  }
 
-  /** Applies computed indexes to a DataFrame by adding computed columns.
-    *
-    * Each computed index is a Spark SQL expression stored in metadata. The
-    * expression is evaluated via `expr()` and added as a new column. If no
-    * computed indexes are configured, the DataFrame is returned unchanged.
-    *
-    * @param df
-    *   The base DataFrame
-    * @return
-    *   DataFrame with computed index columns added
-    * @throws org.apache.spark.sql.AnalysisException
-    *   if a computed index expression is invalid or references non-existent
-    *   columns
-    */
+  /**
+   * Applies computed indexes to a DataFrame by adding computed columns.
+   *
+   * Each computed index is a Spark SQL expression stored in metadata. The expression is evaluated via `expr()` and
+   * added as a new column. If no computed indexes are configured, the DataFrame is returned unchanged.
+   *
+   * @param df
+   *   The base DataFrame
+   * @return
+   *   DataFrame with computed index columns added
+   * @throws org.apache.spark.sql.AnalysisException
+   *   if a computed index expression is invalid or references non-existent columns
+   */
   protected def applyComputedIndexes(df: DataFrame): DataFrame = {
-    logger.debug(
-      s"Applying ${metadata.computed_indexes.size()} computed index(es)"
-    )
-    metadata.computed_indexes.asScala.foldLeft(df) {
-      case (tempDf, (colName, exprStr)) =>
-        tempDf.withColumn(colName, expr(exprStr))
+    logger.debug(s"Applying ${metadata.computed_indexes.size()} computed index(es)")
+    metadata.computed_indexes.asScala.foldLeft(df) { case (tempDf, (colName, exprStr)) =>
+      tempDf.withColumn(colName, expr(exprStr))
     }
   }
 
-  /** Applies exploded field transformations to a DataFrame.
-    *
-    * For each configured exploded field, extracts the nested field path from
-    * the array column and explodes it into a top-level column. This is used on
-    * the read/join path to prepare data for joining on exploded field values.
-    *
-    * Note that `explode()` (not `explode_outer()`) is used intentionally — rows
-    * with null or empty arrays are dropped because they contain no matchable
-    * values for the join. This is consistent with the index build path which
-    * also excludes null/empty arrays.
-    *
-    * @param df
-    *   The DataFrame to transform
-    * @return
-    *   DataFrame with exploded field columns added; rows with null/empty arrays
-    *   are excluded
-    */
+  /**
+   * Applies exploded field transformations to a DataFrame.
+   *
+   * For each configured exploded field, extracts the nested field path from the array column and explodes it into a
+   * top-level column. This is used on the read/join path to prepare data for joining on exploded field values.
+   *
+   * Note that `explode()` (not `explode_outer()`) is used intentionally — rows with null or empty arrays are dropped
+   * because they contain no matchable values for the join. This is consistent with the index build path which also
+   * excludes null/empty arrays.
+   *
+   * @param df
+   *   The DataFrame to transform
+   * @return
+   *   DataFrame with exploded field columns added; rows with null/empty arrays are excluded
+   */
   protected def applyExplodedFields(df: DataFrame): DataFrame = {
-    logger.debug(
-      s"Applying ${metadata.exploded_field_indexes.size()} exploded field transform(s)"
-    )
-    metadata.exploded_field_indexes.asScala.foldLeft(df) {
-      case (tempDf, explodedField) =>
-        tempDf.withColumn(
-          explodedField.as_column,
-          explode(
-            col(s"${explodedField.array_column}.${explodedField.field_path}")
-          )
-        )
+    logger.debug(s"Applying ${metadata.exploded_field_indexes.size()} exploded field transform(s)")
+    metadata.exploded_field_indexes.asScala.foldLeft(df) { case (tempDf, explodedField) =>
+      tempDf.withColumn(
+        explodedField.as_column,
+        explode(col(s"${explodedField.array_column}.${explodedField.field_path}")))
     }
   }
 }

--- a/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
@@ -1,43 +1,40 @@
 package dev.cjfravel.ariadne
 
-import dev.cjfravel.ariadne.exceptions.ColumnNotFoundException
-import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.functions._
-import org.apache.spark.sql.expressions.Window
 import scala.collection.JavaConverters._
 
-/** Trait providing join operations between DataFrames and indexed data.
-  *
-  * Orchestrates the join workflow:
-  *   1. Maps join columns to their storage column names (regular, bloom, range,
-  *      exploded) 2. Locates relevant files using the index (via
-  *      [[IndexQueryOperations.locateFilesFromDataFrame]]) 3. Reads only the
-  *      located data files (file-level pruning) 4. Applies temporal
-  *      deduplication if applicable (keeps latest version per value) 5.
-  *      Performs the final Spark DataFrame join
-  *
-  * Supports inner, left, right, left_semi, left_anti, and other standard Spark
-  * join types.
-  *
-  * Mixed into [[Index]] via `self: Index =>`.
-  */
+import dev.cjfravel.ariadne.exceptions.ColumnNotFoundException
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.expressions.Window
+import org.apache.spark.sql.functions._
+
+/**
+ * Trait providing join operations between DataFrames and indexed data.
+ *
+ * Orchestrates the join workflow:
+ *   1. Maps join columns to their storage column names (regular, bloom, range, exploded) 2. Locates relevant files
+ *      using the index (via [[IndexQueryOperations.locateFilesFromDataFrame]]) 3. Reads only the located data files
+ *      (file-level pruning) 4. Applies temporal deduplication if applicable (keeps latest version per value) 5.
+ *      Performs the final Spark DataFrame join
+ *
+ * Supports inner, left, right, left_semi, left_anti, and other standard Spark join types.
+ *
+ * Mixed into [[Index]] via `self: Index =>`.
+ */
 trait IndexJoinOperations extends IndexBuildOperations {
   self: Index =>
 
-  /** Maps join column names to their corresponding storage column names.
-    *
-    * Bloom filter columns are prefixed with the bloom prefix, range columns are
-    * prefixed with "range_", exploded field columns are mapped to their backing
-    * array column, and all other columns map to themselves.
-    *
-    * @param joinColumns
-    *   The column names used in joins
-    * @return
-    *   Map from each join column name to its storage column name in the index
-    */
-  protected def mapJoinColumnsToStorage(
-      joinColumns: Seq[String]
-  ): Map[String, String] = {
+  /**
+   * Maps join column names to their corresponding storage column names.
+   *
+   * Bloom filter columns are prefixed with the bloom prefix, range columns are prefixed with "range_", exploded field
+   * columns are mapped to their backing array column, and all other columns map to themselves.
+   *
+   * @param joinColumns
+   *   The column names used in joins
+   * @return
+   *   Map from each join column name to its storage column name in the index
+   */
+  protected def mapJoinColumnsToStorage(joinColumns: Seq[String]): Map[String, String] = {
     val bloomColumnSet = bloomColumns
     val rangeColumnSet = metadata.range_indexes.asScala.map(_.column).toSet
 
@@ -45,64 +42,54 @@ trait IndexJoinOperations extends IndexBuildOperations {
       if (bloomColumnSet.contains(joinCol)) {
         joinCol -> (bloomColumnPrefix + joinCol)
       } else if (rangeColumnSet.contains(joinCol)) {
-        joinCol -> (s"range_${joinCol}")
+        joinCol -> s"range_$joinCol"
       } else {
         // Check if this is an exploded field column
         val explodedMapping =
           metadata.exploded_field_indexes.asScala.find(_.as_column == joinCol)
         explodedMapping match {
           case Some(mapping) => joinCol -> mapping.as_column
-          case None          => joinCol -> joinCol
+          case None => joinCol -> joinCol
         }
       }
     }.toMap
   }
 
-  /** Locates and reads indexed data files relevant to the given DataFrame.
-    *
-    * Uses the index to identify which files contain matching values, then reads
-    * those files into a lazy DataFrame. If no matching files are found, returns
-    * an empty DataFrame with the stored schema. The actual row-level filtering
-    * happens in the subsequent join in [[join]].
-    *
-    * Logs data pruning metrics (file count, data size saved) when available,
-    * and includes detailed file-level debug information when debug mode is
-    * enabled.
-    *
-    * @param df
-    *   The DataFrame to match against the index.
-    * @param usingColumns
-    *   The columns used for the join.
-    * @return
-    *   A lazy DataFrame containing data from indexed files, or an empty
-    *   DataFrame if no files match.
-    * @throws dev.cjfravel.ariadne.exceptions.ColumnNotFoundException
-    *   if join columns are not in the selected columns, schema, or indexes
-    * @throws IllegalArgumentException
-    *   if none of the join columns have indexes, or if df/usingColumns are
-    *   null/empty
-    */
+  /**
+   * Locates and reads indexed data files relevant to the given DataFrame.
+   *
+   * Uses the index to identify which files contain matching values, then reads those files into a lazy DataFrame. If no
+   * matching files are found, returns an empty DataFrame with the stored schema. The actual row-level filtering happens
+   * in the subsequent join in [[join]].
+   *
+   * Logs data pruning metrics (file count, data size saved) when available, and includes detailed file-level debug
+   * information when debug mode is enabled.
+   *
+   * @param df
+   *   The DataFrame to match against the index.
+   * @param usingColumns
+   *   The columns used for the join.
+   * @return
+   *   A lazy DataFrame containing data from indexed files, or an empty DataFrame if no files match.
+   * @throws dev.cjfravel.ariadne.exceptions.ColumnNotFoundException
+   *   if join columns are not in the selected columns, schema, or indexes
+   * @throws IllegalArgumentException
+   *   if none of the join columns have indexes, or if df/usingColumns are null/empty
+   */
   protected def joinDf(df: DataFrame, usingColumns: Seq[String]): DataFrame = {
     require(df != null, "DataFrame must not be null")
-    require(
-      usingColumns != null && usingColumns.nonEmpty,
-      "usingColumns must not be null or empty"
-    )
+    require(usingColumns != null && usingColumns.nonEmpty, "usingColumns must not be null or empty")
     val joinStart = System.currentTimeMillis()
     def elapsed(): String = {
       val ms = System.currentTimeMillis() - joinStart
-      if (ms > 60000) f"${ms / 60000}m ${(ms % 60000) / 1000}s"
+      if (ms > 60000) f"${ms / 60000}m ${ms % 60000 / 1000}s"
       else if (ms > 1000) f"${ms / 1000.0}%.1fs"
       else s"${ms}ms"
     }
 
     if (debugEnabled) {
-      logger.warn(
-        s"[debug] joinDf started: index=${name}, usingColumns=${usingColumns.mkString(",")}"
-      )
-      logger.warn(
-        s"[debug] input df schema: ${df.schema.fieldNames.mkString(",")}"
-      )
+      logger.warn(s"[debug] joinDf started: index=$name, usingColumns=${usingColumns.mkString(",")}")
+      logger.warn(s"[debug] input df schema: ${df.schema.fieldNames.mkString(",")}")
     }
 
     // Validate that join columns are included in selected columns (if selection is active)
@@ -112,19 +99,18 @@ trait IndexJoinOperations extends IndexBuildOperations {
         val missingJoinCols = usingColumns.filterNot(selectedCols.contains)
         if (missingJoinCols.nonEmpty) {
           throw new ColumnNotFoundException(
-            s"Join columns must be included in selected columns. Missing: ${missingJoinCols.mkString(", ")}"
-          )
+            s"Join columns must be included in selected columns. Missing: ${missingJoinCols.mkString(", ")}")
         }
       case None =>
         // No selection active, but still validate columns exist in schema or are available indexes
-        val invalidJoinCols = usingColumns.filterNot { colName =>
-          SchemaHelper.fieldExists(storedSchema, colName) || this.indexes
-            .contains(colName)
-        }
+        val invalidJoinCols =
+          usingColumns.filterNot { colName =>
+            SchemaHelper.fieldExists(storedSchema, colName) || this.indexes
+              .contains(colName)
+          }
         if (invalidJoinCols.nonEmpty) {
           throw new ColumnNotFoundException(
-            s"Join columns not found in schema or indexes: ${invalidJoinCols.mkString(", ")}"
-          )
+            s"Join columns not found in schema or indexes: ${invalidJoinCols.mkString(", ")}")
         }
     }
 
@@ -139,38 +125,26 @@ trait IndexJoinOperations extends IndexBuildOperations {
     logger.warn(s"Found indexes for ${storageColumnsToUse.mkString(",")}")
 
     // Get values from the user DataFrame using join column names
-    val joinColumnsToUse = usingColumns.filter(col =>
-      columnMappings.contains(col) && storageColumnsToUse.contains(
-        columnMappings(col)
-      )
-    )
+    val joinColumnsToUse =
+      usingColumns.filter(col => columnMappings.contains(col) && storageColumnsToUse.contains(columnMappings(col)))
 
     if (joinColumnsToUse.isEmpty) {
-      val unindexed = usingColumns.filterNot(c =>
-        storageColumnsToUse.contains(columnMappings.getOrElse(c, c))
-      )
+      val unindexed = usingColumns.filterNot(c => storageColumnsToUse.contains(columnMappings.getOrElse(c, c)))
       throw new IllegalArgumentException(
         s"None of the join columns [${usingColumns.mkString(", ")}] have indexes. " +
           s"Unindexed columns: [${unindexed.mkString(", ")}]. " +
-          "Add indexes on these columns before joining."
-      )
+          "Add indexes on these columns before joining.")
     }
 
     // Get values from the user DataFrame using join column names
     val filteredValuesDf = df.select(joinColumnsToUse.map(col): _*)
 
     // Use the new DataFrame-based method to locate files
-    val files = locateFilesFromDataFrame(
-      filteredValuesDf,
-      columnMappings,
-      joinColumnsToUse
-    )
+    val files = locateFilesFromDataFrame(filteredValuesDf, columnMappings, joinColumnsToUse)
     logger.warn(s"Found ${files.size} files in index")
 
     if (files.isEmpty) {
-      logger.warn(
-        s"No matching files found in index '$name', returning empty DataFrame"
-      )
+      logger.warn(s"No matching files found in index '$name', returning empty DataFrame")
       import org.apache.spark.sql.Row
       spark.createDataFrame(spark.sparkContext.emptyRDD[Row], storedSchema)
     } else {
@@ -185,10 +159,11 @@ trait IndexJoinOperations extends IndexBuildOperations {
               val totalFiles = indexDf.count()
               import spark.implicits._
               val filesDf = files.toSeq.toDF("filename")
-              val matchedSizeRows = indexDf
-                .join(filesDf, Seq("filename"), "inner")
-                .agg(sum("file_size"))
-                .take(1)
+              val matchedSizeRows =
+                indexDf
+                  .join(filesDf, Seq("filename"), "inner")
+                  .agg(sum("file_size"))
+                  .take(1)
               if (matchedSizeRows.nonEmpty) {
                 val matchedSizeResult = matchedSizeRows(0)
                 val matchedSize =
@@ -196,12 +171,13 @@ trait IndexJoinOperations extends IndexBuildOperations {
                   else matchedSizeResult.getLong(0)
                 val totalGB = totalIndexedSize / (1024.0 * 1024.0 * 1024.0)
                 val matchedGB = matchedSize / (1024.0 * 1024.0 * 1024.0)
-                val savedPercent = if (totalIndexedSize > 0)
-                  ((totalIndexedSize - matchedSize) * 100.0 / totalIndexedSize).toInt
-                else 0
+                val savedPercent =
+                  if (totalIndexedSize > 0)
+                    ((totalIndexedSize - matchedSize) * 100.0 / totalIndexedSize).toInt
+                  else 0
                 logger.warn(
-                  f"Index pruning: loaded ${files.size}%d of $totalFiles%d files ($matchedGB%.2f GB of $totalGB%.2f GB) — $savedPercent%%  data pruned"
-                )
+                  f"Index pruning: loaded ${files.size}%d of $totalFiles%d files " +
+                    f"($matchedGB%.2f GB of $totalGB%.2f GB) — $savedPercent%%  data pruned")
               }
             }
           }
@@ -209,46 +185,36 @@ trait IndexJoinOperations extends IndexBuildOperations {
       } catch {
         case e: Exception =>
           logger.warn(
-            s"Failed to compute pruning metrics for index '$name': ${e.getClass.getSimpleName}: ${e.getMessage}"
-          )
+            s"Failed to compute pruning metrics for index '$name': ${e.getClass.getSimpleName}: ${e.getMessage}")
       }
 
       if (debugEnabled) {
-        logger.warn(
-          s"[debug] locateFiles completed in ${elapsed()}, files: ${files.size}"
-        )
+        logger.warn(s"[debug] locateFiles completed in ${elapsed()}, files: ${files.size}")
         if (files.nonEmpty) {
           try {
-            val fileSizes = files.toSeq
-              .map { f =>
-                val path = new org.apache.hadoop.fs.Path(f)
-                val fileFs =
-                  path.getFileSystem(spark.sparkContext.hadoopConfiguration)
-                val size = fileFs.getFileStatus(path).getLen
-                (f, size)
-              }
-              .sortBy(-_._2)
+            val fileSizes =
+              files.toSeq
+                .map { f =>
+                  val path = new org.apache.hadoop.fs.Path(f)
+                  val fileFs =
+                    path.getFileSystem(spark.sparkContext.hadoopConfiguration)
+                  val size = fileFs.getFileStatus(path).getLen
+                  (f, size)
+                }
+                .sortBy(-_._2)
             val totalBytes = fileSizes.map(_._2).sum
             val totalMB = totalBytes / (1024.0 * 1024.0)
             val totalGB = totalBytes / (1024.0 * 1024.0 * 1024.0)
-            logger.warn(
-              f"[debug] total file size: $totalMB%.1fMB ($totalGB%.2fGB) across ${files.size} files"
-            )
+            logger.warn(f"[debug] total file size: $totalMB%.1fMB ($totalGB%.2fGB) across ${files.size} files")
             val avgMB = totalMB / files.size
             if (fileSizes.nonEmpty) {
               val maxFile = fileSizes.head
               val minFile = fileSizes.last
               val maxMB = maxFile._2 / (1024.0 * 1024.0)
               val minMB = minFile._2 / (1024.0 * 1024.0)
-              logger.warn(
-                f"[debug] file sizes: avg=$avgMB%.1fMB, max=$maxMB%.1fMB, min=$minMB%.1fMB"
-              )
-              logger.warn(
-                f"[debug] largest file: $maxMB%.1fMB -> ${maxFile._1}"
-              )
-              logger.warn(
-                f"[debug] smallest file: $minMB%.1fMB -> ${minFile._1}"
-              )
+              logger.warn(f"[debug] file sizes: avg=$avgMB%.1fMB, max=$maxMB%.1fMB, min=$minMB%.1fMB")
+              logger.warn(f"[debug] largest file: $maxMB%.1fMB -> ${maxFile._1}")
+              logger.warn(f"[debug] smallest file: $minMB%.1fMB -> ${minFile._1}")
             }
             // Log top 5 largest files
             fileSizes.take(5).foreach { case (f, size) =>
@@ -268,17 +234,18 @@ trait IndexJoinOperations extends IndexBuildOperations {
       // Enable when reading all columns from very large indexes to reduce
       // per-executor memory pressure.
       logger.warn(s"Reading ${files.size} data files from index '$name'")
-      val rawReadIndex = if (repartitionDataFiles) {
-        maybeRepartition(readFiles(files))
-      } else {
-        readFiles(files)
-      }
+      val rawReadIndex =
+        if (repartitionDataFiles) {
+          maybeRepartition(readFiles(files))
+        } else {
+          readFiles(files)
+        }
       // Apply temporal deduplication if any temporal indexes are being used in this join
       val readIndex = applyTemporalDeduplication(rawReadIndex, usingColumns)
       if (debugEnabled) {
         logger.warn(
-          s"[debug] readFiles setup in ${elapsed()}, repartitionDataFiles=$repartitionDataFiles, schema columns: ${readIndex.schema.fieldNames.length}"
-        )
+          s"[debug] readFiles setup in ${elapsed()}, repartitionDataFiles=$repartitionDataFiles, " +
+            s"schema columns: ${readIndex.schema.fieldNames.length}")
         logger.warn(s"[debug] readFiles physical plan:")
         readIndex.queryExecution.executedPlan
           .toString()
@@ -291,24 +258,21 @@ trait IndexJoinOperations extends IndexBuildOperations {
     }
   }
 
-  /** Applies temporal deduplication to keep only the latest version of each
-    * value for temporal index columns being used in the current join.
-    *
-    * Uses row_number() window function partitioned by the value column and
-    * ordered by the timestamp column descending, keeping only rank 1.
-    *
-    * @param df
-    *   The DataFrame read from data files
-    * @param joinColumns
-    *   The columns being used for the join
-    * @return
-    *   DataFrame with stale duplicates removed, or original if no temporal
-    *   indexes apply
-    */
-  private[ariadne] def applyTemporalDeduplication(
-      df: DataFrame,
-      joinColumns: Seq[String]
-  ): DataFrame = {
+  /**
+   * Applies temporal deduplication to keep only the latest version of each value for temporal index columns being used
+   * in the current join.
+   *
+   * Uses row_number() window function partitioned by the value column and ordered by the timestamp column descending,
+   * keeping only rank 1.
+   *
+   * @param df
+   *   The DataFrame read from data files
+   * @param joinColumns
+   *   The columns being used for the join
+   * @return
+   *   DataFrame with stale duplicates removed, or original if no temporal indexes apply
+   */
+  private[ariadne] def applyTemporalDeduplication(df: DataFrame, joinColumns: Seq[String]): DataFrame = {
     val temporalConfigs = metadata.temporal_indexes.asScala.toSeq
     val applicableConfigs =
       temporalConfigs.filter(tc => joinColumns.contains(tc.column))
@@ -316,86 +280,71 @@ trait IndexJoinOperations extends IndexBuildOperations {
     if (applicableConfigs.isEmpty) {
       df
     } else {
-      logger.warn(
-        s"Applying temporal deduplication for columns: ${applicableConfigs.map(_.column).mkString(", ")}"
-      )
-      val result = applicableConfigs.foldLeft(df) { (accumDf, config) =>
-        val w = Window
-          .partitionBy(config.column)
-          .orderBy(col(config.timestamp_column).desc_nulls_last)
-        accumDf
-          .withColumn("_ariadne_temporal_rank", row_number().over(w))
-          .filter(col("_ariadne_temporal_rank") === 1)
-          .drop("_ariadne_temporal_rank")
-      }
-      logger.debug(
-        s"Temporal deduplication applied for ${applicableConfigs.size} column(s)"
-      )
+      logger.warn(s"Applying temporal deduplication for columns: ${applicableConfigs.map(_.column).mkString(", ")}")
+      val result =
+        applicableConfigs.foldLeft(df) { (accumDf, config) =>
+          val w =
+            Window
+              .partitionBy(config.column)
+              .orderBy(col(config.timestamp_column).desc_nulls_last)
+          accumDf
+            .withColumn("_ariadne_temporal_rank", row_number().over(w))
+            .filter(col("_ariadne_temporal_rank") === 1)
+            .drop("_ariadne_temporal_rank")
+        }
+      logger.debug(s"Temporal deduplication applied for ${applicableConfigs.size} column(s)")
       result
     }
   }
 
-  /** Joins a DataFrame with indexed data files.
-    *
-    * This is the primary public API for index-based joins. The index locates
-    * which files contain matching values, reads only those files, applies
-    * temporal deduplication if applicable, then performs the Spark DataFrame
-    * join.
-    *
-    * The join direction is `indexedData.join(df)` — the index-located data is
-    * on the left. For the reverse direction, use [[Index.DataFrameOps.join]].
-    *
-    * @example
-    *   {{{
-    * val index = Index("orders", ordersSchema)
-    * index.addIndex("customer_id")
-    * index.update
-    *
-    * val lookupDf = Seq("c1", "c2").toDF("customer_id")
-    * val result = index.join(lookupDf, Seq("customer_id"))
-    * // Left join variant:
-    * val leftResult = index.join(lookupDf, Seq("customer_id"), "left")
-    *   }}}
-    *
-    * @param df
-    *   The DataFrame to join against indexed data
-    * @param usingColumns
-    *   The column names to join on (must be indexed columns)
-    * @param joinType
-    *   The Spark join type: "inner", "left", "right", "left_semi", "left_anti",
-    *   etc. (default: "inner")
-    * @return
-    *   The joined DataFrame
-    * @throws dev.cjfravel.ariadne.exceptions.ColumnNotFoundException
-    *   if join columns are not in the schema or indexes
-    * @throws IllegalArgumentException
-    *   if none of the join columns have indexes
-    */
-  def join(
-      df: DataFrame,
-      usingColumns: Seq[String],
-      joinType: String = "inner"
-  ): DataFrame = {
-    logger.warn(
-      s"Index.join on index '$name': $joinType join on columns ${usingColumns.mkString(", ")}"
-    )
+  /**
+   * Joins a DataFrame with indexed data files.
+   *
+   * This is the primary public API for index-based joins. The index locates which files contain matching values, reads
+   * only those files, applies temporal deduplication if applicable, then performs the Spark DataFrame join.
+   *
+   * The join direction is `indexedData.join(df)` — the index-located data is on the left. For the reverse direction,
+   * use [[Index.DataFrameOps.join]].
+   *
+   * @example
+   *   {{{
+   * val index = Index("orders", ordersSchema)
+   * index.addIndex("customer_id")
+   * index.update
+   *
+   * val lookupDf = Seq("c1", "c2").toDF("customer_id")
+   * val result = index.join(lookupDf, Seq("customer_id"))
+   * // Left join variant:
+   * val leftResult = index.join(lookupDf, Seq("customer_id"), "left")
+   *   }}}
+   *
+   * @param df
+   *   The DataFrame to join against indexed data
+   * @param usingColumns
+   *   The column names to join on (must be indexed columns)
+   * @param joinType
+   *   The Spark join type: "inner", "left", "right", "left_semi", "left_anti", etc. (default: "inner")
+   * @return
+   *   The joined DataFrame
+   * @throws dev.cjfravel.ariadne.exceptions.ColumnNotFoundException
+   *   if join columns are not in the schema or indexes
+   * @throws IllegalArgumentException
+   *   if none of the join columns have indexes
+   */
+  def join(df: DataFrame, usingColumns: Seq[String], joinType: String = "inner"): DataFrame = {
+    logger.warn(s"Index.join on index '$name': $joinType join on columns ${usingColumns.mkString(", ")}")
     try {
       val outerJoinStart = System.currentTimeMillis()
       val indexDf = joinDf(df, usingColumns)
       if (debugEnabled) {
         logger.warn(
-          s"[debug] joinDf returned in ${System.currentTimeMillis() - outerJoinStart}ms, now performing $joinType join"
-        )
+          s"[debug] joinDf returned in ${System.currentTimeMillis() - outerJoinStart}ms, now performing $joinType join")
       }
       val result = indexDf.join(df, usingColumns, joinType)
-      logger.warn(
-        s"Index.join on index '$name': $joinType join setup completed in ${System
-            .currentTimeMillis() - outerJoinStart}ms"
-      )
+      logger.warn(s"Index.join on index '$name': $joinType join setup completed in ${System
+          .currentTimeMillis() - outerJoinStart}ms")
       if (debugEnabled) {
-        logger.warn(
-          s"[debug] Index.join complete in ${System.currentTimeMillis() - outerJoinStart}ms"
-        )
+        logger.warn(s"[debug] Index.join complete in ${System.currentTimeMillis() - outerJoinStart}ms")
         logger.warn(s"[debug] result physical plan:")
         result.queryExecution.executedPlan
           .toString()

--- a/src/main/scala/dev/cjfravel/ariadne/IndexLock.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexLock.scala
@@ -1,230 +1,192 @@
 package dev.cjfravel.ariadne
 
+import java.net.InetAddress
+import java.nio.charset.StandardCharsets
+import java.time.{Duration, Instant}
+
+import scala.io.Source
+
 import com.google.gson.Gson
 import dev.cjfravel.ariadne.exceptions.IndexLockException
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
 
-import java.net.InetAddress
-import java.nio.charset.StandardCharsets
-import java.time.{Duration, Instant}
-import scala.io.Source
+/**
+ * Metadata stored in lock files to track lock ownership and freshness.
+ *
+ * Each lock file is a JSON document containing these fields, serialized via Gson. The [[IndexLock]] reads and writes
+ * [[LockInfo]] instances to coordinate distributed access to an index.
+ *
+ * @param correlationId
+ *   Unique identifier for the lock holder's operation
+ * @param acquiredAt
+ *   ISO-8601 timestamp when the lock was first acquired
+ * @param lastRefreshedAt
+ *   ISO-8601 timestamp of the most recent lock refresh
+ * @param owner
+ *   Spark application ID, or the hostname if the application ID is unavailable
+ */
+case class LockInfo(correlationId: String, acquiredAt: String, lastRefreshedAt: String, owner: String)
 
-/** Metadata stored in lock files to track lock ownership and freshness.
-  *
-  * Each lock file is a JSON document containing these fields, serialized via
-  * Gson. The [[IndexLock]] reads and writes [[LockInfo]] instances to
-  * coordinate distributed access to an index.
-  *
-  * @param correlationId
-  *   Unique identifier for the lock holder's operation
-  * @param acquiredAt
-  *   ISO-8601 timestamp when the lock was first acquired
-  * @param lastRefreshedAt
-  *   ISO-8601 timestamp of the most recent lock refresh
-  * @param owner
-  *   Spark application ID, or the hostname if the application ID is unavailable
-  */
-case class LockInfo(
-    correlationId: String,
-    acquiredAt: String,
-    lastRefreshedAt: String,
-    owner: String
-)
-
-/** File-based distributed lock for index operations.
-  *
-  * Provides mutual exclusion for index operations (update, compact, vacuum)
-  * using lock files on HDFS or cloud-compatible filesystems. Lock files are
-  * JSON documents containing a [[LockInfo]] payload.
-  *
-  * ==Concurrency semantics==
-  * Lock acquisition is atomic at the filesystem level: the lock file is created
-  * with `overwrite = false`, so only one writer can succeed. If another process
-  * already holds the lock, acquisition enters a retry loop with exponential
-  * back-off (capped at 60 s) up to `lockMaxWait` seconds.
-  *
-  * ==Stale lock healing==
-  * If the `lastRefreshedAt` timestamp is older than `lockTimeout` seconds, the
-  * lock is considered stale. A stale lock is automatically deleted and
-  * re-acquired, with a warning logged identifying the previous holder.
-  *
-  * ==Corrupt lock file handling==
-  * If the lock file exists but cannot be parsed (empty or invalid JSON), it is
-  * treated as corrupt: the file is deleted and acquisition is retried, up to
-  * `MaxCorruptLockRetries` times to prevent infinite recursion.
-  *
-  * '''Thread safety:''' `IndexLock` instances are '''not''' safe for concurrent
-  * use from multiple threads. The `readLock`/`writeLockFile` methods perform
-  * unsynchronized filesystem I/O. Each thread should use its own `IndexLock`
-  * instance or coordinate externally.
-  *
-  * @param lockPath
-  *   Path to the lock file on the filesystem
-  * @param indexName
-  *   Name of the index being locked (used in log messages)
-  * @param spark
-  *   Implicit SparkSession for filesystem access and configuration
-  */
-case class IndexLock(lockPath: Path, indexName: String)(implicit
-    val spark: SparkSession
-) extends AriadneContextUser {
+/**
+ * File-based distributed lock for index operations.
+ *
+ * Provides mutual exclusion for index operations (update, compact, vacuum) using lock files on HDFS or cloud-compatible
+ * filesystems. Lock files are JSON documents containing a [[LockInfo]] payload.
+ *
+ * ==Concurrency semantics==
+ * Lock acquisition is atomic at the filesystem level: the lock file is created with `overwrite = false`, so only one
+ * writer can succeed. If another process already holds the lock, acquisition enters a retry loop with exponential
+ * back-off (capped at 60 s) up to `lockMaxWait` seconds.
+ *
+ * ==Stale lock healing==
+ * If the `lastRefreshedAt` timestamp is older than `lockTimeout` seconds, the lock is considered stale. A stale lock is
+ * automatically deleted and re-acquired, with a warning logged identifying the previous holder.
+ *
+ * ==Corrupt lock file handling==
+ * If the lock file exists but cannot be parsed (empty or invalid JSON), it is treated as corrupt: the file is deleted
+ * and acquisition is retried, up to `MaxCorruptLockRetries` times to prevent infinite recursion.
+ *
+ * '''Thread safety:''' `IndexLock` instances are '''not''' safe for concurrent use from multiple threads. The
+ * `readLock`/`writeLockFile` methods perform unsynchronized filesystem I/O. Each thread should use its own `IndexLock`
+ * instance or coordinate externally.
+ *
+ * @param lockPath
+ *   Path to the lock file on the filesystem
+ * @param indexName
+ *   Name of the index being locked (used in log messages)
+ * @param spark
+ *   Implicit SparkSession for filesystem access and configuration
+ */
+case class IndexLock(lockPath: Path, indexName: String)(implicit val spark: SparkSession) extends AriadneContextUser {
 
   private val gson = new Gson()
 
-  /** Maximum number of recursive acquire attempts when encountering corrupt or
-    * transient lock files, to prevent stack overflow.
-    */
+  /**
+   * Maximum number of recursive acquire attempts when encountering corrupt or transient lock files, to prevent stack
+   * overflow.
+   */
   private val MaxCorruptLockRetries = 3
 
-  /** Returns the Spark application ID, falling back to the local hostname.
-    *
-    * @return
-    *   an owner identifier string for the lock file
-    */
-  private def getOwner: String = {
+  /**
+   * Returns the Spark application ID, falling back to the local hostname.
+   *
+   * @return
+   *   an owner identifier string for the lock file
+   */
+  private def getOwner: String =
     try {
       spark.sparkContext.applicationId
     } catch {
       case e: Exception =>
-        logger.debug(
-          s"Could not get Spark application ID, falling back to hostname: ${e.getMessage}"
-        )
+        logger.debug(s"Could not get Spark application ID, falling back to hostname: ${e.getMessage}")
         InetAddress.getLocalHost.getHostName
     }
-  }
 
-  /** Acquires the lock for the given correlation ID.
-    *
-    * If the lock file already exists, this method will either heal a stale or
-    * corrupt lock, or enter a retry loop until the lock becomes available or
-    * `lockMaxWait` is exceeded.
-    *
-    * @param correlationId
-    *   unique identifier to associate with this lock hold
-    * @throws IndexLockException
-    *   if the lock cannot be acquired within the configured timeout or after
-    *   max retry attempts
-    * @throws IllegalArgumentException
-    *   if correlationId is null or blank
-    */
+  /**
+   * Acquires the lock for the given correlation ID.
+   *
+   * If the lock file already exists, this method will either heal a stale or corrupt lock, or enter a retry loop until
+   * the lock becomes available or `lockMaxWait` is exceeded.
+   *
+   * @param correlationId
+   *   unique identifier to associate with this lock hold
+   * @throws IndexLockException
+   *   if the lock cannot be acquired within the configured timeout or after max retry attempts
+   * @throws IllegalArgumentException
+   *   if correlationId is null or blank
+   */
   def acquire(correlationId: String): Unit = {
-    require(
-      correlationId != null && correlationId.trim.nonEmpty,
-      "correlationId must not be null or blank"
-    )
+    require(correlationId != null && correlationId.trim.nonEmpty, "correlationId must not be null or blank")
     val acquireStart = System.currentTimeMillis()
     doAcquire(correlationId, depth = 0)
-    logger.debug(
-      s"Lock acquire completed for index '$indexName' in ${System.currentTimeMillis() - acquireStart}ms"
-    )
+    logger.debug(s"Lock acquire completed for index '$indexName' in ${System.currentTimeMillis() - acquireStart}ms")
   }
 
-  /** Internal acquire implementation with a recursion depth guard.
-    *
-    * @param correlationId
-    *   unique identifier to associate with this lock hold
-    * @param depth
-    *   current recursion depth (0-based)
-    */
+  /**
+   * Internal acquire implementation with a recursion depth guard.
+   *
+   * @param correlationId
+   *   unique identifier to associate with this lock hold
+   * @param depth
+   *   current recursion depth (0-based)
+   */
   private def doAcquire(correlationId: String, depth: Int): Unit = {
     if (depth >= MaxCorruptLockRetries) {
       throw new IndexLockException(
         s"Failed to acquire lock for index '$indexName' after $MaxCorruptLockRetries attempts " +
-          s"(possible persistent corrupt lock file at $lockPath)"
-      )
+          s"(possible persistent corrupt lock file at $lockPath)")
     }
 
     val startTime = System.currentTimeMillis()
 
     try {
       val now = Instant.now().toString
-      writeLockFile(
-        LockInfo(correlationId, now, now, getOwner),
-        overwrite = false
-      )
-      logger.warn(
-        s"Lock acquired for index '$indexName' (correlationId='$correlationId')"
-      )
+      writeLockFile(LockInfo(correlationId, now, now, getOwner), overwrite = false)
+      logger.warn(s"Lock acquired for index '$indexName' (correlationId='$correlationId')")
     } catch {
-      case _: org.apache.hadoop.fs.FileAlreadyExistsException |
-          _: java.io.IOException =>
+      case _: org.apache.hadoop.fs.FileAlreadyExistsException | _: java.io.IOException =>
         handleExistingLock(correlationId, startTime, 0, depth)
     }
   }
 
-  /** Handles the case where a lock file already exists during acquisition.
-    *
-    * Reads the existing lock to determine whether it is stale (auto-heal),
-    * active (enter retry loop), or corrupt/unreadable (delete and retry with
-    * depth guard).
-    *
-    * '''TOCTOU note:''' There is an inherent race between reading the lock,
-    * determining it is stale, deleting it, and re-creating it. A third process
-    * could create a new lock between the delete and the re-acquire. The `depth`
-    * guard limits recursion, and the filesystem's atomic-create semantics
-    * (`overwrite = false`) ensure at most one writer succeeds.
-    *
-    * @param correlationId
-    *   unique identifier for the new lock request
-    * @param startTime
-    *   epoch millis when the acquire attempt started
-    * @param attempt
-    *   current retry attempt number (for back-off)
-    * @param depth
-    *   current recursion depth to prevent infinite recursion
-    */
-  private def handleExistingLock(
-      correlationId: String,
-      startTime: Long,
-      attempt: Int,
-      depth: Int
-  ): Unit = {
+  /**
+   * Handles the case where a lock file already exists during acquisition.
+   *
+   * Reads the existing lock to determine whether it is stale (auto-heal), active (enter retry loop), or
+   * corrupt/unreadable (delete and retry with depth guard).
+   *
+   * '''TOCTOU note:''' There is an inherent race between reading the lock, determining it is stale, deleting it, and
+   * re-creating it. A third process could create a new lock between the delete and the re-acquire. The `depth` guard
+   * limits recursion, and the filesystem's atomic-create semantics (`overwrite = false`) ensure at most one writer
+   * succeeds.
+   *
+   * @param correlationId
+   *   unique identifier for the new lock request
+   * @param startTime
+   *   epoch millis when the acquire attempt started
+   * @param attempt
+   *   current retry attempt number (for back-off)
+   * @param depth
+   *   current recursion depth to prevent infinite recursion
+   */
+  private def handleExistingLock(correlationId: String, startTime: Long, attempt: Int, depth: Int): Unit =
     readLock() match {
       case Some(existingLock) if isStale(existingLock) =>
         logger.warn(
           s"Auto-healing stale lock for index '$indexName' " +
-            s"(held by correlationId='${existingLock.correlationId}', owner='${existingLock.owner}')"
-        )
+            s"(held by correlationId='${existingLock.correlationId}', owner='${existingLock.owner}')")
         delete(lockPath)
         doAcquire(correlationId, depth + 1)
       case Some(existingLock) =>
         retryLoop(correlationId, startTime, attempt, existingLock)
       case None =>
         if (exists(lockPath)) {
-          logger.warn(
-            s"Detected corrupt lock file for index '$indexName' at $lockPath, deleting"
-          )
+          logger.warn(s"Detected corrupt lock file for index '$indexName' at $lockPath, deleting")
           delete(lockPath)
         }
         doAcquire(correlationId, depth + 1)
     }
-  }
 
-  /** Retry loop implementing exponential back-off for lock acquisition.
-    *
-    * Sleeps with exponential back-off (capped at 60 s) between attempts. On
-    * each iteration the lock file is re-read to check for staleness or release.
-    * The loop terminates when the lock is successfully acquired, the caller is
-    * interrupted, or `lockMaxWait` is exceeded.
-    *
-    * @param correlationId
-    *   unique identifier for the new lock request
-    * @param startTime
-    *   epoch millis when the acquire attempt started
-    * @param attempt
-    *   initial retry attempt number (for back-off calculation)
-    * @param lastLock
-    *   the most recently observed [[LockInfo]] from the lock file
-    * @throws IndexLockException
-    *   if the lock cannot be acquired within `lockMaxWait` seconds
-    */
-  private def retryLoop(
-      correlationId: String,
-      startTime: Long,
-      attempt: Int,
-      lastLock: LockInfo
-  ): Unit = {
+  /**
+   * Retry loop implementing exponential back-off for lock acquisition.
+   *
+   * Sleeps with exponential back-off (capped at 60 s) between attempts. On each iteration the lock file is re-read to
+   * check for staleness or release. The loop terminates when the lock is successfully acquired, the caller is
+   * interrupted, or `lockMaxWait` is exceeded.
+   *
+   * @param correlationId
+   *   unique identifier for the new lock request
+   * @param startTime
+   *   epoch millis when the acquire attempt started
+   * @param attempt
+   *   initial retry attempt number (for back-off calculation)
+   * @param lastLock
+   *   the most recently observed [[LockInfo]] from the lock file
+   * @throws IndexLockException
+   *   if the lock cannot be acquired within `lockMaxWait` seconds
+   */
+  private def retryLoop(correlationId: String, startTime: Long, attempt: Int, lastLock: LockInfo): Unit = {
     var currentAttempt = attempt
     var currentLock = lastLock
     var acquired = false
@@ -232,32 +194,23 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
     while (!acquired) {
       val elapsed = (System.currentTimeMillis() - startTime) / 1000
       if (elapsed >= lockMaxWait) {
-        throw new IndexLockException(
-          indexName,
-          currentLock.correlationId,
-          currentLock.owner
-        )
+        throw new IndexLockException(indexName, currentLock.correlationId, currentLock.owner)
       }
 
-      val sleepSeconds = math
-        .min(
-          lockRetryInterval.toDouble * math.pow(2, math.min(currentAttempt, 6)),
-          60.0
-        )
-        .toLong
+      val sleepSeconds =
+        math
+          .min(lockRetryInterval.toDouble * math.pow(2, math.min(currentAttempt, 6)), 60.0)
+          .toLong
       logger.warn(
         s"Lock retry for index '$indexName': attempt=$currentAttempt, " +
           s"elapsed=${elapsed}s, sleeping=${sleepSeconds}s, " +
-          s"holder=${currentLock.owner} (correlationId='${currentLock.correlationId}')"
-      )
+          s"holder=${currentLock.owner} (correlationId='${currentLock.correlationId}')")
       try {
         Thread.sleep(sleepSeconds * 1000)
       } catch {
         case _: InterruptedException =>
           Thread.currentThread().interrupt()
-          throw new IndexLockException(
-            s"Lock acquisition interrupted for index '$indexName'"
-          )
+          throw new IndexLockException(s"Lock acquisition interrupted for index '$indexName'")
       }
       currentAttempt += 1
 
@@ -265,22 +218,15 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
         case Some(lock) if isStale(lock) =>
           logger.warn(
             s"Auto-healing stale lock for index '$indexName' " +
-              s"(held by correlationId='${lock.correlationId}', owner='${lock.owner}')"
-          )
+              s"(held by correlationId='${lock.correlationId}', owner='${lock.owner}')")
           delete(lockPath)
           try {
             val now = Instant.now().toString
-            writeLockFile(
-              LockInfo(correlationId, now, now, getOwner),
-              overwrite = false
-            )
-            logger.warn(
-              s"Lock acquired for index '$indexName' (correlationId='$correlationId')"
-            )
+            writeLockFile(LockInfo(correlationId, now, now, getOwner), overwrite = false)
+            logger.warn(s"Lock acquired for index '$indexName' (correlationId='$correlationId')")
             acquired = true
           } catch {
-            case _: org.apache.hadoop.fs.FileAlreadyExistsException |
-                _: java.io.IOException =>
+            case _: org.apache.hadoop.fs.FileAlreadyExistsException | _: java.io.IOException =>
               currentLock = readLock().getOrElse(currentLock)
           }
         case Some(lock) =>
@@ -288,114 +234,87 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
         case None =>
           try {
             val now = Instant.now().toString
-            writeLockFile(
-              LockInfo(correlationId, now, now, getOwner),
-              overwrite = false
-            )
-            logger.warn(
-              s"Lock acquired for index '$indexName' (correlationId='$correlationId')"
-            )
+            writeLockFile(LockInfo(correlationId, now, now, getOwner), overwrite = false)
+            logger.warn(s"Lock acquired for index '$indexName' (correlationId='$correlationId')")
             acquired = true
           } catch {
-            case _: org.apache.hadoop.fs.FileAlreadyExistsException |
-                _: java.io.IOException =>
+            case _: org.apache.hadoop.fs.FileAlreadyExistsException | _: java.io.IOException =>
               currentLock = readLock().getOrElse(currentLock)
           }
       }
     }
   }
 
-  /** Releases the lock if it is held by the given correlation ID.
-    *
-    * If the lock file does not exist or belongs to a different correlation ID,
-    * a warning is logged and no action is taken.
-    *
-    * @param correlationId
-    *   the correlation ID that should currently hold the lock
-    * @throws IllegalArgumentException
-    *   if correlationId is null or blank
-    */
+  /**
+   * Releases the lock if it is held by the given correlation ID.
+   *
+   * If the lock file does not exist or belongs to a different correlation ID, a warning is logged and no action is
+   * taken.
+   *
+   * @param correlationId
+   *   the correlation ID that should currently hold the lock
+   * @throws IllegalArgumentException
+   *   if correlationId is null or blank
+   */
   def release(correlationId: String): Unit = {
-    require(
-      correlationId != null && correlationId.trim.nonEmpty,
-      "correlationId must not be null or blank"
-    )
+    require(correlationId != null && correlationId.trim.nonEmpty, "correlationId must not be null or blank")
     val releaseStart = System.currentTimeMillis()
     readLock() match {
       case Some(lockInfo) if lockInfo.correlationId == correlationId =>
         delete(lockPath)
-        logger.warn(
-          s"Lock released for index '$indexName' (correlationId='$correlationId')"
-        )
+        logger.warn(s"Lock released for index '$indexName' (correlationId='$correlationId')")
       case Some(lockInfo) =>
         logger.warn(
           s"Cannot release lock for index '$indexName': " +
-            s"correlationId mismatch (expected='$correlationId', actual='${lockInfo.correlationId}')"
-        )
+            s"correlationId mismatch (expected='$correlationId', actual='${lockInfo.correlationId}')")
       case None =>
-        logger.warn(
-          s"Cannot release lock for index '$indexName': lock file does not exist"
-        )
+        logger.warn(s"Cannot release lock for index '$indexName': lock file does not exist")
     }
-    logger.debug(
-      s"Lock release completed for index '$indexName' in ${System.currentTimeMillis() - releaseStart}ms"
-    )
+    logger.debug(s"Lock release completed for index '$indexName' in ${System.currentTimeMillis() - releaseStart}ms")
   }
 
-  /** Refreshes the lock's `lastRefreshedAt` timestamp to prevent stale-lock
-    * healing.
-    *
-    * Long-running operations should call this periodically (more frequently
-    * than `lockTimeout`) to signal that the lock holder is still active.
-    *
-    * @param correlationId
-    *   the correlation ID that should currently hold the lock
-    * @throws IllegalArgumentException
-    *   if correlationId is null or blank
-    */
+  /**
+   * Refreshes the lock's `lastRefreshedAt` timestamp to prevent stale-lock healing.
+   *
+   * Long-running operations should call this periodically (more frequently than `lockTimeout`) to signal that the lock
+   * holder is still active.
+   *
+   * @param correlationId
+   *   the correlation ID that should currently hold the lock
+   * @throws IllegalArgumentException
+   *   if correlationId is null or blank
+   */
   def refresh(correlationId: String): Unit = {
-    require(
-      correlationId != null && correlationId.trim.nonEmpty,
-      "correlationId must not be null or blank"
-    )
-    logger.debug(
-      s"Refreshing lock for index '$indexName' (correlationId='$correlationId')"
-    )
+    require(correlationId != null && correlationId.trim.nonEmpty, "correlationId must not be null or blank")
+    logger.debug(s"Refreshing lock for index '$indexName' (correlationId='$correlationId')")
     val refreshStart = System.currentTimeMillis()
     readLock() match {
       case Some(lockInfo) if lockInfo.correlationId == correlationId =>
         val updated = lockInfo.copy(lastRefreshedAt = Instant.now().toString)
         writeLockFile(updated, overwrite = true)
-        logger.warn(
-          s"Lock refreshed for index '$indexName' (correlationId='$correlationId')"
-        )
+        logger.warn(s"Lock refreshed for index '$indexName' (correlationId='$correlationId')")
       case Some(lockInfo) =>
         logger.warn(
           s"Cannot refresh lock for index '$indexName': " +
-            s"correlationId mismatch (expected='$correlationId', actual='${lockInfo.correlationId}')"
-        )
+            s"correlationId mismatch (expected='$correlationId', actual='${lockInfo.correlationId}')")
       case None =>
-        logger.warn(
-          s"Cannot refresh lock for index '$indexName': lock file does not exist"
-        )
+        logger.warn(s"Cannot refresh lock for index '$indexName': lock file does not exist")
     }
-    logger.debug(
-      s"Lock refresh completed for index '$indexName' in ${System.currentTimeMillis() - refreshStart}ms"
-    )
+    logger.debug(s"Lock refresh completed for index '$indexName' in ${System.currentTimeMillis() - refreshStart}ms")
   }
 
-  /** Determines whether the lock is stale based on `lastRefreshedAt`.
-    *
-    * A lock is stale when the time elapsed since its last refresh exceeds the
-    * configured `lockTimeout`. If the timestamp cannot be parsed, the lock is
-    * considered stale and a warning is logged.
-    *
-    * @param lockInfo
-    *   the lock metadata to evaluate
-    * @return
-    *   true if the lock should be considered stale
-    */
-  private def isStale(lockInfo: LockInfo): Boolean = {
+  /**
+   * Determines whether the lock is stale based on `lastRefreshedAt`.
+   *
+   * A lock is stale when the time elapsed since its last refresh exceeds the configured `lockTimeout`. If the timestamp
+   * cannot be parsed, the lock is considered stale and a warning is logged.
+   *
+   * @param lockInfo
+   *   the lock metadata to evaluate
+   * @return
+   *   true if the lock should be considered stale
+   */
+  private def isStale(lockInfo: LockInfo): Boolean =
     try {
       val lastRefreshed = Instant.parse(lockInfo.lastRefreshedAt)
       Duration.between(lastRefreshed, Instant.now()).getSeconds > lockTimeout
@@ -403,19 +322,18 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
       case e: Exception =>
         logger.warn(
           s"Could not parse lastRefreshedAt='${lockInfo.lastRefreshedAt}' for index " +
-            s"'$indexName', treating lock as stale: ${e.getMessage}"
-        )
+            s"'$indexName', treating lock as stale: ${e.getMessage}")
         true
     }
-  }
 
-  /** Reads and deserializes the lock file.
-    *
-    * @return
-    *   `Some(lockInfo)` if the file exists and contains valid JSON, `None` if
-    *   the file does not exist or cannot be parsed
-    */
-  private def readLock(): Option[LockInfo] = {
+  /**
+   * Reads and deserializes the lock file.
+   *
+   * @return
+   *   `Some(lockInfo)` if the file exists and contains valid JSON, `None` if the file does not exist or cannot be
+   *   parsed
+   */
+  private def readLock(): Option[LockInfo] =
     try {
       if (exists(lockPath)) {
         val inputStream = open(lockPath)
@@ -440,16 +358,15 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
         logger.warn(s"Corrupt lock file at $lockPath: ${e.getMessage}")
         None
     }
-  }
 
-  /** Writes lock metadata to the lock file.
-    *
-    * @param lockInfo
-    *   the metadata to serialize as JSON
-    * @param overwrite
-    *   if false, the write fails with `FileAlreadyExistsException` when the
-    *   file already exists (atomic create)
-    */
+  /**
+   * Writes lock metadata to the lock file.
+   *
+   * @param lockInfo
+   *   the metadata to serialize as JSON
+   * @param overwrite
+   *   if false, the write fails with `FileAlreadyExistsException` when the file already exists (atomic create)
+   */
   private def writeLockFile(lockInfo: LockInfo, overwrite: Boolean): Unit = {
     var outputStream: org.apache.hadoop.fs.FSDataOutputStream = null
     try {
@@ -458,9 +375,7 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit
       outputStream.flush()
     } catch {
       case e: Exception =>
-        logger.warn(
-          s"Failed to write lock file for index '$indexName': ${e.getMessage}"
-        )
+        logger.warn(s"Failed to write lock file for index '$indexName': ${e.getMessage}")
         throw e
     } finally {
       if (outputStream != null) {

--- a/src/main/scala/dev/cjfravel/ariadne/IndexMetadata.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexMetadata.scala
@@ -1,138 +1,112 @@
 package dev.cjfravel.ariadne
-
-import com.google.gson.annotations.SerializedName
 import java.util
+
 import com.google.gson.Gson
 import dev.cjfravel.ariadne.exceptions.MetadataMissingOrCorruptException
 
-/** Configuration for a bloom filter index.
-  *
-  * Bloom filters are probabilistic data structures that provide:
-  *   - Guaranteed NO false negatives (if filter says "no", value definitely
-  *     absent)
-  *   - Configurable false positive rate (if filter says "yes", value MIGHT be
-  *     present)
-  *   - Space-efficient storage (approximately 10 bits per element at 1% FPR)
-  *
-  * @param column
-  *   The column name to create a bloom filter for
-  * @param fpr
-  *   False positive rate (0.0 to 1.0, default 0.01 = 1%)
-  */
-case class BloomIndexConfig(
-    var column: String,
-    var fpr: Double = 0.01
-) {
-  require(
-    fpr > 0 && fpr < 1,
-    s"fpr must be between 0 and 1 (exclusive), got $fpr"
-  )
+/**
+ * Configuration for a bloom filter index.
+ *
+ * Bloom filters are probabilistic data structures that provide:
+ *   - Guaranteed NO false negatives (if filter says "no", value definitely absent)
+ *   - Configurable false positive rate (if filter says "yes", value MIGHT be present)
+ *   - Space-efficient storage (approximately 10 bits per element at 1% FPR)
+ *
+ * @param column
+ *   The column name to create a bloom filter for
+ * @param fpr
+ *   False positive rate (0.0 to 1.0, default 0.01 = 1%)
+ */
+case class BloomIndexConfig(var column: String, var fpr: Double = 0.01) {
+  require(fpr > 0 && fpr < 1, s"fpr must be between 0 and 1 (exclusive), got $fpr")
 }
 
-/** Configuration for a temporal index.
-  *
-  * Temporal indexes track entity versions across files. When joining on the
-  * value column, only the row with the latest timestamp is returned,
-  * effectively deduplicating across files by recency.
-  *
-  * @param column
-  *   The value column to index and deduplicate on (e.g., "user_id")
-  * @param timestamp_column
-  *   The timestamp column used to determine recency (e.g., "updated_at")
-  */
-case class TemporalIndexConfig(
-    var column: String,
-    var timestamp_column: String
-)
+/**
+ * Configuration for a temporal index.
+ *
+ * Temporal indexes track entity versions across files. When joining on the value column, only the row with the latest
+ * timestamp is returned, effectively deduplicating across files by recency.
+ *
+ * @param column
+ *   The value column to index and deduplicate on (e.g., "user_id")
+ * @param timestamp_column
+ *   The timestamp column used to determine recency (e.g., "updated_at")
+ */
+case class TemporalIndexConfig(var column: String, var timestamp_column: String)
 
-/** Configuration for a range index.
-  *
-  * Range indexes store min/max values per file for a column, enabling file
-  * pruning at query time. Files whose [min, max] range does not overlap with
-  * the queried values are skipped.
-  *
-  * @param column
-  *   The column name to create a range index for
-  */
-case class RangeIndexConfig(
-    var column: String
-)
+/**
+ * Configuration for a range index.
+ *
+ * Range indexes store min/max values per file for a column, enabling file pruning at query time. Files whose [min, max]
+ * range does not overlap with the queried values are skipped.
+ *
+ * @param column
+ *   The column name to create a range index for
+ */
+case class RangeIndexConfig(var column: String)
 
-/** Represents a mapping for exploded field index configuration.
-  *
-  * This case class defines how to extract and index fields from array elements.
-  * It maps array elements to a flat structure that can be used for efficient
-  * joins by exploding the array and indexing specific fields within each
-  * element.
-  *
-  * @param array_column
-  *   The name of the array column in the schema
-  * @param field_path
-  *   The field path to extract from each array element (e.g., "id",
-  *   "profile.user_id")
-  * @param as_column
-  *   The alias name to use for this extracted field in joins
-  *
-  * @example
-  *   {{{
-  * // For a schema with users: Array[Struct{id: Int, name: String}]
-  * val mapping = ExplodedFieldMapping("users", "id", "user_id")
-  * // This allows joining on "user_id" which represents users[].id
-  *   }}}
-  */
-case class ExplodedFieldMapping(
-    var array_column: String,
-    var field_path: String,
-    var as_column: String
-)
+/**
+ * Represents a mapping for exploded field index configuration.
+ *
+ * This case class defines how to extract and index fields from array elements. It maps array elements to a flat
+ * structure that can be used for efficient joins by exploding the array and indexing specific fields within each
+ * element.
+ *
+ * @param array_column
+ *   The name of the array column in the schema
+ * @param field_path
+ *   The field path to extract from each array element (e.g., "id", "profile.user_id")
+ * @param as_column
+ *   The alias name to use for this extracted field in joins
+ *
+ * @example
+ *   {{{
+ * // For a schema with users: Array[Struct{id: Int, name: String}]
+ * val mapping = ExplodedFieldMapping("users", "id", "user_id")
+ * // This allows joining on "user_id" which represents users[].id
+ *   }}}
+ */
+case class ExplodedFieldMapping(var array_column: String, var field_path: String, var as_column: String)
 
-/** Metadata container for Ariadne index configuration and state.
-  *
-  * This case class stores all metadata required to manage an Ariadne index,
-  * including schema information, indexed columns, and format details. It
-  * supports multiple versions for backward compatibility.
-  *
-  * @param format
-  *   The file format of the indexed data (e.g., "parquet", "csv", "json")
-  * @param schema
-  *   The JSON representation of the DataFrame schema
-  * @param indexes
-  *   List of regular column names that are indexed
-  * @param computed_indexes
-  *   Map of computed index aliases to their SQL expressions
-  * @param exploded_field_indexes
-  *   List of exploded field mappings for nested data structures
-  * @param bloom_indexes
-  *   List of bloom filter index configurations for probabilistic indexing
-  * @param temporal_indexes
-  *   List of temporal index configurations for version-aware deduplication
-  * @param read_options
-  *   Map of read options for format-specific configuration (e.g., "multiLine"
-  *   -> "true" for JSON)
-  * @param total_indexed_file_size
-  *   Total size in bytes of all indexed files, or -1 if not yet computed
-  *   (nullable for Gson compatibility)
-  * @param batches_since_compact
-  *   Number of update batches processed since the last auto-compaction,
-  *   persisted across Spark jobs so that `autoCompactThreshold` works correctly
-  *   even when updates happen in separate runs (v10+, nullable for Gson)
-  *
-  * @note
-  *   The field names use underscore notation to match JSON serialization
-  *   format. All fields use `var` and Java collections (`util.List`,
-  *   `util.Map`) because Gson requires mutable fields for deserialization. Do
-  *   '''not''' refactor to `val` or Scala collections without updating the Gson
-  *   serialization in [[IndexMetadata$ IndexMetadata.apply]] and
-  *   [[IndexMetadataOperations]].
-  */
+/**
+ * Metadata container for Ariadne index configuration and state.
+ *
+ * This case class stores all metadata required to manage an Ariadne index, including schema information, indexed
+ * columns, and format details. It supports multiple versions for backward compatibility.
+ *
+ * @param format
+ *   The file format of the indexed data (e.g., "parquet", "csv", "json")
+ * @param schema
+ *   The JSON representation of the DataFrame schema
+ * @param indexes
+ *   List of regular column names that are indexed
+ * @param computed_indexes
+ *   Map of computed index aliases to their SQL expressions
+ * @param exploded_field_indexes
+ *   List of exploded field mappings for nested data structures
+ * @param bloom_indexes
+ *   List of bloom filter index configurations for probabilistic indexing
+ * @param temporal_indexes
+ *   List of temporal index configurations for version-aware deduplication
+ * @param read_options
+ *   Map of read options for format-specific configuration (e.g., "multiLine" -> "true" for JSON)
+ * @param total_indexed_file_size
+ *   Total size in bytes of all indexed files, or -1 if not yet computed (nullable for Gson compatibility)
+ * @param batches_since_compact
+ *   Number of update batches processed since the last auto-compaction, persisted across Spark jobs so that
+ *   `autoCompactThreshold` works correctly even when updates happen in separate runs (v10+, nullable for Gson)
+ *
+ * @note
+ *   The field names use underscore notation to match JSON serialization format. All fields use `var` and Java
+ *   collections (`util.List`, `util.Map`) because Gson requires mutable fields for deserialization. Do '''not'''
+ *   refactor to `val` or Scala collections without updating the Gson serialization in
+ *   [[IndexMetadata$ IndexMetadata.apply]] and [[IndexMetadataOperations]].
+ */
 case class IndexMetadata(
     var format: String,
     var schema: String,
     var indexes: util.List[String],
-    var computed_indexes: util.Map[
-      String,
-      String
-    ],
+    var computed_indexes: util.Map[String, String],
     var exploded_field_indexes: util.List[ExplodedFieldMapping],
     var bloom_indexes: util.List[BloomIndexConfig],
     var temporal_indexes: util.List[TemporalIndexConfig],
@@ -140,44 +114,45 @@ case class IndexMetadata(
     var range_indexes: util.List[RangeIndexConfig],
     var auto_bloom_indexes: util.List[String],
     var total_indexed_file_size: java.lang.Long,
-    var batches_since_compact: java.lang.Integer
-)
+    var batches_since_compact: java.lang.Integer)
 
-/** Factory object for creating IndexMetadata instances from JSON.
-  *
-  * Provides deserialization capabilities with automatic version migration to
-  * ensure backward compatibility across different metadata formats.
-  */
+/**
+ * Factory object for creating IndexMetadata instances from JSON.
+ *
+ * Provides deserialization capabilities with automatic version migration to ensure backward compatibility across
+ * different metadata formats.
+ */
 object IndexMetadata {
 
-  /** Creates an IndexMetadata instance from a JSON string.
-    *
-    * This method deserializes JSON metadata and automatically handles version
-    * migration to ensure compatibility with older index formats:
-    *   - v1 → v2: Adds computed_indexes field if missing
-    *   - v2 → v3: Adds exploded_field_indexes field if missing
-    *   - v3 → v4: Adds read_options field if missing
-    *   - v4 → v5: Adds bloom_indexes field if missing
-    *   - v5 → v6: Adds temporal_indexes field if missing
-    *   - v6 → v7: Adds range_indexes field if missing
-    *   - v7 → v8: Adds auto_bloom_indexes field if missing
-    *   - v8 → v9: Adds total_indexed_file_size field if missing
-    *   - v9 → v10: Adds batches_since_compact field if missing
-    *
-    * @param jsonString
-    *   The JSON representation of the metadata
-    * @return
-    *   A fully initialized IndexMetadata instance
-    * @throws MetadataMissingOrCorruptException
-    *   if `jsonString` is null, empty, or cannot be deserialized
-    *
-    * @example
-    *   {{{
-    * val jsonString = """{"format":"parquet","schema":"...","indexes":["id"]}"""
-    * val metadata = IndexMetadata(jsonString)
-    * // Returns metadata with all fields properly initialized
-    *   }}}
-    */
+  /**
+   * Creates an IndexMetadata instance from a JSON string.
+   *
+   * This method deserializes JSON metadata and automatically handles version migration to ensure compatibility with
+   * older index formats:
+   *   - v1 → v2: Adds computed_indexes field if missing
+   *   - v2 → v3: Adds exploded_field_indexes field if missing
+   *   - v3 → v4: Adds read_options field if missing
+   *   - v4 → v5: Adds bloom_indexes field if missing
+   *   - v5 → v6: Adds temporal_indexes field if missing
+   *   - v6 → v7: Adds range_indexes field if missing
+   *   - v7 → v8: Adds auto_bloom_indexes field if missing
+   *   - v8 → v9: Adds total_indexed_file_size field if missing
+   *   - v9 → v10: Adds batches_since_compact field if missing
+   *
+   * @param jsonString
+   *   The JSON representation of the metadata
+   * @return
+   *   A fully initialized IndexMetadata instance
+   * @throws MetadataMissingOrCorruptException
+   *   if `jsonString` is null, empty, or cannot be deserialized
+   *
+   * @example
+   *   {{{
+   * val jsonString = """{"format":"parquet","schema":"...","indexes":["id"]}"""
+   * val metadata = IndexMetadata(jsonString)
+   * // Returns metadata with all fields properly initialized
+   *   }}}
+   */
   def apply(jsonString: String): IndexMetadata = {
     if (jsonString == null || jsonString.trim.isEmpty) {
       throw new MetadataMissingOrCorruptException()
@@ -196,10 +171,7 @@ object IndexMetadata {
     // not a valid older version.
     if (indexMetadata.format == null || indexMetadata.schema == null) {
       throw new MetadataMissingOrCorruptException(
-        new IllegalStateException(
-          "IndexMetadata is missing required field 'format' or 'schema'"
-        )
-      )
+        new IllegalStateException("IndexMetadata is missing required field 'format' or 'schema'"))
     }
     // v0 -> v1
     if (indexMetadata.indexes == null) {

--- a/src/main/scala/dev/cjfravel/ariadne/IndexMetadataOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexMetadataOperations.scala
@@ -1,103 +1,106 @@
 package dev.cjfravel.ariadne
 
+import java.nio.charset.StandardCharsets
+
+import scala.io.Source
+
+import com.google.gson.Gson
 import dev.cjfravel.ariadne.exceptions.MetadataMissingOrCorruptException
 import org.apache.hadoop.fs.Path
-import org.apache.logging.log4j.{Logger, LogManager}
-import scala.io.Source
-import java.nio.charset.StandardCharsets
-import com.google.gson.Gson
+import org.apache.logging.log4j.{LogManager, Logger}
 
-/** Trait providing metadata read/write operations for [[Index]] instances.
-  *
-  * Manages the lifecycle of [[IndexMetadata]] — reading from and writing to the
-  * `metadata.json` file on the Hadoop-compatible filesystem. Metadata is cached
-  * in memory after the first load; call [[refreshMetadata]] to force a reload.
-  *
-  * '''Storage:''' Metadata is persisted as a single JSON file at
-  * `{storagePath}/metadata.json`, serialized and deserialized via Gson.
-  *
-  * '''Error handling:''' If the metadata file is missing or corrupt,
-  * [[dev.cjfravel.ariadne.exceptions.MetadataMissingOrCorruptException]] is
-  * thrown. Write failures are logged before the exception propagates.
-  *
-  * '''Thread safety:''' This trait is '''not''' thread-safe. The mutable
-  * `_metadata` cache is not synchronized — concurrent calls to
-  * [[refreshMetadata]] or [[writeMetadata]] from multiple threads may produce
-  * inconsistent state. External synchronization is required for concurrent
-  * access.
-  *
-  * @see
-  *   [[IndexMetadata]] for the metadata schema and version migration logic
-  */
+/**
+ * Trait providing metadata read/write operations for [[Index]] instances.
+ *
+ * Manages the lifecycle of [[IndexMetadata]] — reading from and writing to the `metadata.json` file on the
+ * Hadoop-compatible filesystem. Metadata is cached in memory after the first load; call [[refreshMetadata]] to force a
+ * reload.
+ *
+ * '''Storage:''' Metadata is persisted as a single JSON file at `{storagePath}/metadata.json`, serialized and
+ * deserialized via Gson.
+ *
+ * '''Error handling:''' If the metadata file is missing or corrupt,
+ * [[dev.cjfravel.ariadne.exceptions.MetadataMissingOrCorruptException]] is thrown. Write failures are logged before the
+ * exception propagates.
+ *
+ * '''Thread safety:''' This trait is '''not''' thread-safe. The mutable `_metadata` cache is not synchronized —
+ * concurrent calls to [[refreshMetadata]] or [[writeMetadata]] from multiple threads may produce inconsistent state.
+ * External synchronization is required for concurrent access.
+ *
+ * @see
+ *   [[IndexMetadata]] for the metadata schema and version migration logic
+ */
 trait IndexMetadataOperations extends AriadneContextUser {
   self: Index =>
 
   override lazy val logger: Logger = LogManager.getLogger("ariadne")
 
-  /** Hadoop path for the metadata file.
-    * @return
-    *   the path to `metadata.json` under the index storage directory
-    */
+  /**
+   * Hadoop path for the metadata file.
+   * @return
+   *   the path to `metadata.json` under the index storage directory
+   */
   protected def metadataFilePath: Path = new Path(storagePath, "metadata.json")
 
-  /** Checks if metadata exists in the storage location.
-    * @return
-    *   True if metadata exists, otherwise false.
-    */
+  /**
+   * Checks if metadata exists in the storage location.
+   * @return
+   *   True if metadata exists, otherwise false.
+   */
   protected def metadataExists: Boolean =
     exists(metadataFilePath)
 
   private var _metadata: IndexMetadata = _
 
-  /** Forces a reload of metadata from the `metadata.json` file on disk.
-    *
-    * Replaces the in-memory cached metadata with a freshly deserialized copy.
-    * This is called automatically by [[metadata]] on first access; callers may
-    * invoke it explicitly to pick up external changes.
-    *
-    * @throws MetadataMissingOrCorruptException
-    *   if the metadata file does not exist, cannot be read, or contains invalid
-    *   JSON
-    */
+  /**
+   * Forces a reload of metadata from the `metadata.json` file on disk.
+   *
+   * Replaces the in-memory cached metadata with a freshly deserialized copy. This is called automatically by
+   * [[metadata]] on first access; callers may invoke it explicitly to pick up external changes.
+   *
+   * @throws MetadataMissingOrCorruptException
+   *   if the metadata file does not exist, cannot be read, or contains invalid JSON
+   */
   def refreshMetadata(): Unit = {
-    logger.debug(s"Entering refreshMetadata for index '${name}'")
-    _metadata = if (metadataExists) {
-      try {
-        val inputStream = open(metadataFilePath)
+    logger.debug(s"Entering refreshMetadata for index '$name'")
+    _metadata =
+      if (metadataExists) {
         try {
-          val source =
-            Source.fromInputStream(inputStream)(StandardCharsets.UTF_8)
+          val inputStream = open(metadataFilePath)
           try {
-            val jsonString = source.mkString
-            IndexMetadata(jsonString)
+            val source =
+              Source.fromInputStream(inputStream)(StandardCharsets.UTF_8)
+            try {
+              val jsonString = source.mkString
+              IndexMetadata(jsonString)
+            } finally {
+              source.close()
+            }
           } finally {
-            source.close()
+            inputStream.close()
           }
-        } finally {
-          inputStream.close()
+        } catch {
+          case e: Exception =>
+            logger.warn(
+              s"Failed to read metadata from ${metadataFilePath.toString}: " +
+                s"${e.getClass.getSimpleName}: ${e.getMessage}")
+            throw new MetadataMissingOrCorruptException(e)
         }
-      } catch {
-        case e: Exception =>
-          logger.warn(
-            s"Failed to read metadata from ${metadataFilePath.toString}: " +
-              s"${e.getClass.getSimpleName}: ${e.getMessage}"
-          )
-          throw new MetadataMissingOrCorruptException(e)
+      } else {
+        throw new MetadataMissingOrCorruptException()
       }
-    } else {
-      throw new MetadataMissingOrCorruptException()
-    }
     logger.warn(s"Read metadata from ${metadataFilePath.toString}")
-    logger.debug(s"Completed refreshMetadata for index '${name}'")
+    logger.debug(s"Completed refreshMetadata for index '$name'")
   }
 
-  /** Retrieves the stored metadata for the index.
-    *
-    * @return
-    *   IndexMetadata associated with the index.
-    * @throws MetadataMissingOrCorruptException
-    *   if metadata is missing or cannot be parsed.
-    */
+  /**
+   * Retrieves the stored metadata for the index.
+   *
+   * @return
+   *   IndexMetadata associated with the index.
+   * @throws MetadataMissingOrCorruptException
+   *   if metadata is missing or cannot be parsed.
+   */
   private[ariadne] def metadata: IndexMetadata = {
     if (_metadata == null) {
       refreshMetadata()
@@ -105,22 +108,20 @@ trait IndexMetadataOperations extends AriadneContextUser {
     _metadata
   }
 
-  /** Writes metadata to the `metadata.json` file and updates the in-memory
-    * cache.
-    *
-    * Creates the parent directory if it does not exist. The write is ''not''
-    * atomic — a crash mid-write may leave a corrupt file that triggers
-    * [[dev.cjfravel.ariadne.exceptions.MetadataMissingOrCorruptException]] on
-    * the next read.
-    *
-    * @param metadata
-    *   the metadata instance to serialize and persist
-    * @throws java.io.IOException
-    *   if the write fails (the error is logged before propagating)
-    */
+  /**
+   * Writes metadata to the `metadata.json` file and updates the in-memory cache.
+   *
+   * Creates the parent directory if it does not exist. The write is ''not'' atomic — a crash mid-write may leave a
+   * corrupt file that triggers [[dev.cjfravel.ariadne.exceptions.MetadataMissingOrCorruptException]] on the next read.
+   *
+   * @param metadata
+   *   the metadata instance to serialize and persist
+   * @throws java.io.IOException
+   *   if the write fails (the error is logged before propagating)
+   */
   protected def writeMetadata(metadata: IndexMetadata): Unit = {
     require(metadata != null, "metadata must not be null")
-    logger.debug(s"Entering writeMetadata for index '${name}'")
+    logger.debug(s"Entering writeMetadata for index '$name'")
     val directoryPath = metadataFilePath.getParent
     if (!exists(directoryPath)) fs.mkdirs(directoryPath)
 
@@ -132,39 +133,30 @@ trait IndexMetadataOperations extends AriadneContextUser {
       outputStream.flush()
     } catch {
       case e: Exception =>
-        logger.warn(
-          s"Failed to write metadata to ${metadataFilePath.toString}: ${e.getMessage}"
-        )
+        logger.warn(s"Failed to write metadata to ${metadataFilePath.toString}: ${e.getMessage}")
         throw e
     } finally {
       if (outputStream != null) outputStream.close()
     }
     _metadata = metadata // Update in-memory cache
     logger.warn(s"Wrote metadata to ${metadataFilePath.toString}")
-    logger.debug(s"Completed writeMetadata for index '${name}'")
+    logger.debug(s"Completed writeMetadata for index '$name'")
   }
 
-  /** Returns the file format of the indexed data (e.g., "parquet", "csv",
-    * "json").
-    * @return
-    *   the format string from the stored metadata
-    */
+  /**
+   * Returns the file format of the indexed data (e.g., "parquet", "csv", "json").
+   * @return
+   *   the format string from the stored metadata
+   */
   def format: String = metadata.format
 
-  /** Updates the file format recorded in the stored metadata.
-    *
-    * @param newFormat
-    *   the new format string to persist (e.g., "parquet")
-    * @throws IllegalArgumentException
-    *   if `newFormat` is null or empty
-    */
-  private def format_=(newFormat: String): Unit = {
-    require(
-      newFormat != null && newFormat.nonEmpty,
-      "format must not be null or empty"
-    )
-    val currentMetadata = metadata
-    currentMetadata.format = newFormat
-    writeMetadata(currentMetadata)
-  }
+  /**
+   * Updates the file format recorded in the stored metadata.
+   *
+   * @param newFormat
+   *   the new format string to persist (e.g., "parquet")
+   * @throws IllegalArgumentException
+   *   if `newFormat` is null or empty
+   */
+
 }

--- a/src/main/scala/dev/cjfravel/ariadne/IndexPathUtils.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexPathUtils.scala
@@ -5,180 +5,162 @@ import org.apache.hadoop.fs.Path
 import org.apache.logging.log4j.LogManager
 import org.apache.spark.sql.SparkSession
 
-/** Utility object providing path resolution and lifecycle operations for
-  * indexes.
-  *
-  * All paths are resolved relative to the configured
-  * `spark.ariadne.storagePath`. This object is stateless; filesystem access is
-  * performed through temporary [[AriadneContextUser]] instances created from
-  * the implicit `SparkSession`.
-  */
+/**
+ * Utility object providing path resolution and lifecycle operations for indexes.
+ *
+ * All paths are resolved relative to the configured `spark.ariadne.storagePath`. This object is stateless; filesystem
+ * access is performed through temporary [[AriadneContextUser]] instances created from the implicit `SparkSession`.
+ */
 object IndexPathUtils {
 
   private val logger = LogManager.getLogger("ariadne")
 
-  /** Returns the base storage path for indexes under the configured Ariadne
-    * storage path.
-    *
-    * @param sparkSession
-    *   the implicit SparkSession providing configuration
-    * @return
-    *   the Hadoop Path to the `indexes` directory
-    */
+  /**
+   * Returns the base storage path for indexes under the configured Ariadne storage path.
+   *
+   * @param sparkSession
+   *   the implicit SparkSession providing configuration
+   * @return
+   *   the Hadoop Path to the `indexes` directory
+   */
   def storagePath(implicit sparkSession: SparkSession): Path = {
-    val contextUser = new AriadneContextUser {
-      implicit def spark: SparkSession = sparkSession
-    }
+    val contextUser =
+      new AriadneContextUser {
+        implicit def spark: SparkSession = sparkSession
+      }
     new Path(contextUser.storagePath, "indexes")
   }
 
-  /** Validates that an index name is safe to use as a path component.
-    *
-    * Rejects names that are null, blank, contain path separators (`/`, `\`),
-    * contain the parent-directory segment `..`, contain null bytes, or begin
-    * with `.` (to avoid colliding with hidden files). Valid index names are
-    * used directly as subdirectory names under the Ariadne storage root, so
-    * unchecked input would permit path traversal (e.g., `../foo`) or collisions
-    * with internal control files.
-    *
-    * @param name
-    *   the index name to validate
-    * @throws IllegalArgumentException
-    *   if the name is null, blank, or contains unsafe characters
-    */
+  /**
+   * Validates that an index name is safe to use as a path component.
+   *
+   * Rejects names that are null, blank, contain path separators (`/`, `\`), contain the parent-directory segment `..`,
+   * contain null bytes, or begin with `.` (to avoid colliding with hidden files). Valid index names are used directly
+   * as subdirectory names under the Ariadne storage root, so unchecked input would permit path traversal (e.g.,
+   * `../foo`) or collisions with internal control files.
+   *
+   * @param name
+   *   the index name to validate
+   * @throws IllegalArgumentException
+   *   if the name is null, blank, or contains unsafe characters
+   */
   def validateIndexName(name: String): Unit = {
-    require(
-      name != null && name.trim.nonEmpty,
-      "index name must not be null or blank"
-    )
+    require(name != null && name.trim.nonEmpty, "index name must not be null or blank")
     require(
       !name.contains('/') && !name.contains('\\') && !name.contains('\u0000'),
-      s"index name must not contain path separators or null bytes: '$name'"
-    )
-    require(
-      !name.startsWith("."),
-      s"index name must not start with '.': '$name'"
-    )
+      s"index name must not contain path separators or null bytes: '$name'")
+    require(!name.startsWith("."), s"index name must not start with '.': '$name'")
     require(
       name != ".." && !name.split("[/\\\\]").contains(".."),
-      s"index name must not contain parent-directory segments: '$name'"
-    )
+      s"index name must not contain parent-directory segments: '$name'")
   }
 
-  /** Returns the file list name for a given index name.
-    *
-    * @param name
-    *   The index name
-    * @return
-    *   The prefixed file list identifier
-    * @throws IllegalArgumentException
-    *   if name is null, blank, or contains unsafe path characters
-    */
+  /**
+   * Returns the file list name for a given index name.
+   *
+   * @param name
+   *   The index name
+   * @return
+   *   The prefixed file list identifier
+   * @throws IllegalArgumentException
+   *   if name is null, blank, or contains unsafe path characters
+   */
   def fileListName(name: String): String = {
     validateIndexName(name)
     s"[ariadne_index] $name"
   }
 
-  /** Checks whether an index with the given name exists.
-    *
-    * An index is considered to exist if either its file list entry or its
-    * storage directory is present.
-    *
-    * @note
-    *   This check is subject to a TOCTOU (time-of-check/time-of-use) race
-    *   condition — the index may be created or removed between this call and a
-    *   subsequent operation. Callers must not rely on this result for
-    *   correctness in concurrent environments; use an external lock or perform
-    *   the dependent operation defensively.
-    *
-    * @param name
-    *   The index name to check
-    * @param sparkSession
-    *   The implicit SparkSession
-    * @return
-    *   true if the index exists
-    * @throws IllegalArgumentException
-    *   if name is null, blank, or contains unsafe path characters
-    */
+  /**
+   * Checks whether an index with the given name exists.
+   *
+   * An index is considered to exist if either its file list entry or its storage directory is present.
+   *
+   * @note
+   *   This check is subject to a TOCTOU (time-of-check/time-of-use) race condition — the index may be created or
+   *   removed between this call and a subsequent operation. Callers must not rely on this result for correctness in
+   *   concurrent environments; use an external lock or perform the dependent operation defensively.
+   *
+   * @param name
+   *   The index name to check
+   * @param sparkSession
+   *   The implicit SparkSession
+   * @return
+   *   true if the index exists
+   * @throws IllegalArgumentException
+   *   if name is null, blank, or contains unsafe path characters
+   */
   def exists(name: String)(implicit sparkSession: SparkSession): Boolean = {
     validateIndexName(name)
-    val contextUser = new AriadneContextUser {
-      implicit def spark: SparkSession = sparkSession
-    }
-    FileList.exists(fileListName(name))(sparkSession) || contextUser.exists(
-      new Path(storagePath(sparkSession), name)
-    )
+    val contextUser =
+      new AriadneContextUser {
+        implicit def spark: SparkSession = sparkSession
+      }
+    FileList.exists(fileListName(name))(sparkSession) || contextUser.exists(new Path(storagePath(sparkSession), name))
   }
 
-  /** Removes an index by deleting its file list entry and storage directory.
-    *
-    * Both the file list Delta table and the index storage directory are
-    * removed. The method returns `true` if at least one resource was
-    * successfully deleted.
-    *
-    * @note
-    *   The [[exists]] guard is subject to a TOCTOU (time-of-check/time-of-use)
-    *   race — another process may remove the index between the existence check
-    *   and the actual deletion, or create a new index with the same name
-    *   concurrently. External locking is required to prevent this in
-    *   multi-process environments.
-    *
-    * @param name
-    *   the index name to remove
-    * @param sparkSession
-    *   the implicit SparkSession
-    * @return
-    *   true if any resources were successfully removed
-    * @throws IndexNotFoundException
-    *   if the index does not exist
-    * @throws IllegalArgumentException
-    *   if name is null, blank, or contains unsafe path characters
-    */
+  /**
+   * Removes an index by deleting its file list entry and storage directory.
+   *
+   * Both the file list Delta table and the index storage directory are removed. The method returns `true` if at least
+   * one resource was successfully deleted.
+   *
+   * @note
+   *   The [[exists]] guard is subject to a TOCTOU (time-of-check/time-of-use) race — another process may remove the
+   *   index between the existence check and the actual deletion, or create a new index with the same name concurrently.
+   *   External locking is required to prevent this in multi-process environments.
+   *
+   * @param name
+   *   the index name to remove
+   * @param sparkSession
+   *   the implicit SparkSession
+   * @return
+   *   true if any resources were successfully removed
+   * @throws IndexNotFoundException
+   *   if the index does not exist
+   * @throws IllegalArgumentException
+   *   if name is null, blank, or contains unsafe path characters
+   */
   def remove(name: String)(implicit sparkSession: SparkSession): Boolean = {
     validateIndexName(name)
     if (!exists(name)(sparkSession)) {
       throw new IndexNotFoundException(name)
     }
 
-    logger.warn(s"Removing index '${name}' (file list and storage directory)")
+    logger.warn(s"Removing index '$name' (file list and storage directory)")
     val startTime = System.currentTimeMillis()
-    val contextUser = new AriadneContextUser {
-      implicit def spark: SparkSession = sparkSession
-    }
+    val contextUser =
+      new AriadneContextUser {
+        implicit def spark: SparkSession = sparkSession
+      }
     val fileListRemoved =
       try {
         FileList.remove(fileListName(name))(sparkSession)
       } catch {
         case e: Exception =>
           logger.warn(
-            s"FileList removal failed for index '$name' (continuing with directory deletion): ${e.getMessage}"
-          )
+            s"FileList removal failed for index '$name' (continuing with directory deletion): ${e.getMessage}")
           false
       }
-    val result = contextUser.delete(
-      new Path(storagePath(sparkSession), name)
-    ) || fileListRemoved
+    val result = contextUser.delete(new Path(storagePath(sparkSession), name)) || fileListRemoved
     val elapsed = System.currentTimeMillis() - startTime
     logger.warn(s"Successfully removed index '$name' in ${elapsed}ms")
     result
   }
 
-  /** Cleans a filename for safe storage by replacing non-alphanumeric
-    * characters with underscores, collapsing consecutive underscores, and
-    * trimming leading/trailing underscores.
-    *
-    * @param fileName
-    *   the raw filename to clean; must not be null
-    * @return
-    *   the sanitized filename, or an empty string if input is empty
-    * @throws IllegalArgumentException
-    *   if `fileName` is null
-    */
+  /**
+   * Cleans a filename for safe storage by replacing non-alphanumeric characters with underscores, collapsing
+   * consecutive underscores, and trimming leading/trailing underscores.
+   *
+   * @param fileName
+   *   the raw filename to clean; must not be null
+   * @return
+   *   the sanitized filename, or an empty string if input is empty
+   * @throws IllegalArgumentException
+   *   if `fileName` is null
+   */
   def cleanFileName(fileName: String): String = {
     if (fileName == null) {
-      throw new IllegalArgumentException(
-        "fileName must not be null"
-      )
+      throw new IllegalArgumentException("fileName must not be null")
     }
     if (fileName.isEmpty) {
       ""
@@ -190,20 +172,22 @@ object IndexPathUtils {
     }
   }
 
-  /** Returns a temporary directory path for query staging operations.
-    *
-    * The `_temp` directory is located under the Ariadne storage path and is
-    * used for transient data during query execution.
-    *
-    * @param sparkSession
-    *   the implicit SparkSession
-    * @return
-    *   Hadoop Path to the `_temp` directory
-    */
+  /**
+   * Returns a temporary directory path for query staging operations.
+   *
+   * The `_temp` directory is located under the Ariadne storage path and is used for transient data during query
+   * execution.
+   *
+   * @param sparkSession
+   *   the implicit SparkSession
+   * @return
+   *   Hadoop Path to the `_temp` directory
+   */
   def tempPath(implicit sparkSession: SparkSession): Path = {
-    val contextUser = new AriadneContextUser {
-      implicit def spark: SparkSession = sparkSession
-    }
+    val contextUser =
+      new AriadneContextUser {
+        implicit def spark: SparkSession = sparkSession
+      }
     new Path(contextUser.storagePath, "_temp")
   }
 }

--- a/src/main/scala/dev/cjfravel/ariadne/IndexQueryOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexQueryOperations.scala
@@ -1,90 +1,87 @@
 package dev.cjfravel.ariadne
 
-import org.apache.spark.sql.{DataFrame, Row}
-
-import org.apache.spark.sql.functions._
-import org.apache.spark.sql.expressions.Window
-import io.delta.tables.DeltaTable
-import org.apache.hadoop.fs.Path
 import scala.collection.JavaConverters._
 
-/** Trait providing query and file location operations for Index instances.
-  *
-  * This is the top-level trait in the Index trait hierarchy, providing:
-  *   - File location via regular, bloom, temporal, range, and auto-bloom
-  *     indexes
-  *   - Multi-column intersection with AND semantics across index types
-  *   - Index statistics and diagnostics
-  *   - Delta table management (repartitioning, large index loading)
-  *
-  * File location uses a staged collection strategy: distinct filenames are
-  * written to temporary CSV storage before collection to avoid executor memory
-  * pressure on large result sets.
-  */
+import io.delta.tables.DeltaTable
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.expressions.Window
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.{DataFrame, Row}
+
+/**
+ * Trait providing query and file location operations for Index instances.
+ *
+ * This is the top-level trait in the Index trait hierarchy, providing:
+ *   - File location via regular, bloom, temporal, range, and auto-bloom indexes
+ *   - Multi-column intersection with AND semantics across index types
+ *   - Index statistics and diagnostics
+ *   - Delta table management (repartitioning, large index loading)
+ *
+ * File location uses a staged collection strategy: distinct filenames are written to temporary CSV storage before
+ * collection to avoid executor memory pressure on large result sets.
+ */
 trait IndexQueryOperations extends IndexJoinOperations {
   self: Index =>
 
-  /** Conditionally repartitions a DataFrame if indexRepartitionCount is
-    * configured. This helps avoid FetchFailedExceptions when working with very
-    * large index DataFrames by spreading data across more partitions before
-    * expensive operations like explode.
-    *
-    * @param df
-    *   The DataFrame to potentially repartition
-    * @return
-    *   Repartitioned DataFrame if configured, otherwise the original DataFrame
-    */
-  protected def maybeRepartition(df: DataFrame): DataFrame = {
+  /**
+   * Conditionally repartitions a DataFrame if indexRepartitionCount is configured. This helps avoid
+   * FetchFailedExceptions when working with very large index DataFrames by spreading data across more partitions before
+   * expensive operations like explode.
+   *
+   * @param df
+   *   The DataFrame to potentially repartition
+   * @return
+   *   Repartitioned DataFrame if configured, otherwise the original DataFrame
+   */
+  protected def maybeRepartition(df: DataFrame): DataFrame =
     indexRepartitionCount match {
       case Some(count) =>
         logger.warn(s"Repartitioning DataFrame to $count partitions")
         df.repartition(count)
       case None => df
     }
-  }
 
-  /** Helper function to load the index.
-    *
-    * On first call, checks for and performs any needed exploded field column
-    * migration (pre-0.1.1 indexes stored columns under `array_column` names).
-    *
-    * @return
-    *   `Some(DataFrame)` containing the latest version of the index, or `None`
-    *   if the index Delta table does not yet exist
-    */
+  /**
+   * Helper function to load the index.
+   *
+   * On first call, checks for and performs any needed exploded field column migration (pre-0.1.1 indexes stored columns
+   * under `array_column` names).
+   *
+   * @return
+   *   `Some(DataFrame)` containing the latest version of the index, or `None` if the index Delta table does not yet
+   *   exist
+   */
   protected def index: Option[DataFrame] = {
     migrateExplodedFieldColumns()
     delta(indexFilePath).map(_.toDF)
   }
 
-  /** Returns the set of column names that have large index Delta tables.
-    *
-    * @return
-    *   Set of column names with large index storage
-    */
-  protected def largeIndexColumns: Set[String] = {
+  /**
+   * Returns the set of column names that have large index Delta tables.
+   *
+   * @return
+   *   Set of column names with large index storage
+   */
+  protected def largeIndexColumns: Set[String] =
     if (!exists(largeIndexesFilePath)) Set.empty
     else {
       fs.listStatus(largeIndexesFilePath)
         .filter(_.isDirectory)
         .map(_.getPath)
-        .filter(path =>
-          exists(path) && DeltaTable.isDeltaTable(spark, path.toString)
-        )
+        .filter(path => exists(path) && DeltaTable.isDeltaTable(spark, path.toString))
         .map(_.getName)
         .toSet
     }
-  }
 
-  /** Loads a large index Delta table for a specific column. Large indexes store
-    * data in exploded (filename, value) row form rather than as arrays.
-    *
-    * @param colName
-    *   The column name
-    * @return
-    *   DataFrame with (filename, colName) rows, or None if no large index
-    *   exists
-    */
+  /**
+   * Loads a large index Delta table for a specific column. Large indexes store data in exploded (filename, value) row
+   * form rather than as arrays.
+   *
+   * @param colName
+   *   The column name
+   * @return
+   *   DataFrame with (filename, colName) rows, or None if no large index exists
+   */
   protected def loadLargeIndex(colName: String): Option[DataFrame] = {
     val columnPath = new Path(largeIndexesFilePath, colName)
     try {
@@ -96,41 +93,37 @@ trait IndexQueryOperations extends IndexJoinOperations {
       else None
     } catch {
       case e: Exception =>
-        logger.warn(
-          s"Failed to load large index for column '$colName' in index '$name': ${e.getMessage}"
-        )
+        logger.warn(s"Failed to load large index for column '$colName' in index '$name': ${e.getMessage}")
         None
     }
   }
 
-  /** Returns a unified (filename, colName) DataFrame for a regular index column
-    * by exploding the main index arrays and unioning with any large index rows
-    * that exist for that column.
-    *
-    * @param indexDf
-    *   The main index DataFrame (may be repartitioned)
-    * @param colName
-    *   The storage column name
-    * @param bloomCandidateFiles
-    *   Optional set of files that passed auto-bloom pre-filtering. When
-    *   provided, only large index rows for these files are included.
-    * @return
-    *   DataFrame with (filename, colName) scalar rows
-    */
+  /**
+   * Returns a unified (filename, colName) DataFrame for a regular index column by exploding the main index arrays and
+   * unioning with any large index rows that exist for that column.
+   *
+   * @param indexDf
+   *   The main index DataFrame (may be repartitioned)
+   * @param colName
+   *   The storage column name
+   * @param bloomCandidateFiles
+   *   Optional set of files that passed auto-bloom pre-filtering. When provided, only large index rows for these files
+   *   are included.
+   * @return
+   *   DataFrame with (filename, colName) scalar rows
+   */
   protected def loadColumnIndex(
       indexDf: DataFrame,
       colName: String,
-      bloomCandidateFiles: Option[Set[String]] = None
-  ): DataFrame = {
-    val mainRows = indexDf
-      .select(col("filename"), explode(col(colName)).alias(colName))
+      bloomCandidateFiles: Option[Set[String]] = None): DataFrame = {
+    val mainRows =
+      indexDf
+        .select(col("filename"), explode(col(colName)).alias(colName))
     loadLargeIndex(colName) match {
       case Some(largeDf) =>
         bloomCandidateFiles match {
           case Some(candidates) if candidates.nonEmpty =>
-            logger.warn(
-              s"Filtering large index for $colName to ${candidates.size} bloom-candidate files"
-            )
+            logger.warn(s"Filtering large index for $colName to ${candidates.size} bloom-candidate files")
             val filteredLarge =
               largeDf.where(col("filename").isin(candidates.toSeq: _*))
             mainRows.union(filteredLarge)
@@ -141,68 +134,57 @@ trait IndexQueryOperations extends IndexJoinOperations {
     }
   }
 
-  /** Returns a unified (filename, _value, _max_ts) DataFrame for a temporal
-    * index column by exploding the main index struct arrays and unioning with
-    * any large index rows that exist for that column.
-    *
-    * @param indexDf
-    *   The main index DataFrame (may be repartitioned)
-    * @param colName
-    *   The temporal column name
-    * @return
-    *   DataFrame with (filename, _value, _max_ts) rows
-    */
-  protected def loadTemporalColumnIndex(
-      indexDf: DataFrame,
-      colName: String
-  ): DataFrame = {
-    val mainRows = indexDf
-      .select(col("filename"), explode(col(colName)).alias("_temporal"))
-      .select(
-        col("filename"),
-        col("_temporal.value").alias("_value"),
-        col("_temporal.max_ts").alias("_max_ts")
-      )
+  /**
+   * Returns a unified (filename, _value, _max_ts) DataFrame for a temporal index column by exploding the main index
+   * struct arrays and unioning with any large index rows that exist for that column.
+   *
+   * @param indexDf
+   *   The main index DataFrame (may be repartitioned)
+   * @param colName
+   *   The temporal column name
+   * @return
+   *   DataFrame with (filename, _value, _max_ts) rows
+   */
+  protected def loadTemporalColumnIndex(indexDf: DataFrame, colName: String): DataFrame = {
+    val mainRows =
+      indexDf
+        .select(col("filename"), explode(col(colName)).alias("_temporal"))
+        .select(col("filename"), col("_temporal.value").alias("_value"), col("_temporal.max_ts").alias("_max_ts"))
     loadLargeIndex(colName) match {
       case Some(largeDf) =>
-        val largeRows = largeDf
-          .select(
-            col("filename"),
-            col(s"$colName.value").alias("_value"),
-            col(s"$colName.max_ts").alias("_max_ts")
-          )
+        val largeRows =
+          largeDf
+            .select(col("filename"), col(s"$colName.value").alias("_value"), col(s"$colName.max_ts").alias("_max_ts"))
         mainRows.union(largeRows)
       case None => mainRows
     }
   }
 
-  /** Locates files matching the given index values across all index types.
-    *
-    * Queries regular, bloom, temporal, range, and auto-bloom indexes in
-    * parallel and intersects results with AND semantics. Each index type
-    * independently returns candidate files, and only files present in all
-    * queried categories are included in the final result.
-    *
-    * @param indexes
-    *   A map of index column names to arrays of values to search for. Columns
-    *   are automatically routed to the appropriate index type (bloom, temporal,
-    *   range, or regular).
-    * @return
-    *   A set of file paths matching all query criteria, or an empty set if no
-    *   matches are found or no index exists
-    *
-    * @throws IllegalArgumentException
-    *   if `indexes` is null
-    *
-    * @note
-    *   If a staging table exists, its contents are collected to the driver for
-    *   merging. This may cause driver OOM for very large staging tables.
-    *
-    * @example
-    *   {{{
-    * val matchingFiles = index.locateFiles(Map("userId" -> Array("u1", "u2")))
-    *   }}}
-    */
+  /**
+   * Locates files matching the given index values across all index types.
+   *
+   * Queries regular, bloom, temporal, range, and auto-bloom indexes in parallel and intersects results with AND
+   * semantics. Each index type independently returns candidate files, and only files present in all queried categories
+   * are included in the final result.
+   *
+   * @param indexes
+   *   A map of index column names to arrays of values to search for. Columns are automatically routed to the
+   *   appropriate index type (bloom, temporal, range, or regular).
+   * @return
+   *   A set of file paths matching all query criteria, or an empty set if no matches are found or no index exists
+   *
+   * @throws IllegalArgumentException
+   *   if `indexes` is null
+   *
+   * @note
+   *   If a staging table exists, its contents are collected to the driver for merging. This may cause driver OOM for
+   *   very large staging tables.
+   *
+   * @example
+   *   {{{
+   * val matchingFiles = index.locateFiles(Map("userId" -> Array("u1", "u2")))
+   *   }}}
+   */
   def locateFiles(indexes: Map[String, Array[Any]]): Set[String] = {
     require(indexes != null, "columnValues must not be null")
     val locateStart = System.currentTimeMillis()
@@ -215,126 +197,119 @@ trait IndexQueryOperations extends IndexJoinOperations {
         val temporalColumnSet =
           metadata.temporal_indexes.asScala.map(_.column).toSet
         val rangeColumnSet = metadata.range_indexes.asScala.map(_.column).toSet
-        val (bloomQueries, nonBloomQueries) = indexes.partition {
-          case (col, _) => bloomColumnSet.contains(col)
-        }
-        val (temporalQueries, nonTemporalQueries) = nonBloomQueries.partition {
-          case (col, _) => temporalColumnSet.contains(col)
-        }
-        val (rangeQueries, regularQueries) = nonTemporalQueries.partition {
-          case (col, _) => rangeColumnSet.contains(col)
-        }
+        val (bloomQueries, nonBloomQueries) = indexes.partition { case (col, _) => bloomColumnSet.contains(col) }
+        val (temporalQueries, nonTemporalQueries) =
+          nonBloomQueries.partition { case (col, _) => temporalColumnSet.contains(col) }
+        val (rangeQueries, regularQueries) =
+          nonTemporalQueries.partition { case (col, _) => rangeColumnSet.contains(col) }
 
         // Get files from bloom filters
         val bloomStart = System.currentTimeMillis()
-        val bloomFiles = if (bloomQueries.nonEmpty) {
-          bloomQueries
-            .map { case (col, values) =>
-              locateFilesWithBloom(col, values, df)
-            }
-            .reduce(_ intersect _)
-        } else {
-          Set.empty[String]
-        }
+        val bloomFiles =
+          if (bloomQueries.nonEmpty) {
+            bloomQueries
+              .map { case (col, values) =>
+                locateFilesWithBloom(col, values, df)
+              }
+              .reduce(_ intersect _)
+          } else {
+            Set.empty[String]
+          }
         val bloomMs = System.currentTimeMillis() - bloomStart
 
         // Get files from temporal indexes (pruned to latest timestamp per value)
         val temporalStart = System.currentTimeMillis()
-        val temporalFiles = if (temporalQueries.nonEmpty) {
-          temporalQueries
-            .map { case (column, values) =>
-              locateFilesWithTemporal(column, values, df)
-            }
-            .reduce(_ intersect _)
-        } else {
-          Set.empty[String]
-        }
+        val temporalFiles =
+          if (temporalQueries.nonEmpty) {
+            temporalQueries
+              .map { case (column, values) =>
+                locateFilesWithTemporal(column, values, df)
+              }
+              .reduce(_ intersect _)
+          } else {
+            Set.empty[String]
+          }
         val temporalMs = System.currentTimeMillis() - temporalStart
 
         // Get files from range indexes
         val rangeStart = System.currentTimeMillis()
-        val rangeFiles = if (rangeQueries.nonEmpty) {
-          rangeQueries
-            .map { case (column, values) =>
-              locateFilesWithRange(column, values, df)
-            }
-            .reduce(_ intersect _)
-        } else {
-          Set.empty[String]
-        }
+        val rangeFiles =
+          if (rangeQueries.nonEmpty) {
+            rangeQueries
+              .map { case (column, values) =>
+                locateFilesWithRange(column, values, df)
+              }
+              .reduce(_ intersect _)
+          } else {
+            Set.empty[String]
+          }
         val rangeMs = System.currentTimeMillis() - rangeStart
 
         // Get files from regular indexes
         val regularStart = System.currentTimeMillis()
-        val regularFiles = if (regularQueries.nonEmpty) {
-          locateFilesRegular(regularQueries, df)
-        } else {
-          Set.empty[String]
-        }
+        val regularFiles =
+          if (regularQueries.nonEmpty) {
+            locateFilesRegular(regularQueries, df)
+          } else {
+            Set.empty[String]
+          }
         val regularMs = System.currentTimeMillis() - regularStart
 
         // Combine results - intersect across types that returned results (AND semantics)
         // Track which categories were queried (had input), not just which returned results
-        val queriedResults: Seq[Set[String]] = Seq(
-          if (bloomQueries.nonEmpty) Some(bloomFiles) else None,
-          if (temporalQueries.nonEmpty) Some(temporalFiles) else None,
-          if (rangeQueries.nonEmpty) Some(rangeFiles) else None,
-          if (regularQueries.nonEmpty) Some(regularFiles) else None
-        ).flatten
+        val queriedResults: Seq[Set[String]] =
+          Seq(
+            if (bloomQueries.nonEmpty) Some(bloomFiles) else None,
+            if (temporalQueries.nonEmpty) Some(temporalFiles) else None,
+            if (rangeQueries.nonEmpty) Some(rangeFiles) else None,
+            if (regularQueries.nonEmpty) Some(regularFiles) else None).flatten
 
-        val allFiles = if (queriedResults.isEmpty) {
-          Set.empty[String]
-        } else {
-          queriedResults.reduce(_ intersect _)
-        }
+        val allFiles =
+          if (queriedResults.isEmpty) {
+            Set.empty[String]
+          } else {
+            queriedResults.reduce(_ intersect _)
+          }
         if (debugEnabled) {
           logger.warn(
             s"[debug] Cross-type combination: bloom=${bloomFiles.size}, temporal=${temporalFiles.size}, " +
-              s"range=${rangeFiles.size}, regular=${regularFiles.size} -> final=${allFiles.size}"
-          )
+              s"range=${rangeFiles.size}, regular=${regularFiles.size} -> final=${allFiles.size}")
         }
         val totalMs = System.currentTimeMillis() - locateStart
         logger.warn(
           s"locateFiles: ${allFiles.size} files matched in ${totalMs}ms " +
-            s"(bloom=${bloomMs}ms, temporal=${temporalMs}ms, range=${rangeMs}ms, regular=${regularMs}ms)"
-        )
+            s"(bloom=${bloomMs}ms, temporal=${temporalMs}ms, range=${rangeMs}ms, regular=${regularMs}ms)")
         if (allFiles.isEmpty) Set.empty else allFiles
       case None =>
-        logger.warn(
-          s"Index table not found for index '$name'; returning empty file set"
-        )
+        logger.warn(s"Index table not found for index '$name'; returning empty file set")
         Set.empty
     }
   }
 
-  /** Collects filenames via staging through temporary CSV storage.
-    *
-    * Separates the distributed distinct operation from the driver-side collect
-    * to avoid executor memory pressure on large result sets. Writes distinct
-    * filenames to a temporary CSV path, then reads them back and collects. The
-    * temporary path is cleaned up in a finally block.
-    *
-    * @note
-    *   All distinct filenames are collected to the driver. For indexes with
-    *   millions of files, this can cause driver OOM.
-    *
-    * @param resultDF
-    *   DataFrame containing a "filename" column to collect
-    * @return
-    *   Set of distinct filenames collected from the staged CSV
-    */
+  /**
+   * Collects filenames via staging through temporary CSV storage.
+   *
+   * Separates the distributed distinct operation from the driver-side collect to avoid executor memory pressure on
+   * large result sets. Writes distinct filenames to a temporary CSV path, then reads them back and collects. The
+   * temporary path is cleaned up in a finally block.
+   *
+   * @note
+   *   All distinct filenames are collected to the driver. For indexes with millions of files, this can cause driver
+   *   OOM.
+   *
+   * @param resultDF
+   *   DataFrame containing a "filename" column to collect
+   * @return
+   *   Set of distinct filenames collected from the staged CSV
+   */
   private def collectFilenamesViaStaging(resultDF: DataFrame): Set[String] = {
     val stagingStart = System.currentTimeMillis()
-    val tempPath = new Path(
-      IndexPathUtils.tempPath,
-      s"query_files_${System.currentTimeMillis()}_${java.util.UUID.randomUUID()}"
-    )
+    val tempPath =
+      new Path(IndexPathUtils.tempPath, s"query_files_${System.currentTimeMillis()}_${java.util.UUID.randomUUID()}")
 
     try {
       if (debugEnabled) {
-        logger.warn(
-          s"[debug] collectFilenamesViaStaging: writing distinct filenames to $tempPath"
-        )
+        logger.warn(s"[debug] collectFilenamesViaStaging: writing distinct filenames to $tempPath")
       }
       // Write distinct filenames to temp location (distributed operation)
       // Using CSV for simplicity and easier debugging (single column of strings)
@@ -347,26 +322,27 @@ trait IndexQueryOperations extends IndexJoinOperations {
 
       if (debugEnabled) {
         logger.warn(
-          s"[debug] collectFilenamesViaStaging: CSV write completed in ${System.currentTimeMillis() - stagingStart}ms"
-        )
+          s"[debug] collectFilenamesViaStaging: CSV write completed in ${System.currentTimeMillis() - stagingStart}ms")
       }
 
       logger.debug(s"Staged filenames to $tempPath")
 
       // Read back from temp (simple, optimized operation)
-      val stagedFiles = spark.read
-        .option("header", "true")
-        .csv(tempPath.toString)
-        .select("filename")
+      val stagedFiles =
+        spark.read
+          .option("header", "true")
+          .csv(tempPath.toString)
+          .select("filename")
 
       val collectedFiles = stagedFiles.collect()
       val fileCount = collectedFiles.length
       logger.warn(s"Collecting $fileCount distinct filenames from staging")
 
-      val files = collectedFiles
-        .map(_.getString(0))
-        .filter(_ != null)
-        .toSet
+      val files =
+        collectedFiles
+          .map(_.getString(0))
+          .filter(_ != null)
+          .toSet
 
       if (debugEnabled) {
         logger.warn(s"[debug] collectFilenamesViaStaging: complete in ${System
@@ -388,196 +364,179 @@ trait IndexQueryOperations extends IndexJoinOperations {
     }
   }
 
-  /** Gets candidate files from the auto-bloom filter for a specific column.
-    *
-    * Collects all bloom filter byte arrays from the index to the driver and
-    * tests each value against them. Files whose bloom filter is null are
-    * included as candidates for backward compatibility with indexes built
-    * before auto-bloom was added.
-    *
-    * @note
-    *   This method collects all (filename, bloom_filter_bytes) rows to the
-    *   driver. For very large indexes (100k+ files), this can cause driver OOM.
-    *   Monitor driver memory when using auto-bloom on large indexes.
-    *
-    * @param column
-    *   The storage column name to check for auto-bloom filtering
-    * @param values
-    *   Array of values to probe against each file's bloom filter
-    * @param indexDf
-    *   The main index DataFrame containing auto-bloom binary columns
-    * @return
-    *   Some(set of candidate filenames) if an auto-bloom index exists for the
-    *   column, None otherwise
-    */
-  protected def getAutoBloomCandidates(
-      column: String,
-      values: Array[Any],
-      indexDf: DataFrame
-  ): Option[Set[String]] = {
+  /**
+   * Gets candidate files from the auto-bloom filter for a specific column.
+   *
+   * Collects all bloom filter byte arrays from the index to the driver and tests each value against them. Files whose
+   * bloom filter is null are included as candidates for backward compatibility with indexes built before auto-bloom was
+   * added.
+   *
+   * @note
+   *   This method collects all (filename, bloom_filter_bytes) rows to the driver. For very large indexes (100k+ files),
+   *   this can cause driver OOM. Monitor driver memory when using auto-bloom on large indexes.
+   *
+   * @param column
+   *   The storage column name to check for auto-bloom filtering
+   * @param values
+   *   Array of values to probe against each file's bloom filter
+   * @param indexDf
+   *   The main index DataFrame containing auto-bloom binary columns
+   * @return
+   *   Some(set of candidate filenames) if an auto-bloom index exists for the column, None otherwise
+   */
+  protected def getAutoBloomCandidates(column: String, values: Array[Any], indexDf: DataFrame): Option[Set[String]] =
     if (!metadata.auto_bloom_indexes.asScala.contains(column)) None
     else {
-      val autoBloomCol = s"auto_bloom_${column}"
+      val autoBloomCol = s"auto_bloom_$column"
       if (!indexDf.columns.contains(autoBloomCol)) None
       else {
         val rowCount = indexDf.count()
         if (rowCount > 100000) {
           logger.warn(
-            s"getAutoBloomCandidates: collecting $rowCount rows to driver for column '$column' — risk of driver OOM on very large indexes"
-          )
+            s"getAutoBloomCandidates: collecting $rowCount rows to driver for column '$column' — " +
+              s"risk of driver OOM on very large indexes")
         }
 
-        val allRows = indexDf
-          .select("filename", autoBloomCol)
-          .collect()
+        val allRows =
+          indexDf
+            .select("filename", autoBloomCol)
+            .collect()
 
-        val candidates = allRows
-          .filter { row =>
-            val bloomBytes = row.getAs[Array[Byte]](autoBloomCol)
-            if (bloomBytes == null) true
-            else values.exists(v => bloomMightContain(bloomBytes, v))
-          }
-          .map(_.getString(0))
-          .toSet
+        val candidates =
+          allRows
+            .filter { row =>
+              val bloomBytes = row.getAs[Array[Byte]](autoBloomCol)
+              if (bloomBytes == null) true
+              else values.exists(v => bloomMightContain(bloomBytes, v))
+            }
+            .map(_.getString(0))
+            .toSet
 
         val totalFiles = allRows.length
         val reduction =
-          if (totalFiles > 0) 100 - (candidates.size * 100 / totalFiles) else 0
+          if (totalFiles > 0) 100 - candidates.size * 100 / totalFiles else 0
         logger.warn(
-          s"Auto-bloom filter for '$column': $totalFiles total files -> ${candidates.size} candidates ($reduction% reduction)"
-        )
+          s"Auto-bloom filter for '$column': $totalFiles total files -> " +
+            s"${candidates.size} candidates ($reduction% reduction)")
         Some(candidates)
       }
     }
-  }
 
-  /** Gets candidate files from the auto-bloom filter using values extracted
-    * from a DataFrame.
-    *
-    * Collects distinct non-null values from the given DataFrame column, then
-    * delegates to [[getAutoBloomCandidates]] for the actual bloom filter
-    * probing.
-    *
-    * @note
-    *   This method collects distinct values from `valuesDf` to the driver and
-    *   then delegates to [[getAutoBloomCandidates]], which collects all bloom
-    *   filter rows. Both collections can cause driver OOM on large indexes.
-    *
-    * @param storageColumn
-    *   The storage column name in the index (used to look up the auto-bloom)
-    * @param joinColumn
-    *   The column name in `valuesDf` containing the query values
-    * @param valuesDf
-    *   DataFrame containing the values to probe against bloom filters
-    * @param indexDf
-    *   The main index DataFrame containing auto-bloom binary columns
-    * @return
-    *   Some(set of candidate filenames) if an auto-bloom index exists, None
-    *   otherwise
-    */
+  /**
+   * Gets candidate files from the auto-bloom filter using values extracted from a DataFrame.
+   *
+   * Collects distinct non-null values from the given DataFrame column, then delegates to [[getAutoBloomCandidates]] for
+   * the actual bloom filter probing.
+   *
+   * @note
+   *   This method collects distinct values from `valuesDf` to the driver and then delegates to
+   *   [[getAutoBloomCandidates]], which collects all bloom filter rows. Both collections can cause driver OOM on large
+   *   indexes.
+   *
+   * @param storageColumn
+   *   The storage column name in the index (used to look up the auto-bloom)
+   * @param joinColumn
+   *   The column name in `valuesDf` containing the query values
+   * @param valuesDf
+   *   DataFrame containing the values to probe against bloom filters
+   * @param indexDf
+   *   The main index DataFrame containing auto-bloom binary columns
+   * @return
+   *   Some(set of candidate filenames) if an auto-bloom index exists, None otherwise
+   */
   protected def getAutoBloomCandidatesFromDf(
       storageColumn: String,
       joinColumn: String,
       valuesDf: DataFrame,
-      indexDf: DataFrame
-  ): Option[Set[String]] = {
+      indexDf: DataFrame): Option[Set[String]] =
     if (!metadata.auto_bloom_indexes.asScala.contains(storageColumn)) None
     else {
-      val autoBloomCol = s"auto_bloom_${storageColumn}"
+      val autoBloomCol = s"auto_bloom_$storageColumn"
       if (!indexDf.columns.contains(autoBloomCol)) None
       else {
-        val values = valuesDf
-          .select(joinColumn)
-          .where(col(joinColumn).isNotNull)
-          .distinct()
-          .collect()
-          .map(_.get(0))
+        val values =
+          valuesDf
+            .select(joinColumn)
+            .where(col(joinColumn).isNotNull)
+            .distinct()
+            .collect()
+            .map(_.get(0))
 
         if (values.isEmpty) None
         else getAutoBloomCandidates(storageColumn, values, indexDf)
       }
     }
-  }
 
-  /** Locates files using regular (non-bloom, non-temporal, non-range) indexes.
-    *
-    * For each column, explodes the index arrays and filters to matching values,
-    * optionally using auto-bloom pre-filtering. When multiple columns are
-    * queried, results are intersected (AND semantics) via inner joins on
-    * filename.
-    *
-    * @param indexes
-    *   A map of storage column names to arrays of values to match
-    * @param df
-    *   The main index DataFrame
-    * @return
-    *   Set of filenames matching all specified column values
-    */
-  private def locateFilesRegular(
-      indexes: Map[String, Array[Any]],
-      df: DataFrame
-  ): Set[String] = {
+  /**
+   * Locates files using regular (non-bloom, non-temporal, non-range) indexes.
+   *
+   * For each column, explodes the index arrays and filters to matching values, optionally using auto-bloom
+   * pre-filtering. When multiple columns are queried, results are intersected (AND semantics) via inner joins on
+   * filename.
+   *
+   * @param indexes
+   *   A map of storage column names to arrays of values to match
+   * @param df
+   *   The main index DataFrame
+   * @return
+   *   Set of filenames matching all specified column values
+   */
+  private def locateFilesRegular(indexes: Map[String, Array[Any]], df: DataFrame): Set[String] =
     if (indexes.isEmpty) {
       Set.empty
     } else {
       // Filter null values from each column — isin() throws on an empty array
-      val filteredIndexes = indexes.map { case (column, values) =>
-        column -> values.filter(_ != null)
-      }
+      val filteredIndexes =
+        indexes.map { case (column, values) =>
+          column -> values.filter(_ != null)
+        }
       if (filteredIndexes.exists(_._2.isEmpty)) {
         val emptyColumns =
           filteredIndexes.filter(_._2.isEmpty).keys.mkString(", ")
-        logger.debug(
-          s"locateFilesRegular: columns [$emptyColumns] have no non-null values, returning empty result"
-        )
+        logger.debug(s"locateFilesRegular: columns [$emptyColumns] have no non-null values, returning empty result")
         Set.empty[String]
       } else {
-        val perColumnFiles = filteredIndexes.map { case (column, values) =>
-          val bloomCandidates = getAutoBloomCandidates(column, values, df)
-          loadColumnIndex(df, column, bloomCandidates)
-            .where(col(column).isin(values: _*))
-            .select("filename")
-            .distinct
-        }.toSeq
+        val perColumnFiles =
+          filteredIndexes.map { case (column, values) =>
+            val bloomCandidates = getAutoBloomCandidates(column, values, df)
+            loadColumnIndex(df, column, bloomCandidates)
+              .where(col(column).isin(values: _*))
+              .select("filename")
+              .distinct
+          }.toSeq
 
-        val intersectedDF = if (perColumnFiles.size == 1) {
-          perColumnFiles.head
-        } else {
-          perColumnFiles.reduce((a, b) => a.join(b, Seq("filename"), "inner"))
-        }
+        val intersectedDF =
+          if (perColumnFiles.size == 1) {
+            perColumnFiles.head
+          } else {
+            perColumnFiles.reduce((a, b) => a.join(b, Seq("filename"), "inner"))
+          }
 
         val result = collectFilenamesViaStaging(intersectedDF)
         if (debugEnabled && indexes.size > 1) {
-          logger.warn(
-            s"[debug] Multi-column intersection: ${indexes.size} columns, result: ${result.size} files"
-          )
+          logger.warn(s"[debug] Multi-column intersection: ${indexes.size} columns, result: ${result.size} files")
         }
         result
       }
     }
-  }
 
-  /** Locates files using temporal indexes, pruning to only files containing the
-    * latest version of each value (by max timestamp).
-    *
-    * Uses a window function partitioned by value, ordered by max_ts descending,
-    * keeping only rank 1 to ensure only the most recent file per value is
-    * returned.
-    *
-    * @param column
-    *   The temporal index value column name
-    * @param values
-    *   Array of values to search for in the temporal index
-    * @param df
-    *   The main index DataFrame containing temporal struct arrays
-    * @return
-    *   Set of filenames containing the latest version of any matching value
-    */
-  private def locateFilesWithTemporal(
-      column: String,
-      values: Array[Any],
-      df: DataFrame
-  ): Set[String] = {
+  /**
+   * Locates files using temporal indexes, pruning to only files containing the latest version of each value (by max
+   * timestamp).
+   *
+   * Uses a window function partitioned by value, ordered by max_ts descending, keeping only rank 1 to ensure only the
+   * most recent file per value is returned.
+   *
+   * @param column
+   *   The temporal index value column name
+   * @param values
+   *   Array of values to search for in the temporal index
+   * @param df
+   *   The main index DataFrame containing temporal struct arrays
+   * @return
+   *   Set of filenames containing the latest version of any matching value
+   */
+  private def locateFilesWithTemporal(column: String, values: Array[Any], df: DataFrame): Set[String] = {
     val allExploded = loadTemporalColumnIndex(df, column)
 
     // Filter to requested values
@@ -585,115 +544,94 @@ trait IndexQueryOperations extends IndexJoinOperations {
 
     // For each value, keep only the file with the latest timestamp
     val w = Window.partitionBy("_value").orderBy(col("_max_ts").desc_nulls_last)
-    val pruned = filtered
-      .withColumn("_rank", row_number().over(w))
-      .filter(col("_rank") === 1)
-      .select("filename")
-      .distinct()
+    val pruned =
+      filtered
+        .withColumn("_rank", row_number().over(w))
+        .filter(col("_rank") === 1)
+        .select("filename")
+        .distinct()
 
     collectFilenamesViaStaging(pruned)
   }
 
-  /** Locates files using range indexes by checking if any query value falls
-    * within the file's [min, max] range.
-    *
-    * Builds an OR condition across all values, checking file_min <= value AND
-    * file_max >= value for each. Logs a warning when value count exceeds 1000.
-    *
-    * @param column
-    *   The range index column name
-    * @param values
-    *   Array of values to check against per-file min/max ranges
-    * @param indexDf
-    *   The main index DataFrame containing range struct columns
-    * @return
-    *   Set of filenames whose stored range contains at least one query value
-    */
-  private def locateFilesWithRange(
-      column: String,
-      values: Array[Any],
-      indexDf: DataFrame
-  ): Set[String] = {
-    val rangeCol = s"range_${column}"
+  /**
+   * Locates files using range indexes by checking if any query value falls within the file's [min, max] range.
+   *
+   * Builds an OR condition across all values, checking file_min <= value AND file_max >= value for each. Logs a warning
+   * when value count exceeds 1000.
+   *
+   * @param column
+   *   The range index column name
+   * @param values
+   *   Array of values to check against per-file min/max ranges
+   * @param indexDf
+   *   The main index DataFrame containing range struct columns
+   * @return
+   *   Set of filenames whose stored range contains at least one query value
+   */
+  private def locateFilesWithRange(column: String, values: Array[Any], indexDf: DataFrame): Set[String] = {
+    val rangeCol = s"range_$column"
     if (!indexDf.columns.contains(rangeCol)) {
-      logger.warn(
-        s"Range column $rangeCol not found in index, returning empty result"
-      )
+      logger.warn(s"Range column $rangeCol not found in index, returning empty result")
       Set.empty
     } else if (values.isEmpty) {
       Set.empty
     } else {
-      logger.warn(
-        s"Range query on column '$column' with ${values.length} values"
-      )
+      logger.warn(s"Range query on column '$column' with ${values.length} values")
       if (values.length > 1000) {
-        logger.warn(
-          s"Range query has ${values.length} values; large OR expression may be slow"
-        )
+        logger.warn(s"Range query has ${values.length} values; large OR expression may be slow")
       }
 
       // Use Spark lit() for type-safe comparisons instead of Comparable casts.
       // This handles type coercion (e.g. Long vs Int) and NaN correctly.
-      val valueConditions = values.map { v =>
-        col("file_min") <= lit(v) && col("file_max") >= lit(v)
-      }
+      val valueConditions = values.map(v => col("file_min") <= lit(v) && col("file_max") >= lit(v))
 
-      val matchingFiles = indexDf
-        .select(
-          col("filename"),
-          col(s"$rangeCol.min").alias("file_min"),
-          col(s"$rangeCol.max").alias("file_max")
-        )
-        .where(col("file_min").isNotNull && col("file_max").isNotNull)
-        .where(valueConditions.reduce(_ || _))
-        .select("filename")
-        .distinct()
+      val matchingFiles =
+        indexDf
+          .select(col("filename"), col(s"$rangeCol.min").alias("file_min"), col(s"$rangeCol.max").alias("file_max"))
+          .where(col("file_min").isNotNull && col("file_max").isNotNull)
+          .where(valueConditions.reduce(_ || _))
+          .select("filename")
+          .distinct()
 
       collectFilenamesViaStaging(matchingFiles)
     }
   }
 
-  /** Locates files based on a DataFrame containing join column values. Handles
-    * both regular indexes and bloom filter indexes.
-    *
-    * @param valuesDf
-    *   DataFrame containing the distinct values to search for
-    * @param columnMappings
-    *   Map from join column names to storage column names in the index
-    * @param joinColumns
-    *   The columns to use for filtering
-    * @return
-    *   A set of file names matching the criteria.
-    *
-    * @throws IllegalArgumentException
-    *   if `valuesDf` is null or `columnMappings` is null or empty
-    *
-    * @example
-    *   {{{
-    * val columnMappings = Map("userId" -> "userId")
-    * val files = index.locateFilesFromDataFrame(lookupDf, columnMappings, Seq("userId"))
-    *   }}}
-    */
+  /**
+   * Locates files based on a DataFrame containing join column values. Handles both regular indexes and bloom filter
+   * indexes.
+   *
+   * @param valuesDf
+   *   DataFrame containing the distinct values to search for
+   * @param columnMappings
+   *   Map from join column names to storage column names in the index
+   * @param joinColumns
+   *   The columns to use for filtering
+   * @return
+   *   A set of file names matching the criteria.
+   *
+   * @throws IllegalArgumentException
+   *   if `valuesDf` is null or `columnMappings` is null or empty
+   *
+   * @example
+   *   {{{
+   * val columnMappings = Map("userId" -> "userId")
+   * val files = index.locateFilesFromDataFrame(lookupDf, columnMappings, Seq("userId"))
+   *   }}}
+   */
   def locateFilesFromDataFrame(
       valuesDf: DataFrame,
       columnMappings: Map[String, String],
-      joinColumns: Seq[String]
-  ): Set[String] = {
+      joinColumns: Seq[String]): Set[String] = {
     require(valuesDf != null, "DataFrame must not be null")
-    require(
-      columnMappings != null && columnMappings.nonEmpty,
-      "columnMappings must not be null or empty"
-    )
+    require(columnMappings != null && columnMappings.nonEmpty, "columnMappings must not be null or empty")
     val locateStart = System.currentTimeMillis()
-    logger.warn(
-      s"locateFilesFromDataFrame: querying columns ${joinColumns.mkString(", ")}"
-    )
+    logger.warn(s"locateFilesFromDataFrame: querying columns ${joinColumns.mkString(", ")}")
     index match {
       case Some(indexDf) =>
         if (debugEnabled) {
-          logger.warn(
-            s"[debug] locateFilesFromDataFrame started: joinColumns=${joinColumns.mkString(",")}"
-          )
+          logger.warn(s"[debug] locateFilesFromDataFrame started: joinColumns=${joinColumns.mkString(",")}")
         }
         val bloomColumnSet = bloomColumns
         val temporalColumnSet =
@@ -701,289 +639,244 @@ trait IndexQueryOperations extends IndexJoinOperations {
         val rangeColumnSet = metadata.range_indexes.asScala.map(_.column).toSet
 
         // Separate bloom, temporal, range, and regular columns
-        val (bloomJoinColumns, nonBloomColumns) = joinColumns.partition {
-          joinColumn => bloomColumnSet.contains(joinColumn)
-        }
+        val (bloomJoinColumns, nonBloomColumns) =
+          joinColumns.partition(joinColumn => bloomColumnSet.contains(joinColumn))
         val (temporalJoinColumns, nonTemporalColumns) =
-          nonBloomColumns.partition { joinColumn =>
-            temporalColumnSet.contains(joinColumn)
-          }
+          nonBloomColumns.partition(joinColumn => temporalColumnSet.contains(joinColumn))
         val (rangeJoinColumns, regularJoinColumns) =
-          nonTemporalColumns.partition { joinColumn =>
-            rangeColumnSet.contains(joinColumn)
-          }
+          nonTemporalColumns.partition(joinColumn => rangeColumnSet.contains(joinColumn))
 
         // Get files from bloom filters
         val bloomStart = System.currentTimeMillis()
-        val bloomFiles = if (bloomJoinColumns.nonEmpty) {
-          bloomJoinColumns
-            .map { joinColumn =>
-              locateFilesWithBloomFromDataFrame(joinColumn, valuesDf, indexDf)
-            }
-            .reduce(_ intersect _)
-        } else {
-          Set.empty[String]
-        }
+        val bloomFiles =
+          if (bloomJoinColumns.nonEmpty) {
+            bloomJoinColumns
+              .map(joinColumn => locateFilesWithBloomFromDataFrame(joinColumn, valuesDf, indexDf))
+              .reduce(_ intersect _)
+          } else {
+            Set.empty[String]
+          }
         val bloomMs = System.currentTimeMillis() - bloomStart
 
         // Get files from temporal indexes (pruned to latest timestamp per value)
         val temporalStart = System.currentTimeMillis()
-        val temporalFiles = if (temporalJoinColumns.nonEmpty) {
-          val repartitionedIndex = maybeRepartition(indexDf)
-          temporalJoinColumns
-            .map { joinColumn =>
-              locateFilesWithTemporalFromDataFrame(
-                joinColumn,
-                valuesDf,
-                repartitionedIndex
-              )
-            }
-            .reduce(_ intersect _)
-        } else {
-          Set.empty[String]
-        }
+        val temporalFiles =
+          if (temporalJoinColumns.nonEmpty) {
+            val repartitionedIndex = maybeRepartition(indexDf)
+            temporalJoinColumns
+              .map(joinColumn => locateFilesWithTemporalFromDataFrame(joinColumn, valuesDf, repartitionedIndex))
+              .reduce(_ intersect _)
+          } else {
+            Set.empty[String]
+          }
         val temporalMs = System.currentTimeMillis() - temporalStart
 
         // Get files from range indexes
         val rangeStart = System.currentTimeMillis()
-        val rangeFiles = if (rangeJoinColumns.nonEmpty) {
-          rangeJoinColumns
-            .map { joinColumn =>
-              locateFilesWithRangeFromDataFrame(joinColumn, valuesDf, indexDf)
-            }
-            .reduce(_ intersect _)
-        } else {
-          Set.empty[String]
-        }
+        val rangeFiles =
+          if (rangeJoinColumns.nonEmpty) {
+            rangeJoinColumns
+              .map(joinColumn => locateFilesWithRangeFromDataFrame(joinColumn, valuesDf, indexDf))
+              .reduce(_ intersect _)
+          } else {
+            Set.empty[String]
+          }
         val rangeMs = System.currentTimeMillis() - rangeStart
 
         // Get files from regular indexes
         val regularStart = System.currentTimeMillis()
-        val regularFiles = if (regularJoinColumns.nonEmpty) {
-          // Repartition the index DataFrame before explode to reduce
-          // per-executor memory pressure on large indexes
-          val repartitionedIndex = maybeRepartition(indexDf)
-          if (debugEnabled) {
-            logger.warn(s"[debug] locateFiles: index repartitioned")
-          }
+        val regularFiles =
+          if (regularJoinColumns.nonEmpty) {
+            // Repartition the index DataFrame before explode to reduce
+            // per-executor memory pressure on large indexes
+            val repartitionedIndex = maybeRepartition(indexDf)
+            if (debugEnabled) {
+              logger.warn(s"[debug] locateFiles: index repartitioned")
+            }
 
-          val perColumnDFs = regularJoinColumns.map { joinColumn =>
-            val storageColumn = columnMappings(joinColumn)
-            val distinctValues = valuesDf.select(col(joinColumn)).distinct()
-            val bloomCandidates = getAutoBloomCandidatesFromDf(
-              storageColumn,
-              joinColumn,
-              valuesDf,
-              indexDf
-            )
-            loadColumnIndex(repartitionedIndex, storageColumn, bloomCandidates)
-              .join(
-                distinctValues.withColumnRenamed(joinColumn, storageColumn),
-                Seq(storageColumn),
-                "leftsemi"
-              )
-              .select("filename")
-              .distinct()
-          }
+            val perColumnDFs =
+              regularJoinColumns.map { joinColumn =>
+                val storageColumn = columnMappings(joinColumn)
+                val distinctValues = valuesDf.select(col(joinColumn)).distinct()
+                val bloomCandidates = getAutoBloomCandidatesFromDf(storageColumn, joinColumn, valuesDf, indexDf)
+                loadColumnIndex(repartitionedIndex, storageColumn, bloomCandidates)
+                  .join(distinctValues.withColumnRenamed(joinColumn, storageColumn), Seq(storageColumn), "leftsemi")
+                  .select("filename")
+                  .distinct()
+              }
 
-          val intersectedDF = if (perColumnDFs.size == 1) {
-            perColumnDFs.head
+            val intersectedDF =
+              if (perColumnDFs.size == 1) {
+                perColumnDFs.head
+              } else {
+                perColumnDFs.reduce((a, b) => a.join(b, Seq("filename"), "inner"))
+              }
+
+            if (debugEnabled) {
+              logger.warn(s"[debug] locateFiles: about to collectFilenamesViaStaging at ${System
+                  .currentTimeMillis() - locateStart}ms")
+            }
+            collectFilenamesViaStaging(intersectedDF)
           } else {
-            perColumnDFs.reduce((a, b) => a.join(b, Seq("filename"), "inner"))
+            Set.empty[String]
           }
-
-          if (debugEnabled) {
-            logger.warn(
-              s"[debug] locateFiles: about to collectFilenamesViaStaging at ${System
-                  .currentTimeMillis() - locateStart}ms"
-            )
-          }
-          collectFilenamesViaStaging(intersectedDF)
-        } else {
-          Set.empty[String]
-        }
         val regularMs = System.currentTimeMillis() - regularStart
 
         // Combine results - intersect across types that returned results (AND semantics)
         // Track which categories were queried (had input), not just which returned results
-        val queriedResults: Seq[Set[String]] = Seq(
-          if (bloomJoinColumns.nonEmpty) Some(bloomFiles) else None,
-          if (temporalJoinColumns.nonEmpty) Some(temporalFiles) else None,
-          if (rangeJoinColumns.nonEmpty) Some(rangeFiles) else None,
-          if (regularJoinColumns.nonEmpty) Some(regularFiles) else None
-        ).flatten
+        val queriedResults: Seq[Set[String]] =
+          Seq(
+            if (bloomJoinColumns.nonEmpty) Some(bloomFiles) else None,
+            if (temporalJoinColumns.nonEmpty) Some(temporalFiles) else None,
+            if (rangeJoinColumns.nonEmpty) Some(rangeFiles) else None,
+            if (regularJoinColumns.nonEmpty) Some(regularFiles) else None).flatten
 
-        val allFiles = if (queriedResults.isEmpty) {
-          Set.empty[String]
-        } else {
-          queriedResults.reduce(_ intersect _)
-        }
+        val allFiles =
+          if (queriedResults.isEmpty) {
+            Set.empty[String]
+          } else {
+            queriedResults.reduce(_ intersect _)
+          }
         val totalMs = System.currentTimeMillis() - locateStart
         // Add per-type timing (#38) to match locateFiles
         logger.warn(
           s"locateFilesFromDataFrame: ${allFiles.size} files matched in ${totalMs}ms " +
-            s"(bloom=${bloomMs}ms, temporal=${temporalMs}ms, range=${rangeMs}ms, regular=${regularMs}ms)"
-        )
+            s"(bloom=${bloomMs}ms, temporal=${temporalMs}ms, range=${rangeMs}ms, regular=${regularMs}ms)")
         if (allFiles.isEmpty) Set.empty else allFiles
       case None =>
         // Log when index table is None (#33)
-        logger.warn(
-          s"locateFilesFromDataFrame: no index table found for index '$name', returning empty result"
-        )
+        logger.warn(s"locateFilesFromDataFrame: no index table found for index '$name', returning empty result")
         Set.empty
     }
   }
 
-  /** Locates files using temporal indexes from a DataFrame of values, pruning
-    * to only files containing the latest version of each value.
-    *
-    * Joins the exploded temporal index with distinct query values, then applies
-    * a window function to keep only the file with the highest max_ts per value.
-    * This ensures joins against temporal indexes always use the most recent
-    * data.
-    *
-    * @param column
-    *   The temporal index value column name
-    * @param valuesDf
-    *   DataFrame containing a column named `column` with values to search for
-    * @param indexDf
-    *   The main index DataFrame (should already be repartitioned if needed)
-    * @return
-    *   Set of filenames containing the latest version of any matching value
-    */
+  /**
+   * Locates files using temporal indexes from a DataFrame of values, pruning to only files containing the latest
+   * version of each value.
+   *
+   * Joins the exploded temporal index with distinct query values, then applies a window function to keep only the file
+   * with the highest max_ts per value. This ensures joins against temporal indexes always use the most recent data.
+   *
+   * @param column
+   *   The temporal index value column name
+   * @param valuesDf
+   *   DataFrame containing a column named `column` with values to search for
+   * @param indexDf
+   *   The main index DataFrame (should already be repartitioned if needed)
+   * @return
+   *   Set of filenames containing the latest version of any matching value
+   */
   private def locateFilesWithTemporalFromDataFrame(
       column: String,
       valuesDf: DataFrame,
-      indexDf: DataFrame
-  ): Set[String] = {
+      indexDf: DataFrame): Set[String] = {
     val allExploded = loadTemporalColumnIndex(indexDf, column)
 
     // Join with query values
-    val distinctValues = valuesDf
-      .select(col(column))
-      .distinct()
-      .withColumnRenamed(column, "_value")
+    val distinctValues =
+      valuesDf
+        .select(col(column))
+        .distinct()
+        .withColumnRenamed(column, "_value")
     val matched = allExploded.join(distinctValues, Seq("_value"), "inner")
 
     // For each value, keep only the file with the latest timestamp
     val w = Window.partitionBy("_value").orderBy(col("_max_ts").desc_nulls_last)
-    val pruned = matched
-      .withColumn("_rank", row_number().over(w))
-      .filter(col("_rank") === 1)
-      .select("filename")
-      .distinct()
+    val pruned =
+      matched
+        .withColumn("_rank", row_number().over(w))
+        .filter(col("_rank") === 1)
+        .select("filename")
+        .distinct()
 
     val result = collectFilenamesViaStaging(pruned)
     // Add result logging (#36)
-    logger.warn(
-      s"Temporal DF query on column '$column': ${result.size} files matched"
-    )
+    logger.warn(s"Temporal DF query on column '$column': ${result.size} files matched")
     result
   }
 
-  /** Locates files using range indexes from a DataFrame of values.
-    *
-    * Collects up to 10,000 distinct query values. For sets exceeding 1,000
-    * values, falls back to a bounding-box optimization (query min/max vs file
-    * min/max). For smaller sets, checks per-value containment for precise
-    * pruning.
-    *
-    * @note
-    *   Distinct values are truncated to 10,000 to avoid driver OOM. For value
-    *   sets exceeding 1,000, a bounding-box optimization is used which may
-    *   include false-positive files whose ranges overlap but contain no actual
-    *   matching values.
-    *
-    * @param column
-    *   The range index column name
-    * @param valuesDf
-    *   DataFrame containing a column named `column` with values to search for
-    * @param indexDf
-    *   The main index DataFrame containing range struct columns
-    * @return
-    *   Set of filenames whose stored range overlaps with the query values
-    */
+  /**
+   * Locates files using range indexes from a DataFrame of values.
+   *
+   * Collects up to 10,000 distinct query values. For sets exceeding 1,000 values, falls back to a bounding-box
+   * optimization (query min/max vs file min/max). For smaller sets, checks per-value containment for precise pruning.
+   *
+   * @note
+   *   Distinct values are truncated to 10,000 to avoid driver OOM. For value sets exceeding 1,000, a bounding-box
+   *   optimization is used which may include false-positive files whose ranges overlap but contain no actual matching
+   *   values.
+   *
+   * @param column
+   *   The range index column name
+   * @param valuesDf
+   *   DataFrame containing a column named `column` with values to search for
+   * @param indexDf
+   *   The main index DataFrame containing range struct columns
+   * @return
+   *   Set of filenames whose stored range overlaps with the query values
+   */
   private def locateFilesWithRangeFromDataFrame(
       column: String,
       valuesDf: DataFrame,
-      indexDf: DataFrame
-  ): Set[String] = {
-    val rangeCol = s"range_${column}"
+      indexDf: DataFrame): Set[String] = {
+    val rangeCol = s"range_$column"
     if (!indexDf.columns.contains(rangeCol)) {
       Set.empty
     } else {
       // Collect distinct query values (bounded to avoid driver OOM)
       val rawCount = valuesDf.select(col(column)).distinct().count()
       if (rawCount > 10000) {
-        logger.warn(
-          s"Range query on '$column': truncating $rawCount distinct values to 10000 for per-value pruning"
-        )
+        logger.warn(s"Range query on '$column': truncating $rawCount distinct values to 10000 for per-value pruning")
       }
-      val distinctValues = valuesDf
-        .select(col(column))
-        .where(col(column).isNotNull)
-        .distinct()
-        .limit(10000)
-        .collect()
-        .map(_.get(0))
+      val distinctValues =
+        valuesDf
+          .select(col(column))
+          .where(col(column).isNotNull)
+          .distinct()
+          .limit(10000)
+          .collect()
+          .map(_.get(0))
 
       if (distinctValues.isEmpty) {
         Set.empty
       } else {
-        logger.warn(
-          s"Range query on column '$column' with ${distinctValues.length} distinct values"
-        )
+        logger.warn(s"Range query on column '$column' with ${distinctValues.length} distinct values")
 
         if (distinctValues.length > 1000) {
-          logger.warn(
-            s"Range query: large value set (${distinctValues.length}), using bounding box optimization"
-          )
-          val minMaxRow = valuesDf
-            .agg(
-              min(col(column)).alias("q_min"),
-              max(col(column)).alias("q_max")
-            )
-            .head()
+          logger.warn(s"Range query: large value set (${distinctValues.length}), using bounding box optimization")
+          val minMaxRow =
+            valuesDf
+              .agg(min(col(column)).alias("q_min"), max(col(column)).alias("q_max"))
+              .head()
 
           if (minMaxRow.isNullAt(0) || minMaxRow.isNullAt(1)) {
-            logger.warn(
-              s"Range query for '$column': min/max values are null after aggregation, returning empty result"
-            )
+            logger.warn(s"Range query for '$column': min/max values are null after aggregation, returning empty result")
             Set.empty[String]
           } else {
-            val matchingFiles = indexDf
-              .select(
-                col("filename"),
-                col(s"$rangeCol.min").alias("file_min"),
-                col(s"$rangeCol.max").alias("file_max")
-              )
-              .where(col("file_min").isNotNull && col("file_max").isNotNull)
-              .where(
-                col("file_max") >= lit(minMaxRow.get(0)) && col(
-                  "file_min"
-                ) <= lit(minMaxRow.get(1))
-              )
-              .select("filename")
-              .distinct()
+            val matchingFiles =
+              indexDf
+                .select(
+                  col("filename"),
+                  col(s"$rangeCol.min").alias("file_min"),
+                  col(s"$rangeCol.max").alias("file_max"))
+                .where(col("file_min").isNotNull && col("file_max").isNotNull)
+                .where(col("file_max") >= lit(minMaxRow.get(0)) && col("file_min") <= lit(minMaxRow.get(1)))
+                .select("filename")
+                .distinct()
 
             collectFilenamesViaStaging(matchingFiles)
           }
         } else {
           // For reasonable value sets, check per-value containment (precise pruning)
-          val valueConditions = distinctValues.map { v =>
-            col("file_min") <= lit(v) && col("file_max") >= lit(v)
-          }
+          val valueConditions = distinctValues.map(v => col("file_min") <= lit(v) && col("file_max") >= lit(v))
 
-          val matchingFiles = indexDf
-            .select(
-              col("filename"),
-              col(s"$rangeCol.min").alias("file_min"),
-              col(s"$rangeCol.max").alias("file_max")
-            )
-            .where(col("file_min").isNotNull && col("file_max").isNotNull)
-            .where(valueConditions.reduce(_ || _))
-            .select("filename")
-            .distinct()
+          val matchingFiles =
+            indexDf
+              .select(col("filename"), col(s"$rangeCol.min").alias("file_min"), col(s"$rangeCol.max").alias("file_max"))
+              .where(col("file_min").isNotNull && col("file_max").isNotNull)
+              .where(valueConditions.reduce(_ || _))
+              .select("filename")
+              .distinct()
 
           collectFilenamesViaStaging(matchingFiles)
         }
@@ -991,32 +884,30 @@ trait IndexQueryOperations extends IndexJoinOperations {
     }
   }
 
-  /** Returns a DataFrame of per-column index statistics and total file count.
-    *
-    * For each indexed column, computes statistics on the array length (number
-    * of distinct values per file): min, max, avg, median, and standard
-    * deviation. Also includes the total number of indexed files.
-    *
-    * Returns an empty DataFrame if no index table exists. If `storageColumns`
-    * is empty (e.g., only bloom or range indexes), the result contains zero
-    * stat rows.
-    *
-    * @return
-    *   Single-row DataFrame with FileCount and per-column stat structs, or an
-    *   empty DataFrame if no index exists
-    *
-    * @example
-    *   {{{
-    * // Compute and display index statistics
-    * val statsDF = index.stats()
-    * statsDF.show()
-    * // +----------+---------+---------+---------+---------+------------+------+
-    * // |    Column|FileCount|MinValues|MaxValues|AvgValues|MedianValues|StdDev|
-    * // +----------+---------+---------+---------+---------+------------+------+
-    * // | user_id  |     150 |       1 |    5000 |   120.3 |         45 | 340.2|
-    * // +----------+---------+---------+---------+---------+------------+------+
-    *   }}}
-    */
+  /**
+   * Returns a DataFrame of per-column index statistics and total file count.
+   *
+   * For each indexed column, computes statistics on the array length (number of distinct values per file): min, max,
+   * avg, median, and standard deviation. Also includes the total number of indexed files.
+   *
+   * Returns an empty DataFrame if no index table exists. If `storageColumns` is empty (e.g., only bloom or range
+   * indexes), the result contains zero stat rows.
+   *
+   * @return
+   *   Single-row DataFrame with FileCount and per-column stat structs, or an empty DataFrame if no index exists
+   *
+   * @example
+   *   {{{
+   * // Compute and display index statistics
+   * val statsDF = index.stats()
+   * statsDF.show()
+   * // +----------+---------+---------+---------+---------+------------+------+
+   * // |    Column|FileCount|MinValues|MaxValues|AvgValues|MedianValues|StdDev|
+   * // +----------+---------+---------+---------+---------+------------+------+
+   * // | user_id  |     150 |       1 |    5000 |   120.3 |         45 | 340.2|
+   * // +----------+---------+---------+---------+---------+------------+------+
+   *   }}}
+   */
   def stats(): DataFrame = {
     val startTime = System.currentTimeMillis()
     logger.warn(s"Computing stats for index '$name'")
@@ -1024,79 +915,71 @@ trait IndexQueryOperations extends IndexJoinOperations {
       case Some(df) =>
         val fileCount = df.select(countDistinct("filename")).head().getLong(0)
 
-        val rows = storageColumns.toSeq.map { colName =>
-          val lenCol = size(col(colName))
-          val row = df
-            .agg(
-              min(lenCol),
-              max(lenCol),
-              avg(lenCol),
-              expr(s"percentile_approx(size(`$colName`), 0.5)"),
-              stddev(lenCol)
-            )
-            .head()
-          val avgVal =
-            if (row.isNullAt(2)) null
-            else
-              java.math.BigDecimal
-                .valueOf(row.getDouble(2))
-                .setScale(1, java.math.RoundingMode.HALF_UP)
-          val stdVal =
-            if (row.isNullAt(4)) null
-            else
-              java.math.BigDecimal
-                .valueOf(row.getDouble(4))
-                .setScale(1, java.math.RoundingMode.HALF_UP)
-          Row(
-            colName,
-            fileCount,
-            if (row.isNullAt(0)) null else row.getInt(0),
-            if (row.isNullAt(1)) null else row.getInt(1),
-            avgVal,
-            if (row.isNullAt(3)) null else row.getInt(3),
-            stdVal
-          )
-        }
+        val rows =
+          storageColumns.toSeq.map { colName =>
+            val lenCol = size(col(colName))
+            val row =
+              df
+                .agg(
+                  min(lenCol),
+                  max(lenCol),
+                  avg(lenCol),
+                  expr(s"percentile_approx(size(`$colName`), 0.5)"),
+                  stddev(lenCol))
+                .head()
+            val avgVal =
+              if (row.isNullAt(2)) null
+              else
+                java.math.BigDecimal
+                  .valueOf(row.getDouble(2))
+                  .setScale(1, java.math.RoundingMode.HALF_UP)
+            val stdVal =
+              if (row.isNullAt(4)) null
+              else
+                java.math.BigDecimal
+                  .valueOf(row.getDouble(4))
+                  .setScale(1, java.math.RoundingMode.HALF_UP)
+            Row(
+              colName,
+              fileCount,
+              if (row.isNullAt(0)) null else row.getInt(0),
+              if (row.isNullAt(1)) null else row.getInt(1),
+              avgVal,
+              if (row.isNullAt(3)) null else row.getInt(3),
+              stdVal)
+          }
 
         import org.apache.spark.sql.types._
-        val statsSchema = StructType(
-          Seq(
-            StructField("Column", StringType),
-            StructField("FileCount", LongType),
-            StructField("MinValues", IntegerType),
-            StructField("MaxValues", IntegerType),
-            StructField("AvgValues", DecimalType(10, 1)),
-            StructField("MedianValues", IntegerType),
-            StructField("StdDev", DecimalType(10, 1))
-          )
-        )
-        val result = spark.createDataFrame(
-          spark.sparkContext.parallelize(rows),
-          statsSchema
-        )
+        val statsSchema =
+          StructType(
+            Seq(
+              StructField("Column", StringType),
+              StructField("FileCount", LongType),
+              StructField("MinValues", IntegerType),
+              StructField("MaxValues", IntegerType),
+              StructField("AvgValues", DecimalType(10, 1)),
+              StructField("MedianValues", IntegerType),
+              StructField("StdDev", DecimalType(10, 1))))
+        val result = spark.createDataFrame(spark.sparkContext.parallelize(rows), statsSchema)
 
-        logger.warn(
-          s"Stats computation for index '$name' completed in ${System.currentTimeMillis() - startTime}ms"
-        )
+        logger.warn(s"Stats computation for index '$name' completed in ${System.currentTimeMillis() - startTime}ms")
         result
 
       case None =>
-        logger.warn(
-          s"No index data found for stats on '$name' (${System.currentTimeMillis() - startTime}ms)"
-        )
+        logger.warn(s"No index data found for stats on '$name' (${System.currentTimeMillis() - startTime}ms)")
         spark.emptyDataFrame
     }
   }
 
-  /** Prints the index DataFrame to the console for debugging.
-    *
-    * Displays the contents and schema of the main index Delta table. This is an
-    * internal/diagnostic method.
-    *
-    * @param truncate
-    *   Whether to truncate long values in the display (default: false)
-    */
-  private[ariadne] def printIndex(truncate: Boolean = false): Unit = {
+  /**
+   * Prints the index DataFrame to the console for debugging.
+   *
+   * Displays the contents and schema of the main index Delta table. This is an internal/diagnostic method.
+   *
+   * @param truncate
+   *   Whether to truncate long values in the display (default: false)
+   */
+  private[ariadne] def printIndex(truncate: Boolean = false): Unit =
     index match {
       case Some(df) =>
         df.show(truncate)
@@ -1104,16 +987,17 @@ trait IndexQueryOperations extends IndexJoinOperations {
       case None =>
         logger.warn(s"No index data found for index '$name'")
     }
-  }
 
-  /** Prints the metadata associated with the index to the console.
-    *
-    * Outputs the string representation of [[IndexMetadata]], which includes the
-    * index schema, format, read options, and all configured index types
-    * (regular, bloom, temporal, range, computed, exploded).
-    *
-    * @see
-    *   [[IndexMetadataOperations.metadata]]
-    */
+  /**
+   * Prints the metadata associated with the index to the console.
+   *
+   * Outputs the string representation of [[IndexMetadata]], which includes the index schema, format, read options, and
+   * all configured index types (regular, bloom, temporal, range, computed, exploded).
+   *
+   * @see
+   *   [[IndexMetadataOperations.metadata]]
+   */
+  // scalastyle:off println
   private[ariadne] def printMetadata: Unit = println(metadata)
+  // scalastyle:on println
 }

--- a/src/main/scala/dev/cjfravel/ariadne/SchemaHelper.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/SchemaHelper.scala
@@ -2,46 +2,39 @@ package dev.cjfravel.ariadne
 
 import org.apache.spark.sql.types._
 
-/** Utility object for Spark schema introspection.
-  *
-  * Provides methods for validating field existence within
-  * [[org.apache.spark.sql.types.StructType]] schemas, including support for
-  * nested field paths using dot notation. Used throughout Ariadne to validate
-  * that indexed columns exist in the user-supplied schema before persisting
-  * metadata.
-  *
-  * '''Thread safety:''' All methods are pure functions with no mutable state;
-  * safe to call concurrently from any thread.
-  */
+/**
+ * Utility object for Spark schema introspection.
+ *
+ * Provides methods for validating field existence within [[org.apache.spark.sql.types.StructType]] schemas, including
+ * support for nested field paths using dot notation. Used throughout Ariadne to validate that indexed columns exist in
+ * the user-supplied schema before persisting metadata.
+ *
+ * '''Thread safety:''' All methods are pure functions with no mutable state; safe to call concurrently from any thread.
+ */
 object SchemaHelper {
 
-  /** Checks whether a field exists in the given schema, supporting nested
-    * paths.
-    *
-    * Supports dot-separated field paths for nested struct navigation (e.g.,
-    * `"address.city"` looks for a `city` field inside an `address` struct).
-    * Only direct `StructType` nesting is traversed — `ArrayType` elements are
-    * ''not'' descended into.
-    *
-    * @param schema
-    *   The root `StructType` schema to search. Must not be null.
-    * @param fieldName
-    *   A field name or dot-separated path (e.g., `"user.profile.id"`). Must not
-    *   be null or blank.
-    * @return
-    *   `true` if the field exists at the specified path, `false` otherwise
-    * @throws IllegalArgumentException
-    *   if schema is null or fieldName is null/blank
-    */
+  /**
+   * Checks whether a field exists in the given schema, supporting nested paths.
+   *
+   * Supports dot-separated field paths for nested struct navigation (e.g., `"address.city"` looks for a `city` field
+   * inside an `address` struct). Only direct `StructType` nesting is traversed — `ArrayType` elements are ''not''
+   * descended into.
+   *
+   * @param schema
+   *   The root `StructType` schema to search. Must not be null.
+   * @param fieldName
+   *   A field name or dot-separated path (e.g., `"user.profile.id"`). Must not be null or blank.
+   * @return
+   *   `true` if the field exists at the specified path, `false` otherwise
+   * @throws IllegalArgumentException
+   *   if schema is null or fieldName is null/blank
+   */
   def fieldExists(schema: StructType, fieldName: String): Boolean = {
     require(schema != null, "schema must not be null")
-    require(
-      fieldName != null && fieldName.trim.nonEmpty,
-      "fieldName must not be null or blank"
-    )
+    require(fieldName != null && fieldName.trim.nonEmpty, "fieldName must not be null or blank")
     val parts = fieldName.split("\\.")
 
-    def findField(currentSchema: StructType, path: List[String]): Boolean = {
+    def findField(currentSchema: StructType, path: List[String]): Boolean =
       path match {
         case Nil => false
         case head :: tail =>
@@ -51,33 +44,30 @@ object SchemaHelper {
                 case nestedSchema: StructType if tail.nonEmpty =>
                   findField(nestedSchema, tail)
                 case _ if tail.isEmpty => true
-                case _                 => false
+                case _ => false
               }
             case None => false
           }
       }
-    }
 
     findField(schema, parts.toList)
   }
 
-  /** Returns the data type of a top-level field in the schema.
-    *
-    * @param schema
-    *   The root `StructType` schema to search. Must not be null.
-    * @param fieldName
-    *   The top-level field name to look up. Must not be null or blank.
-    * @return
-    *   `Some(dataType)` if the field exists, `None` otherwise
-    * @throws IllegalArgumentException
-    *   if schema is null or fieldName is null/blank
-    */
+  /**
+   * Returns the data type of a top-level field in the schema.
+   *
+   * @param schema
+   *   The root `StructType` schema to search. Must not be null.
+   * @param fieldName
+   *   The top-level field name to look up. Must not be null or blank.
+   * @return
+   *   `Some(dataType)` if the field exists, `None` otherwise
+   * @throws IllegalArgumentException
+   *   if schema is null or fieldName is null/blank
+   */
   def fieldType(schema: StructType, fieldName: String): Option[DataType] = {
     require(schema != null, "schema must not be null")
-    require(
-      fieldName != null && fieldName.trim.nonEmpty,
-      "fieldName must not be null or blank"
-    )
+    require(fieldName != null && fieldName.trim.nonEmpty, "fieldName must not be null or blank")
     schema.fields.find(_.name == fieldName).map(_.dataType)
   }
 }

--- a/src/main/scala/dev/cjfravel/ariadne/catalog/AriadneCatalog.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/catalog/AriadneCatalog.scala
@@ -1,7 +1,8 @@
 package dev.cjfravel.ariadne.catalog
 
+import java.util
+
 import dev.cjfravel.ariadne.{Index, IndexCatalog, IndexPathUtils}
-import dev.cjfravel.ariadne.exceptions.IndexNotFoundException
 import org.apache.logging.log4j.LogManager
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.catalog._
@@ -9,98 +10,93 @@ import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
-import java.util
-
-/** Spark V2 catalog plugin that exposes Ariadne indexes as SQL tables.
-  *
-  * All indexes under `spark.ariadne.storagePath` are automatically discovered
-  * and exposed under a single `default` namespace. Users reference indexes as
-  * `{catalogName}.{indexName}` (which resolves via the default namespace) or
-  * explicitly as `{catalogName}.default.{indexName}`.
-  *
-  * '''Configuration:'''
-  * {{{
-  * spark.conf.set("spark.sql.catalog.ariadne", "dev.cjfravel.ariadne.catalog.AriadneCatalog")
-  * }}}
-  *
-  * '''SQL usage:'''
-  * {{{
-  * SHOW TABLES IN ariadne;
-  * DESCRIBE ariadne.customers;
-  * SELECT * FROM ariadne.customers WHERE id = 123;
-  * SELECT * FROM ariadne.customers c JOIN orders o ON c.id = o.customerid;
-  * }}}
-  *
-  * This catalog is read-only. `createTable`, `dropTable`, and `alterTable`
-  * throw `UnsupportedOperationException`. Index lifecycle management is
-  * performed through the [[Index]] API.
-  *
-  * '''Thread safety:''' Spark creates one catalog instance per `SparkSession`.
-  * The mutable `catalogName` field is set once during `initialize` and read
-  * thereafter. Concurrent use across threads within a single session is safe
-  * after initialization.
-  *
-  * @see
-  *   [[AriadneTable]] for the table implementation
-  * @see
-  *   [[AriadneSparkExtension]] for registering the JOIN optimization rule
-  */
+/**
+ * Spark V2 catalog plugin that exposes Ariadne indexes as SQL tables.
+ *
+ * All indexes under `spark.ariadne.storagePath` are automatically discovered and exposed under a single `default`
+ * namespace. Users reference indexes as `{catalogName}.{indexName}` (which resolves via the default namespace) or
+ * explicitly as `{catalogName}.default.{indexName}`.
+ *
+ * '''Configuration:'''
+ * {{{
+ * spark.conf.set("spark.sql.catalog.ariadne", "dev.cjfravel.ariadne.catalog.AriadneCatalog")
+ * }}}
+ *
+ * '''SQL usage:'''
+ * {{{
+ * SHOW TABLES IN ariadne;
+ * DESCRIBE ariadne.customers;
+ * SELECT * FROM ariadne.customers WHERE id = 123;
+ * SELECT * FROM ariadne.customers c JOIN orders o ON c.id = o.customerid;
+ * }}}
+ *
+ * This catalog is read-only. `createTable`, `dropTable`, and `alterTable` throw `UnsupportedOperationException`. Index
+ * lifecycle management is performed through the [[Index]] API.
+ *
+ * '''Thread safety:''' Spark creates one catalog instance per `SparkSession`. The mutable `catalogName` field is set
+ * once during `initialize` and read thereafter. Concurrent use across threads within a single session is safe after
+ * initialization.
+ *
+ * @see
+ *   [[AriadneTable]] for the table implementation
+ * @see
+ *   [[AriadneSparkExtension]] for registering the JOIN optimization rule
+ */
 class AriadneCatalog extends TableCatalog with SupportsNamespaces {
 
   private val logger = LogManager.getLogger("ariadne")
   private var catalogName: String = _
   private val defaultNs = Array("default")
 
-  /** Initializes the catalog with the name assigned in the Spark configuration.
-    *
-    * Called once by Spark when the catalog is first accessed.
-    *
-    * @param name
-    *   the catalog name from `spark.sql.catalog.{name}`
-    * @param options
-    *   configuration options (currently unused)
-    */
-  override def initialize(
-      name: String,
-      options: CaseInsensitiveStringMap
-  ): Unit = {
+  /**
+   * Initializes the catalog with the name assigned in the Spark configuration.
+   *
+   * Called once by Spark when the catalog is first accessed.
+   *
+   * @param name
+   *   the catalog name from `spark.sql.catalog.{name}`
+   * @param options
+   *   configuration options (currently unused)
+   */
+  override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
     this.catalogName = name
     logger.warn(s"AriadneCatalog initialized with name '$name'")
   }
 
-  /** Returns the catalog name assigned during initialization.
-    *
-    * @return
-    *   the catalog name
-    */
+  /**
+   * Returns the catalog name assigned during initialization.
+   *
+   * @return
+   *   the catalog name
+   */
   override def name(): String = catalogName
 
-  /** Returns `Array("default")` as the default namespace.
-    *
-    * This follows Spark conventions (Delta, Iceberg) so that
-    * `ariadne.customers` resolves to `ariadne.default.customers` and `SHOW
-    * TABLES IN ariadne` displays `default` in the namespace column.
-    *
-    * @return
-    *   single-element array containing `"default"`
-    */
+  /**
+   * Returns `Array("default")` as the default namespace.
+   *
+   * This follows Spark conventions (Delta, Iceberg) so that `ariadne.customers` resolves to `ariadne.default.customers`
+   * and `SHOW TABLES IN ariadne` displays `default` in the namespace column.
+   *
+   * @return
+   *   single-element array containing `"default"`
+   */
   override def defaultNamespace(): Array[String] = defaultNs
 
   // --- TableCatalog ---
 
-  /** Lists all Ariadne indexes as table identifiers.
-    *
-    * Delegates to [[IndexCatalog.list()]] which scans `storagePath/indexes/`
-    * for directories containing `metadata.json`. All indexes are placed in the
-    * `default` namespace.
-    *
-    * @param namespace
-    *   must be `Array("default")` or empty
-    * @return
-    *   array of identifiers, one per index
-    * @throws org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException
-    *   if an unrecognized namespace is provided
-    */
+  /**
+   * Lists all Ariadne indexes as table identifiers.
+   *
+   * Delegates to [[IndexCatalog.list()]] which scans `storagePath/indexes/` for directories containing `metadata.json`.
+   * All indexes are placed in the `default` namespace.
+   *
+   * @param namespace
+   *   must be `Array("default")` or empty
+   * @return
+   *   array of identifiers, one per index
+   * @throws org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException
+   *   if an unrecognized namespace is provided
+   */
   override def listTables(namespace: Array[String]): Array[Identifier] = {
     validateNamespace(namespace)
     implicit val spark: SparkSession = SparkSession.active
@@ -109,47 +105,41 @@ class AriadneCatalog extends TableCatalog with SupportsNamespaces {
     names.map(n => Identifier.of(defaultNs, n)).toArray
   }
 
-  /** Loads an Ariadne index as a Spark V2 [[AriadneTable]].
-    *
-    * Reads the index's metadata to obtain the source data schema, format, and
-    * index configuration.
-    *
-    * @param ident
-    *   table identifier (namespace must be `default` or empty, name is the
-    *   index name)
-    * @return
-    *   the AriadneTable wrapping this index
-    * @throws org.apache.spark.sql.catalyst.analysis.NoSuchTableException
-    *   if no index with the given name exists
-    */
+  /**
+   * Loads an Ariadne index as a Spark V2 [[AriadneTable]].
+   *
+   * Reads the index's metadata to obtain the source data schema, format, and index configuration.
+   *
+   * @param ident
+   *   table identifier (namespace must be `default` or empty, name is the index name)
+   * @return
+   *   the AriadneTable wrapping this index
+   * @throws org.apache.spark.sql.catalyst.analysis.NoSuchTableException
+   *   if no index with the given name exists
+   */
   override def loadTable(ident: Identifier): Table = {
     implicit val spark: SparkSession = SparkSession.active
     val ns = ident.namespace()
     if (ns.nonEmpty && !ns.sameElements(defaultNs)) {
-      throw new org.apache.spark.sql.catalyst.analysis.NoSuchTableException(
-        catalogName,
-        ident.toString
-      )
+      throw new org.apache.spark.sql.catalyst.analysis.NoSuchTableException(catalogName, ident.toString)
     }
     val indexName = ident.name()
     logger.warn(s"AriadneCatalog.loadTable: loading index '$indexName'")
     if (!IndexPathUtils.exists(indexName)) {
-      throw new org.apache.spark.sql.catalyst.analysis.NoSuchTableException(
-        catalogName,
-        indexName
-      )
+      throw new org.apache.spark.sql.catalyst.analysis.NoSuchTableException(catalogName, indexName)
     }
     val index = Index(indexName)
     AriadneTable(indexName, index.storedSchema, index.metadata)
   }
 
-  /** Checks whether an Ariadne index with the given name exists.
-    *
-    * @param ident
-    *   table identifier (name is the index name)
-    * @return
-    *   true if the index exists on storage, false otherwise
-    */
+  /**
+   * Checks whether an Ariadne index with the given name exists.
+   *
+   * @param ident
+   *   table identifier (name is the index name)
+   * @return
+   *   true if the index exists on storage, false otherwise
+   */
   override def tableExists(ident: Identifier): Boolean = {
     val ns = ident.namespace()
     if (ns.nonEmpty && !ns.sameElements(defaultNs)) return false
@@ -157,162 +147,135 @@ class AriadneCatalog extends TableCatalog with SupportsNamespaces {
     IndexPathUtils.exists(ident.name())
   }
 
-  /** Not supported — always throws.
-    *
-    * Use [[dev.cjfravel.ariadne.Index.apply]] to create indexes.
-    *
-    * @throws UnsupportedOperationException
-    *   always
-    */
+  /**
+   * Not supported — always throws.
+   *
+   * Use [[dev.cjfravel.ariadne.Index.apply]] to create indexes.
+   *
+   * @throws UnsupportedOperationException
+   *   always
+   */
   override def createTable(
       ident: Identifier,
       schema: StructType,
       partitions: Array[Transform],
-      properties: util.Map[String, String]
-  ): Table = {
-    throw new UnsupportedOperationException(
-      "AriadneCatalog is read-only. Use Index.apply() to create indexes."
-    )
-  }
+      properties: util.Map[String, String]): Table =
+    throw new UnsupportedOperationException("AriadneCatalog is read-only. Use Index.apply() to create indexes.")
 
-  /** Not supported — always throws.
-    *
-    * Use [[dev.cjfravel.ariadne.Index.remove]] to delete indexes.
-    *
-    * @throws UnsupportedOperationException
-    *   always
-    */
-  override def dropTable(ident: Identifier): Boolean = {
-    throw new UnsupportedOperationException(
-      "AriadneCatalog is read-only. Use Index.remove() to delete indexes."
-    )
-  }
+  /**
+   * Not supported — always throws.
+   *
+   * Use [[dev.cjfravel.ariadne.Index.remove]] to delete indexes.
+   *
+   * @throws UnsupportedOperationException
+   *   always
+   */
+  override def dropTable(ident: Identifier): Boolean =
+    throw new UnsupportedOperationException("AriadneCatalog is read-only. Use Index.remove() to delete indexes.")
 
-  /** Not supported — always throws.
-    *
-    * @throws UnsupportedOperationException
-    *   always
-    */
-  override def renameTable(oldIdent: Identifier, newIdent: Identifier): Unit = {
-    throw new UnsupportedOperationException(
-      "AriadneCatalog does not support renaming indexes."
-    )
-  }
+  /**
+   * Not supported — always throws.
+   *
+   * @throws UnsupportedOperationException
+   *   always
+   */
+  override def renameTable(oldIdent: Identifier, newIdent: Identifier): Unit =
+    throw new UnsupportedOperationException("AriadneCatalog does not support renaming indexes.")
 
-  /** Not supported — always throws.
-    *
-    * Use the [[dev.cjfravel.ariadne.Index]] API to modify indexes.
-    *
-    * @throws UnsupportedOperationException
-    *   always
-    */
-  override def alterTable(ident: Identifier, changes: TableChange*): Table = {
-    throw new UnsupportedOperationException(
-      "AriadneCatalog is read-only. Use the Index API to modify indexes."
-    )
-  }
+  /**
+   * Not supported — always throws.
+   *
+   * Use the [[dev.cjfravel.ariadne.Index]] API to modify indexes.
+   *
+   * @throws UnsupportedOperationException
+   *   always
+   */
+  override def alterTable(ident: Identifier, changes: TableChange*): Table =
+    throw new UnsupportedOperationException("AriadneCatalog is read-only. Use the Index API to modify indexes.")
 
   // --- SupportsNamespaces (single "default" namespace) ---
 
-  /** Lists available namespaces. Returns a single `"default"` namespace.
-    *
-    * @return
-    *   array containing one element: `Array("default")`
-    */
-  override def listNamespaces(): Array[Array[String]] = {
+  /**
+   * Lists available namespaces. Returns a single `"default"` namespace.
+   *
+   * @return
+   *   array containing one element: `Array("default")`
+   */
+  override def listNamespaces(): Array[Array[String]] =
     Array(defaultNs)
-  }
 
-  /** Lists child namespaces under the given namespace.
-    *
-    * Since Ariadne has a flat namespace structure, this always returns empty.
-    *
-    * @param namespace
-    *   the parent namespace (must be `default` or empty)
-    * @return
-    *   empty array (no child namespaces)
-    * @throws org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException
-    *   if the namespace is not `default`
-    */
-  override def listNamespaces(
-      namespace: Array[String]
-  ): Array[Array[String]] = {
+  /**
+   * Lists child namespaces under the given namespace.
+   *
+   * Since Ariadne has a flat namespace structure, this always returns empty.
+   *
+   * @param namespace
+   *   the parent namespace (must be `default` or empty)
+   * @return
+   *   empty array (no child namespaces)
+   * @throws org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException
+   *   if the namespace is not `default`
+   */
+  override def listNamespaces(namespace: Array[String]): Array[Array[String]] = {
     validateNamespace(namespace)
     Array.empty
   }
 
-  /** Loads metadata for the given namespace.
-    *
-    * Returns an empty map for the `default` namespace. Ariadne does not store
-    * namespace-level metadata.
-    *
-    * @param namespace
-    *   the namespace to load (must be `default` or empty)
-    * @return
-    *   empty metadata map
-    * @throws org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException
-    *   if the namespace is not `default`
-    */
-  override def loadNamespaceMetadata(
-      namespace: Array[String]
-  ): util.Map[String, String] = {
+  /**
+   * Loads metadata for the given namespace.
+   *
+   * Returns an empty map for the `default` namespace. Ariadne does not store namespace-level metadata.
+   *
+   * @param namespace
+   *   the namespace to load (must be `default` or empty)
+   * @return
+   *   empty metadata map
+   * @throws org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException
+   *   if the namespace is not `default`
+   */
+  override def loadNamespaceMetadata(namespace: Array[String]): util.Map[String, String] = {
     validateNamespace(namespace)
     new util.HashMap[String, String]()
   }
 
-  /** Not supported — always throws.
-    *
-    * Ariadne has a single `default` namespace.
-    *
-    * @throws UnsupportedOperationException
-    *   always
-    */
-  override def createNamespace(
-      namespace: Array[String],
-      metadata: util.Map[String, String]
-  ): Unit = {
+  /**
+   * Not supported — always throws.
+   *
+   * Ariadne has a single `default` namespace.
+   *
+   * @throws UnsupportedOperationException
+   *   always
+   */
+  override def createNamespace(namespace: Array[String], metadata: util.Map[String, String]): Unit =
     throw new UnsupportedOperationException(
-      "AriadneCatalog has a single 'default' namespace. Additional namespaces are not supported."
-    )
-  }
+      "AriadneCatalog has a single 'default' namespace. Additional namespaces are not supported.")
 
-  /** Not supported — always throws.
-    *
-    * Ariadne has a single `default` namespace.
-    *
-    * @throws UnsupportedOperationException
-    *   always
-    */
-  override def alterNamespace(
-      namespace: Array[String],
-      changes: NamespaceChange*
-  ): Unit = {
+  /**
+   * Not supported — always throws.
+   *
+   * Ariadne has a single `default` namespace.
+   *
+   * @throws UnsupportedOperationException
+   *   always
+   */
+  override def alterNamespace(namespace: Array[String], changes: NamespaceChange*): Unit =
     throw new UnsupportedOperationException(
-      "AriadneCatalog has a single 'default' namespace. Namespace alteration is not supported."
-    )
-  }
+      "AriadneCatalog has a single 'default' namespace. Namespace alteration is not supported.")
 
-  /** Not supported — always throws.
-    *
-    * Ariadne has a single `default` namespace.
-    *
-    * @throws UnsupportedOperationException
-    *   always
-    */
-  override def dropNamespace(
-      namespace: Array[String],
-      cascade: Boolean
-  ): Boolean = {
+  /**
+   * Not supported — always throws.
+   *
+   * Ariadne has a single `default` namespace.
+   *
+   * @throws UnsupportedOperationException
+   *   always
+   */
+  override def dropNamespace(namespace: Array[String], cascade: Boolean): Boolean =
     throw new UnsupportedOperationException(
-      "AriadneCatalog has a single 'default' namespace. Namespace deletion is not supported."
-    )
-  }
+      "AriadneCatalog has a single 'default' namespace. Namespace deletion is not supported.")
 
-  private def validateNamespace(namespace: Array[String]): Unit = {
+  private def validateNamespace(namespace: Array[String]): Unit =
     if (namespace.nonEmpty && !namespace.sameElements(defaultNs)) {
-      throw new org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException(
-        namespace
-      )
+      throw new org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException(namespace)
     }
-  }
 }

--- a/src/main/scala/dev/cjfravel/ariadne/catalog/AriadneJoinRule.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/catalog/AriadneJoinRule.scala
@@ -1,169 +1,127 @@
 package dev.cjfravel.ariadne.catalog
 
+import scala.collection.JavaConverters._
+
 import dev.cjfravel.ariadne.Index
 import org.apache.logging.log4j.LogManager
-import org.apache.spark.sql.{
-  AriadneInternalHelper,
-  Row,
-  SparkSession,
-  functions
-}
-import org.apache.spark.sql.catalyst.expressions.{
-  Alias,
-  And,
-  Attribute,
-  EqualTo,
-  Expression
-}
+import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.Inner
 import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.execution.datasources.v2.{
-  DataSourceV2Relation,
-  DataSourceV2ScanRelation
-}
+import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, DataSourceV2ScanRelation}
 import org.apache.spark.sql.types.{StructField, StructType}
 
-import scala.collection.JavaConverters._
-
-/** Catalyst optimizer rule that rewrites JOINs involving Ariadne tables.
-  *
-  * When a SQL query joins against an Ariadne catalog table, this rule
-  * intercepts the logical plan and replaces the Ariadne scan with a pre-pruned
-  * read that only includes files matching the join values. The original `Join`
-  * node, condition, hints, and ExprIds are all preserved.
-  *
-  * '''Safety constraints (the rule only fires when ALL hold):'''
-  *   1. The join type is `INNER` 2. The entire condition is composed of
-  *      equi-join predicates (`a.col = b.col`) 3. Every Ariadne-side join
-  *      column is indexed in the Ariadne index 4. The Ariadne table is the
-  *      direct child of the `Join` node (no intervening Filter, Project, or
-  *      other operators)
-  *
-  * Column names may differ between sides (e.g., `c.id = q.customer_id`); the
-  * rule identifies which attribute belongs to the Ariadne side by ExprId and
-  * maps values accordingly for `locateFiles()`.
-  *
-  * When any constraint is not met, the rule does not fire and Spark falls back
-  * to the standard V1Scan path (full table scan + standard join).
-  *
-  * '''How the rewrite works:'''
-  *   1. Converts the non-Ariadne side into a DataFrame of join-key values 2.
-  *      Calls `locateFilesFromDataFrame()` which performs a distributed join
-  *      against the Ariadne index table — value matching stays in Spark
-  *      executors and only the final filename set (bounded by file count) is
-  *      collected to the driver 3. Replaces the Ariadne `DataSourceV2Relation`
-  *      with a plan that reads only those files, aliased to preserve the
-  *      original output ExprIds 4. Applies temporal deduplication if the index
-  *      has temporal columns 5. Returns a new `Join` node with the pruned
-  *      Ariadne side, preserving the original condition, join type, and hints
-  *
-  * '''Limitations:'''
-  *   - Non-equi conditions, outer/semi/anti joins, and partially-indexed
-  *     conditions all fall back to the V1Scan path
-  *   - The other side of the join is executed during optimization to perform
-  *     the distributed file lookup. This is consistent with the behavior of the
-  *     programmatic `Index.join()` API.
-  *
-  * '''Registration:''' This rule is registered via [[AriadneSparkExtension]]:
-  * {{{
-  * // spark.sql.extensions must be set on SparkConf before SparkContext creation
-  * conf.set("spark.sql.extensions",
-  *   "dev.cjfravel.ariadne.catalog.AriadneSparkExtension")
-  * }}}
-  *
-  * '''Thread safety:''' This rule holds no mutable state. Catalyst may invoke
-  * it concurrently for different query plans; each invocation is independent.
-  *
-  * @param sparkSession
-  *   the active SparkSession
-  *
-  * @see
-  *   [[AriadneSparkExtension]] for registration
-  * @see
-  *   [[AriadneCatalog]] for the catalog integration
-  */
+/**
+ * Catalyst optimizer rule that rewrites JOINs involving Ariadne tables.
+ *
+ * When a SQL query joins against an Ariadne catalog table, this rule intercepts the logical plan and replaces the
+ * Ariadne scan with a pre-pruned read that only includes files matching the join values. The original `Join` node,
+ * condition, hints, and ExprIds are all preserved.
+ *
+ * '''Safety constraints (the rule only fires when ALL hold):'''
+ *   1. The join type is `INNER` 2. The entire condition is composed of equi-join predicates (`a.col = b.col`) 3. Every
+ *      Ariadne-side join column is indexed in the Ariadne index 4. The Ariadne table is the direct child of the `Join`
+ *      node (no intervening Filter, Project, or other operators)
+ *
+ * Column names may differ between sides (e.g., `c.id = q.customer_id`); the rule identifies which attribute belongs to
+ * the Ariadne side by ExprId and maps values accordingly for `locateFiles()`.
+ *
+ * When any constraint is not met, the rule does not fire and Spark falls back to the standard V1Scan path (full table
+ * scan + standard join).
+ *
+ * '''How the rewrite works:'''
+ *   1. Converts the non-Ariadne side into a DataFrame of join-key values 2. Calls `locateFilesFromDataFrame()` which
+ *      performs a distributed join against the Ariadne index table — value matching stays in Spark executors and only
+ *      the final filename set (bounded by file count) is collected to the driver 3. Replaces the Ariadne
+ *      `DataSourceV2Relation` with a plan that reads only those files, aliased to preserve the original ExprIds 4.
+ *      Applies temporal deduplication if the index has temporal columns 5. Returns a new `Join` node with the pruned
+ *      Ariadne side, preserving the original condition, join type, and hints
+ *
+ * '''Limitations:'''
+ *   - Non-equi conditions, outer/semi/anti joins, and partially-indexed conditions all fall back to the V1Scan path
+ *   - The other side of the join is executed during optimization to perform the distributed file lookup. This is
+ *     consistent with the behavior of the programmatic `Index.join()` API.
+ *
+ * '''Registration:''' This rule is registered via [[AriadneSparkExtension]]:
+ * {{{
+ * // spark.sql.extensions must be set on SparkConf before SparkContext creation
+ * conf.set("spark.sql.extensions",
+ *   "dev.cjfravel.ariadne.catalog.AriadneSparkExtension")
+ * }}}
+ *
+ * '''Thread safety:''' This rule holds no mutable state. Catalyst may invoke it concurrently for different query plans;
+ * each invocation is independent.
+ *
+ * @param sparkSession
+ *   the active SparkSession
+ *
+ * @see
+ *   [[AriadneSparkExtension]] for registration
+ * @see
+ *   [[AriadneCatalog]] for the catalog integration
+ */
 class AriadneJoinRule(sparkSession: SparkSession) extends Rule[LogicalPlan] {
 
   private val logger = LogManager.getLogger("ariadne")
 
-  /** Transforms a logical plan by rewriting eligible JOINs involving Ariadne
-    * tables.
-    *
-    * Uses `transformUp` to visit each Join node bottom-up. Only rewrites INNER
-    * equi-joins where every Ariadne-side column is indexed. If the rewrite
-    * fails for any reason, the original Join node is returned unchanged and
-    * Spark falls back to the standard V1Scan path.
-    *
-    * @param plan
-    *   the logical plan to transform
-    * @return
-    *   the transformed plan with Ariadne JOINs rewritten, or the original plan
-    *   if no rewrites were applicable
-    */
-  override def apply(plan: LogicalPlan): LogicalPlan = plan.transformUp {
-    case j @ Join(left, right, joinType, Some(condition), hint) =>
+  /**
+   * Transforms a logical plan by rewriting eligible JOINs involving Ariadne tables.
+   *
+   * Uses `transformUp` to visit each Join node bottom-up. Only rewrites INNER equi-joins where every Ariadne-side
+   * column is indexed. If the rewrite fails for any reason, the original Join node is returned unchanged and Spark
+   * falls back to the standard V1Scan path.
+   *
+   * @param plan
+   *   the logical plan to transform
+   * @return
+   *   the transformed plan with Ariadne JOINs rewritten, or the original plan if no rewrites were applicable
+   */
+  override def apply(plan: LogicalPlan): LogicalPlan =
+    plan.transformUp { case j @ Join(left, right, joinType, Some(condition), hint) =>
       val leftAriadne = extractDirectAriadneTable(left)
       val rightAriadne = extractDirectAriadneTable(right)
 
       (leftAriadne, rightAriadne) match {
         case (Some((tableName, _)), None) =>
-          rewriteJoin(
-            tableName,
-            left,
-            right,
-            condition,
-            joinType,
-            hint,
-            isAriadneLeft = true
-          ).getOrElse(j)
+          rewriteJoin(tableName, left, right, condition, joinType, hint, isAriadneLeft = true).getOrElse(j)
 
         case (None, Some((tableName, _))) =>
-          rewriteJoin(
-            tableName,
-            right,
-            left,
-            condition,
-            joinType,
-            hint,
-            isAriadneLeft = false
-          ).getOrElse(j)
+          rewriteJoin(tableName, right, left, condition, joinType, hint, isAriadneLeft = false).getOrElse(j)
 
         case _ => j
       }
-  }
+    }
 
-  /** Attempts to optimize a join by pre-pruning the Ariadne side's file list.
-    *
-    * Instead of replacing the entire Join, this method replaces only the
-    * Ariadne scan with a pre-pruned read. The original Join node, condition,
-    * hints, and ExprIds are preserved, avoiding ExprId mismatch errors.
-    *
-    * '''Driver OOM risk:''' `locateFilesFromDataFrame` collects the matching
-    * filename set to the driver. This is bounded by file count (not join key
-    * cardinality), but extremely large file lists could pressure driver memory.
-    *
-    * '''Fallback behavior:''' If any exception occurs during rewriting (e.g.,
-    * index read failure), the exception is logged and `None` is returned,
-    * causing Spark to fall back to the standard un-optimized join.
-    *
-    * @param ariadneIndexName
-    *   the Ariadne index name
-    * @param ariadnePlan
-    *   the logical plan of the Ariadne side
-    * @param otherPlan
-    *   the logical plan of the non-Ariadne side
-    * @param condition
-    *   the join condition expression
-    * @param joinType
-    *   the join type (must be Inner)
-    * @param hint
-    *   the join hint from the original plan
-    * @param isAriadneLeft
-    *   true if the Ariadne table is on the left side
-    * @return
-    *   Some(rewritten plan) if successful, None to fall back
-    */
+  /**
+   * Attempts to optimize a join by pre-pruning the Ariadne side's file list.
+   *
+   * Instead of replacing the entire Join, this method replaces only the Ariadne scan with a pre-pruned read. The
+   * original Join node, condition, hints, and ExprIds are preserved, avoiding ExprId mismatch errors.
+   *
+   * '''Driver OOM risk:''' `locateFilesFromDataFrame` collects the matching filename set to the driver. This is bounded
+   * by file count (not join key cardinality), but extremely large file lists could pressure driver memory.
+   *
+   * '''Fallback behavior:''' If any exception occurs during rewriting (e.g., index read failure), the exception is
+   * logged and `None` is returned, causing Spark to fall back to the standard un-optimized join.
+   *
+   * @param ariadneIndexName
+   *   the Ariadne index name
+   * @param ariadnePlan
+   *   the logical plan of the Ariadne side
+   * @param otherPlan
+   *   the logical plan of the non-Ariadne side
+   * @param condition
+   *   the join condition expression
+   * @param joinType
+   *   the join type (must be Inner)
+   * @param hint
+   *   the join hint from the original plan
+   * @param isAriadneLeft
+   *   true if the Ariadne table is on the left side
+   * @return
+   *   Some(rewritten plan) if successful, None to fall back
+   */
   private def rewriteJoin(
       ariadneIndexName: String,
       ariadnePlan: LogicalPlan,
@@ -171,21 +129,18 @@ class AriadneJoinRule(sparkSession: SparkSession) extends Rule[LogicalPlan] {
       condition: Expression,
       joinType: org.apache.spark.sql.catalyst.plans.JoinType,
       hint: org.apache.spark.sql.catalyst.plans.logical.JoinHint,
-      isAriadneLeft: Boolean
-  ): Option[LogicalPlan] = {
+      isAriadneLeft: Boolean): Option[LogicalPlan] = {
     if (joinType != Inner) {
       logger.warn(
         s"AriadneJoinRule: only INNER joins are optimized for index " +
-          s"'$ariadneIndexName', got ${joinType.sql}, skipping"
-      )
+          s"'$ariadneIndexName', got ${joinType.sql}, skipping")
       return None
     }
 
     if (!isAllEquiJoin(condition)) {
       logger.warn(
         s"AriadneJoinRule: condition contains non-equi predicates for index " +
-          s"'$ariadneIndexName', skipping optimization"
-      )
+          s"'$ariadneIndexName', skipping optimization")
       return None
     }
 
@@ -193,26 +148,25 @@ class AriadneJoinRule(sparkSession: SparkSession) extends Rule[LogicalPlan] {
     if (equiPairs.isEmpty) {
       logger.warn(
         s"AriadneJoinRule: no equi-join columns found for index " +
-          s"'$ariadneIndexName', skipping optimization"
-      )
+          s"'$ariadneIndexName', skipping optimization")
       return None
     }
 
     // Identify which attribute in each pair belongs to the Ariadne side
     val ariadneExprIds = ariadnePlan.output.map(_.exprId).toSet
-    val columnMapping = equiPairs.flatMap { case (left, right) =>
-      if (ariadneExprIds.contains(left.exprId))
-        Some((left.name, right.name)) // (ariadneCol, otherCol)
-      else if (ariadneExprIds.contains(right.exprId))
-        Some((right.name, left.name)) // (ariadneCol, otherCol)
-      else
-        None
-    }
+    val columnMapping =
+      equiPairs.flatMap { case (left, right) =>
+        if (ariadneExprIds.contains(left.exprId))
+          Some((left.name, right.name)) // (ariadneCol, otherCol)
+        else if (ariadneExprIds.contains(right.exprId))
+          Some((right.name, left.name)) // (ariadneCol, otherCol)
+        else
+          None
+      }
     if (columnMapping.length != equiPairs.length) {
       logger.warn(
         s"AriadneJoinRule: could not resolve column ownership for index " +
-          s"'$ariadneIndexName', skipping optimization"
-      )
+          s"'$ariadneIndexName', skipping optimization")
       return None
     }
 
@@ -226,15 +180,13 @@ class AriadneJoinRule(sparkSession: SparkSession) extends Rule[LogicalPlan] {
       logger.warn(
         s"AriadneJoinRule: not all Ariadne join columns " +
           s"[${ariadneJoinCols.mkString(", ")}] are indexed in " +
-          s"'$ariadneIndexName', skipping optimization"
-      )
+          s"'$ariadneIndexName', skipping optimization")
       return None
     }
 
     logger.warn(
       s"AriadneJoinRule: rewriting INNER join on index '$ariadneIndexName' " +
-        s"with columns [${columnMapping.map { case (a, o) => s"$a=$o" }.mkString(", ")}]"
-    )
+        s"with columns [${columnMapping.map { case (a, o) => s"$a=$o" }.mkString(", ")}]")
 
     try {
       val otherDf = AriadneInternalHelper.dataFrameFromPlan(spark, otherPlan)
@@ -245,28 +197,26 @@ class AriadneJoinRule(sparkSession: SparkSession) extends Rule[LogicalPlan] {
       // bounded by file count (typically thousands), not join key cardinality
       // (potentially millions).
       val mappingMap = columnMapping.toMap // ariadneCol -> otherCol, deduped
-      val valuesDf = otherDf.select(
-        mappingMap.map { case (ariadneCol, otherCol) =>
+      val valuesDf =
+        otherDf.select(mappingMap.map { case (ariadneCol, otherCol) =>
           functions.col(otherCol).as(ariadneCol)
-        }.toSeq: _*
-      )
+        }.toSeq: _*)
       val colMappings = ariadneJoinCols.map(c => c -> c).toMap
       val files =
         index.locateFilesFromDataFrame(valuesDf, colMappings, ariadneJoinCols)
       val originalOutput = ariadnePlan.output
 
-      val prunedDf = if (files.nonEmpty) {
-        val rawDf = index.readFiles(files)
-        val temporalCols =
-          index.metadata.temporal_indexes.asScala.map(_.column).toSeq
-        val dedupedDf = index.applyTemporalDeduplication(rawDf, temporalCols)
-        dedupedDf.select(originalOutput.map(a => functions.col(a.name)): _*)
-      } else {
-        val schema = StructType(
-          originalOutput.map(a => StructField(a.name, a.dataType, a.nullable))
-        )
-        spark.createDataFrame(spark.sparkContext.emptyRDD[Row], schema)
-      }
+      val prunedDf =
+        if (files.nonEmpty) {
+          val rawDf = index.readFiles(files)
+          val temporalCols =
+            index.metadata.temporal_indexes.asScala.map(_.column).toSeq
+          val dedupedDf = index.applyTemporalDeduplication(rawDf, temporalCols)
+          dedupedDf.select(originalOutput.map(a => functions.col(a.name)): _*)
+        } else {
+          val schema = StructType(originalOutput.map(a => StructField(a.name, a.dataType, a.nullable)))
+          spark.createDataFrame(spark.sparkContext.emptyRDD[Row], schema)
+        }
 
       // Alias output to preserve original ExprIds so parent operators resolve
       val prunedPlan = prunedDf.queryExecution.analyzed
@@ -276,73 +226,64 @@ class AriadneJoinRule(sparkSession: SparkSession) extends Rule[LogicalPlan] {
         }
       val aliasedPlan = Project(aliasedExprs, prunedPlan)
 
-      val (newLeft, newRight) = if (isAriadneLeft) {
-        (aliasedPlan, otherPlan)
-      } else {
-        (otherPlan, aliasedPlan)
-      }
+      val (newLeft, newRight) =
+        if (isAriadneLeft) {
+          (aliasedPlan, otherPlan)
+        } else {
+          (otherPlan, aliasedPlan)
+        }
 
       logger.warn(
         s"AriadneJoinRule: optimized join for index '$ariadneIndexName' " +
-          s"(${files.size} file(s) located)"
-      )
+          s"(${files.size} file(s) located)")
       Some(Join(newLeft, newRight, joinType, Some(condition), hint))
     } catch {
       case e: InterruptedException => throw e
       case e: Exception =>
         logger.warn(
           s"AriadneJoinRule: failed to optimize join for index " +
-            s"'$ariadneIndexName': ${e.getMessage}"
-        )
+            s"'$ariadneIndexName': ${e.getMessage}")
         None
     }
   }
 
-  /** Returns true if the condition consists entirely of equi-join predicates.
-    */
-  private def isAllEquiJoin(condition: Expression): Boolean = condition match {
-    case And(left, right) => isAllEquiJoin(left) && isAllEquiJoin(right)
-    case EqualTo(_: Attribute, _: Attribute) => true
-    case _                                   => false
-  }
+  /**
+   * Returns true if the condition consists entirely of equi-join predicates.
+   */
+  private def isAllEquiJoin(condition: Expression): Boolean =
+    condition match {
+      case And(left, right) => isAllEquiJoin(left) && isAllEquiJoin(right)
+      case EqualTo(_: Attribute, _: Attribute) => true
+      case _ => false
+    }
 
   /** Extracts (left, right) attribute pairs from equi-join conditions. */
-  private def extractEquiJoinPairs(
-      condition: Expression
-  ): Seq[(Attribute, Attribute)] = condition match {
-    case And(left, right) =>
-      extractEquiJoinPairs(left) ++ extractEquiJoinPairs(right)
-    case EqualTo(left: Attribute, right: Attribute) =>
-      Seq((left, right))
-    case _ => Seq.empty
-  }
+  private def extractEquiJoinPairs(condition: Expression): Seq[(Attribute, Attribute)] =
+    condition match {
+      case And(left, right) =>
+        extractEquiJoinPairs(left) ++ extractEquiJoinPairs(right)
+      case EqualTo(left: Attribute, right: Attribute) =>
+        Seq((left, right))
+      case _ => Seq.empty
+    }
 
-  /** Checks if the plan IS a direct AriadneTable reference (not nested).
-    * Matches DataSourceV2Relation or DataSourceV2ScanRelation at the top level.
-    * Also looks through column-pruning Projects (Projects whose expressions are
-    * all simple Attributes) which Spark's ColumnPruning rule inserts above the
-    * scan when not all columns are selected. Does NOT look through Filters,
-    * Aggregates, or expression Projects to avoid silently discarding operators
-    * that transform data.
-    */
-  private def extractDirectAriadneTable(
-      plan: LogicalPlan
-  ): Option[(String, AriadneTable)] = plan match {
-    case DataSourceV2Relation(table: AriadneTable, _, _, _, _) =>
-      Some((table.indexName, table))
-    case DataSourceV2ScanRelation(
-          DataSourceV2Relation(table: AriadneTable, _, _, _, _),
-          _,
-          _,
-          _,
-          _
-        ) =>
-      Some((table.indexName, table))
-    case Project(projectList, child)
-        if projectList.forall(_.isInstanceOf[Attribute]) =>
-      extractDirectAriadneTable(child)
-    case _ => None
-  }
+  /**
+   * Checks if the plan IS a direct AriadneTable reference (not nested). Matches DataSourceV2Relation or
+   * DataSourceV2ScanRelation at the top level. Also looks through column-pruning Projects (Projects whose expressions
+   * are all simple Attributes) which Spark's ColumnPruning rule inserts above the scan when not all columns are
+   * selected. Does NOT look through Filters, Aggregates, or expression Projects to avoid silently discarding operators
+   * that transform data.
+   */
+  private def extractDirectAriadneTable(plan: LogicalPlan): Option[(String, AriadneTable)] =
+    plan match {
+      case DataSourceV2Relation(table: AriadneTable, _, _, _, _) =>
+        Some((table.indexName, table))
+      case DataSourceV2ScanRelation(DataSourceV2Relation(table: AriadneTable, _, _, _, _), _, _, _, _) =>
+        Some((table.indexName, table))
+      case Project(projectList, child) if projectList.forall(_.isInstanceOf[Attribute]) =>
+        extractDirectAriadneTable(child)
+      case _ => None
+    }
 
   /** Returns all column names that have any type of index configured. */
   private def allIndexedColumns(index: Index): Set[String] = {

--- a/src/main/scala/dev/cjfravel/ariadne/catalog/AriadneScan.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/catalog/AriadneScan.scala
@@ -1,91 +1,80 @@
 package dev.cjfravel.ariadne.catalog
 
-import dev.cjfravel.ariadne.{FileList, Index, IndexMetadata, IndexPathUtils}
-import org.apache.logging.log4j.LogManager
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{Row, SQLContext, SparkSession}
-import org.apache.spark.sql.connector.read.{
-  Scan,
-  ScanBuilder,
-  SupportsPushDownFilters,
-  V1Scan
-}
-import org.apache.spark.sql.sources._
-import org.apache.spark.sql.types.StructType
-
 import scala.collection.JavaConverters._
 
-/** Builds a scan for reading Ariadne index source data with filter pushdown.
-  *
-  * Implements [[SupportsPushDownFilters]] to convert `WHERE` clause filters on
-  * indexed columns into
-  * [[dev.cjfravel.ariadne.IndexQueryOperations.locateFiles]] calls, pruning the
-  * source file list before reading.
-  *
-  * '''Thread safety:''' Instances are created per scan by
-  * [[AriadneTable.newScanBuilder]] and are not shared across threads.
-  *
-  * @param indexName
-  *   the Ariadne index name
-  * @param sourceSchema
-  *   the schema of the source data files
-  * @param metadata
-  *   the index metadata
-  *
-  * @see
-  *   [[AriadneV1Scan]] for the scan implementation
-  */
-class AriadneScanBuilder(
-    indexName: String,
-    sourceSchema: StructType,
-    metadata: IndexMetadata
-) extends ScanBuilder
+import dev.cjfravel.ariadne._
+import org.apache.logging.log4j.LogManager
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.connector.read._
+import org.apache.spark.sql.sources._
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{Row, SQLContext, SparkSession}
+
+/**
+ * Builds a scan for reading Ariadne index source data with filter pushdown.
+ *
+ * Implements [[SupportsPushDownFilters]] to convert `WHERE` clause filters on indexed columns into
+ * [[dev.cjfravel.ariadne.IndexQueryOperations.locateFiles]] calls, pruning the source file list before reading.
+ *
+ * '''Thread safety:''' Instances are created per scan by [[AriadneTable.newScanBuilder]] and are not shared across
+ * threads.
+ *
+ * @param indexName
+ *   the Ariadne index name
+ * @param sourceSchema
+ *   the schema of the source data files
+ * @param metadata
+ *   the index metadata
+ *
+ * @see
+ *   [[AriadneV1Scan]] for the scan implementation
+ */
+class AriadneScanBuilder(indexName: String, sourceSchema: StructType, metadata: IndexMetadata)
+    extends ScanBuilder
     with SupportsPushDownFilters {
 
   private val logger = LogManager.getLogger("ariadne")
   private var pushedFilterArray: Array[Filter] = Array.empty
 
-  /** Pushes filters to the scan for file-level pruning via the index.
-    *
-    * Filters on indexed columns (`EqualTo`, `In`) are accepted and used to call
-    * `locateFiles()` to prune the source file list. Filters on non-indexed
-    * columns are returned for Spark to apply post-scan.
-    *
-    * @param filters
-    *   the filters to push
-    * @return
-    *   filters that could NOT be pushed (must be applied post-scan)
-    */
+  /**
+   * Pushes filters to the scan for file-level pruning via the index.
+   *
+   * Filters on indexed columns (`EqualTo`, `In`) are accepted and used to call `locateFiles()` to prune the source file
+   * list. Filters on non-indexed columns are returned for Spark to apply post-scan.
+   *
+   * @param filters
+   *   the filters to push
+   * @return
+   *   filters that could NOT be pushed (must be applied post-scan)
+   */
   override def pushFilters(filters: Array[Filter]): Array[Filter] = {
     val indexedColumns = allIndexedColumns
-    val pushable = filters.filter { f =>
-      extractFilterColumn(f).exists(indexedColumns.contains)
-    }
+    val pushable = filters.filter(f => extractFilterColumn(f).exists(indexedColumns.contains))
     pushedFilterArray = pushable
     logger.warn(
       s"AriadneScanBuilder: accepted ${pushable.length} filter(s) for file pruning " +
-        s"on index '$indexName' (all ${filters.length} filters applied post-scan by Spark)"
-    )
+        s"on index '$indexName' (all ${filters.length} filters applied post-scan by Spark)")
     // Return ALL filters — Spark must apply them post-scan since our
     // file-level pruning via locateFiles is coarse-grained (file, not row)
     filters
   }
 
-  /** Returns the filters that were successfully pushed for file-level pruning.
-    *
-    * @return
-    *   array of pushed filters
-    */
+  /**
+   * Returns the filters that were successfully pushed for file-level pruning.
+   *
+   * @return
+   *   array of pushed filters
+   */
   override def pushedFilters(): Array[Filter] = pushedFilterArray
 
-  /** Builds a [[AriadneV1Scan]] with the current pushed filters.
-    *
-    * @return
-    *   a new V1-based scan for reading Ariadne source data
-    */
-  override def build(): Scan = {
+  /**
+   * Builds a [[AriadneV1Scan]] with the current pushed filters.
+   *
+   * @return
+   *   a new V1-based scan for reading Ariadne source data
+   */
+  override def build(): Scan =
     new AriadneV1Scan(indexName, sourceSchema, metadata, pushedFilterArray)
-  }
 
   private def allIndexedColumns: Set[String] = {
     val regular = metadata.indexes.asScala.toSet
@@ -101,93 +90,83 @@ class AriadneScanBuilder(
   private def extractFilterColumn(filter: Filter): Option[String] =
     filter match {
       case EqualTo(attr, _) => Some(attr)
-      case In(attr, _)      => Some(attr)
-      case _                => None
+      case In(attr, _) => Some(attr)
+      case _ => None
     }
 }
 
-/** V1-based scan that delegates file reading to Spark's built-in readers.
-  *
-  * Uses `V1Scan` to create a `BaseRelation` that reads source data files using
-  * `spark.read` with the appropriate format (CSV, Parquet, JSON). This avoids
-  * reimplementing file readers and gives full Spark optimization (predicate
-  * pushdown to Parquet, column pruning, etc.).
-  *
-  * When WHERE filters were pushed through [[AriadneScanBuilder]], the file list
-  * is pruned via [[dev.cjfravel.ariadne.IndexQueryOperations.locateFiles]]
-  * before reading.
-  *
-  * '''Driver memory note:''' `locateMatchingFiles` collects the file list to
-  * the driver. This is bounded by the number of indexed files (not row count),
-  * but extremely large file lists could pressure driver memory.
-  *
-  * '''Thread safety:''' Instances are created per scan and are not shared
-  * across threads.
-  *
-  * @param indexName
-  *   the Ariadne index name
-  * @param sourceSchema
-  *   the schema of the source data files
-  * @param metadata
-  *   the index metadata
-  * @param pushedFilters
-  *   the filters pushed from the ScanBuilder
-  */
-class AriadneV1Scan(
-    indexName: String,
-    sourceSchema: StructType,
-    metadata: IndexMetadata,
-    pushedFilters: Array[Filter]
-) extends V1Scan {
+/**
+ * V1-based scan that delegates file reading to Spark's built-in readers.
+ *
+ * Uses `V1Scan` to create a `BaseRelation` that reads source data files using `spark.read` with the appropriate format
+ * (CSV, Parquet, JSON). This avoids reimplementing file readers and gives full Spark optimization (predicate pushdown
+ * to Parquet, column pruning, etc.).
+ *
+ * When WHERE filters were pushed through [[AriadneScanBuilder]], the file list is pruned via
+ * [[dev.cjfravel.ariadne.IndexQueryOperations.locateFiles]] before reading.
+ *
+ * '''Driver memory note:''' `locateMatchingFiles` collects the file list to the driver. This is bounded by the number
+ * of indexed files (not row count), but extremely large file lists could pressure driver memory.
+ *
+ * '''Thread safety:''' Instances are created per scan and are not shared across threads.
+ *
+ * @param indexName
+ *   the Ariadne index name
+ * @param sourceSchema
+ *   the schema of the source data files
+ * @param metadata
+ *   the index metadata
+ * @param pushedFilters
+ *   the filters pushed from the ScanBuilder
+ */
+class AriadneV1Scan(indexName: String, sourceSchema: StructType, metadata: IndexMetadata, pushedFilters: Array[Filter])
+    extends V1Scan {
 
   private val logger = LogManager.getLogger("ariadne")
 
-  /** Returns the schema of the source data files.
-    *
-    * @return
-    *   the source data schema stored in index metadata
-    */
+  /**
+   * Returns the schema of the source data files.
+   *
+   * @return
+   *   the source data schema stored in index metadata
+   */
   override def readSchema(): StructType = sourceSchema
 
-  /** Creates a V1 BaseRelation that reads the source data files.
-    *
-    * If filters were pushed, uses `locateFiles()` to prune the file list.
-    * Otherwise reads all indexed files.
-    *
-    * @param sqlCtx
-    *   the SQLContext provided by Spark
-    * @return
-    *   a BaseRelation backed by Ariadne's source data files
-    */
-  override def toV1TableScan[T <: BaseRelation with TableScan](
-      sqlCtx: SQLContext
-  ): T = {
+  /**
+   * Creates a V1 BaseRelation that reads the source data files.
+   *
+   * If filters were pushed, uses `locateFiles()` to prune the file list. Otherwise reads all indexed files.
+   *
+   * @param sqlCtx
+   *   the SQLContext provided by Spark
+   * @return
+   *   a BaseRelation backed by Ariadne's source data files
+   */
+  override def toV1TableScan[T <: BaseRelation with TableScan](sqlCtx: SQLContext): T = {
     implicit val spark: SparkSession = sqlCtx.sparkSession
 
     val files = locateMatchingFiles()
     logger.warn(
       s"AriadneV1Scan: reading ${files.size} file(s) for index '$indexName'" +
-        s" (${pushedFilters.length} pushed filter(s))"
-    )
+        s" (${pushedFilters.length} pushed filter(s))")
 
     new AriadneBaseRelation(sqlCtx, indexName, sourceSchema, metadata, files)
       .asInstanceOf[T]
   }
 
-  private def locateMatchingFiles()(implicit
-      spark: SparkSession
-  ): Set[String] = {
+  private def locateMatchingFiles()(implicit spark: SparkSession): Set[String] = {
     val fileListName = IndexPathUtils.fileListName(indexName)
     if (!FileList.exists(fileListName)) {
       logger.warn(s"AriadneV1Scan: no file list found for index '$indexName'")
       return Set.empty
     }
 
-    val allFiles = FileList(fileListName).files
-      .select("filename")
-      .collect()
-      .flatMap(r => Option(r.getString(0)))
-      .toSet
+    val allFiles =
+      FileList(fileListName).files
+        .select("filename")
+        .collect()
+        .flatMap(r => Option(r.getString(0)))
+        .toSet
 
     if (pushedFilters.isEmpty) {
       allFiles
@@ -198,107 +177,98 @@ class AriadneV1Scan(
       } else {
         val index = Index(indexName)
         val located = index.locateFiles(filterMap)
-        logger.warn(
-          s"AriadneV1Scan: locateFiles pruned ${allFiles.size} → ${located.size} file(s)"
-        )
+        logger.warn(s"AriadneV1Scan: locateFiles pruned ${allFiles.size} → ${located.size} file(s)")
         located
       }
     }
   }
 
-  private def buildLocateFilesMap(): Map[String, Array[Any]] = {
+  private def buildLocateFilesMap(): Map[String, Array[Any]] =
     pushedFilters
       .flatMap {
         case EqualTo(attr, value) => Some(attr -> Array[Any](value))
         case In(attr, values) => Some(attr -> values.map(_.asInstanceOf[Any]))
-        case _                => None
+        case _ => None
       }
       .groupBy(_._1)
       .map { case (col, entries) =>
         col -> entries.flatMap(_._2).distinct
       }
-  }
 }
 
-/** BaseRelation that reads Ariadne index source data files.
-  *
-  * Delegates to Spark's built-in format readers (CSV, Parquet, JSON) using
-  * `spark.read`. Applies computed indexes and exploded field transformations
-  * from the index metadata.
-  *
-  * Extends both `TableScan` and `PrunedFilteredScan`. Spark prefers
-  * `PrunedFilteredScan.buildScan(requiredColumns, filters)` when available,
-  * falling back to `TableScan.buildScan()` only if column pruning is not
-  * needed.
-  *
-  * '''Thread safety:''' Instances are created per scan and are not shared
-  * across threads.
-  *
-  * @param sqlCtx
-  *   the SQLContext
-  * @param indexName
-  *   the Ariadne index name
-  * @param sourceSchema
-  *   the source data schema
-  * @param metadata
-  *   the index metadata
-  * @param files
-  *   the set of source file paths to read
-  */
+/**
+ * BaseRelation that reads Ariadne index source data files.
+ *
+ * Delegates to Spark's built-in format readers (CSV, Parquet, JSON) using `spark.read`. Applies computed indexes and
+ * exploded field transformations from the index metadata.
+ *
+ * Extends both `TableScan` and `PrunedFilteredScan`. Spark prefers
+ * `PrunedFilteredScan.buildScan(requiredColumns, filters)` when available, falling back to `TableScan.buildScan()` only
+ * if column pruning is not needed.
+ *
+ * '''Thread safety:''' Instances are created per scan and are not shared across threads.
+ *
+ * @param sqlCtx
+ *   the SQLContext
+ * @param indexName
+ *   the Ariadne index name
+ * @param sourceSchema
+ *   the source data schema
+ * @param metadata
+ *   the index metadata
+ * @param files
+ *   the set of source file paths to read
+ */
 class AriadneBaseRelation(
     override val sqlContext: SQLContext,
     indexName: String,
     sourceSchema: StructType,
     metadata: IndexMetadata,
-    files: Set[String]
-) extends BaseRelation
+    files: Set[String])
+    extends BaseRelation
     with TableScan
     with PrunedFilteredScan {
 
   private val logger = LogManager.getLogger("ariadne")
 
-  /** Returns the source data schema.
-    *
-    * @return
-    *   the schema of the original source data files
-    */
+  /**
+   * Returns the source data schema.
+   *
+   * @return
+   *   the schema of the original source data files
+   */
   override def schema: StructType = sourceSchema
 
-  /** Full table scan — reads all source data files.
-    *
-    * Used when Spark doesn't push column pruning or filters.
-    *
-    * @return
-    *   RDD of source data rows
-    */
-  override def buildScan(): RDD[Row] = {
+  /**
+   * Full table scan — reads all source data files.
+   *
+   * Used when Spark doesn't push column pruning or filters.
+   *
+   * @return
+   *   RDD of source data rows
+   */
+  override def buildScan(): RDD[Row] =
     buildScan(sourceSchema.fieldNames, Array.empty)
-  }
 
-  /** Builds an RDD of Rows by reading source data files.
-    *
-    * Uses [[dev.cjfravel.ariadne.Index]] internally to read files with computed
-    * indexes and exploded fields applied, then selects only the required
-    * columns.
-    *
-    * @param requiredColumns
-    *   columns Spark needs from this scan
-    * @param filters
-    *   additional filters Spark wants applied (best-effort)
-    * @return
-    *   RDD of source data rows
-    */
-  override def buildScan(
-      requiredColumns: Array[String],
-      filters: Array[Filter]
-  ): RDD[Row] = {
+  /**
+   * Builds an RDD of Rows by reading source data files.
+   *
+   * Uses [[dev.cjfravel.ariadne.Index]] internally to read files with computed indexes and exploded fields applied,
+   * then selects only the required columns.
+   *
+   * @param requiredColumns
+   *   columns Spark needs from this scan
+   * @param filters
+   *   additional filters Spark wants applied (best-effort)
+   * @return
+   *   RDD of source data rows
+   */
+  override def buildScan(requiredColumns: Array[String], filters: Array[Filter]): RDD[Row] = {
     implicit val spark: SparkSession = sqlContext.sparkSession
     val startTime = System.currentTimeMillis()
 
     if (files.isEmpty) {
-      logger.warn(
-        s"AriadneBaseRelation: no files to read for index '$indexName'"
-      )
+      logger.warn(s"AriadneBaseRelation: no files to read for index '$indexName'")
       return spark.sparkContext.emptyRDD[Row]
     }
 
@@ -311,21 +281,19 @@ class AriadneBaseRelation(
     val temporalCols = metadata.temporal_indexes.asScala.map(_.column).toSeq
     val df = index.applyTemporalDeduplication(rawDf, temporalCols)
 
-    val selected = if (requiredColumns.nonEmpty) {
-      df.select(requiredColumns.map(org.apache.spark.sql.functions.col): _*)
-    } else {
-      // Even when no specific columns requested, limit to source schema
-      // to exclude computed/exploded columns added by readFiles
-      df.select(
-        sourceSchema.fieldNames.map(org.apache.spark.sql.functions.col): _*
-      )
-    }
+    val selected =
+      if (requiredColumns.nonEmpty) {
+        df.select(requiredColumns.map(org.apache.spark.sql.functions.col): _*)
+      } else {
+        // Even when no specific columns requested, limit to source schema
+        // to exclude computed/exploded columns added by readFiles
+        df.select(sourceSchema.fieldNames.map(org.apache.spark.sql.functions.col): _*)
+      }
 
     logger.warn(
       s"AriadneBaseRelation: scan setup for index '$indexName' " +
         s"(${files.size} files, ${requiredColumns.length} columns) " +
-        s"in ${System.currentTimeMillis() - startTime}ms"
-    )
+        s"in ${System.currentTimeMillis() - startTime}ms")
     selected.rdd
   }
 }

--- a/src/main/scala/dev/cjfravel/ariadne/catalog/AriadneSparkExtension.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/catalog/AriadneSparkExtension.scala
@@ -3,45 +3,41 @@ package dev.cjfravel.ariadne.catalog
 import org.apache.logging.log4j.LogManager
 import org.apache.spark.sql.SparkSessionExtensions
 
-/** Spark session extension that registers the Ariadne JOIN optimization rule.
-  *
-  * When registered, this extension injects the [[AriadneJoinRule]] into Spark's
-  * optimizer. The rule rewrites JOINs involving Ariadne catalog tables to use
-  * the optimized file-pruning join path.
-  *
-  * '''Configuration:'''
-  * {{{
-  * spark.conf.set("spark.sql.extensions",
-  *   "dev.cjfravel.ariadne.catalog.AriadneSparkExtension")
-  * }}}
-  *
-  * '''Note:''' If your Spark session also uses Delta Lake SQL features, append
-  * this extension to the existing `spark.sql.extensions` value
-  * (comma-separated).
-  *
-  * '''Thread safety:''' The `apply` method is called once during `SparkSession`
-  * creation. It is not invoked concurrently.
-  *
-  * @see
-  *   [[AriadneJoinRule]] for the optimizer rule
-  * @see
-  *   [[AriadneCatalog]] for the catalog plugin
-  */
+/**
+ * Spark session extension that registers the Ariadne JOIN optimization rule.
+ *
+ * When registered, this extension injects the [[AriadneJoinRule]] into Spark's optimizer. The rule rewrites JOINs
+ * involving Ariadne catalog tables to use the optimized file-pruning join path.
+ *
+ * '''Configuration:'''
+ * {{{
+ * spark.conf.set("spark.sql.extensions",
+ *   "dev.cjfravel.ariadne.catalog.AriadneSparkExtension")
+ * }}}
+ *
+ * '''Note:''' If your Spark session also uses Delta Lake SQL features, append this extension to the existing
+ * `spark.sql.extensions` value (comma-separated).
+ *
+ * '''Thread safety:''' The `apply` method is called once during `SparkSession` creation. It is not invoked
+ * concurrently.
+ *
+ * @see
+ *   [[AriadneJoinRule]] for the optimizer rule
+ * @see
+ *   [[AriadneCatalog]] for the catalog plugin
+ */
 class AriadneSparkExtension extends (SparkSessionExtensions => Unit) {
 
   private val logger = LogManager.getLogger("ariadne")
 
-  /** Registers the [[AriadneJoinRule]] optimizer rule with the Spark session.
-    *
-    * @param extensions
-    *   the SparkSessionExtensions to inject rules into
-    */
+  /**
+   * Registers the [[AriadneJoinRule]] optimizer rule with the Spark session.
+   *
+   * @param extensions
+   *   the SparkSessionExtensions to inject rules into
+   */
   override def apply(extensions: SparkSessionExtensions): Unit = {
-    logger.warn(
-      "AriadneSparkExtension: registering AriadneJoinRule optimizer rule"
-    )
-    extensions.injectOptimizerRule { session =>
-      new AriadneJoinRule(session)
-    }
+    logger.warn("AriadneSparkExtension: registering AriadneJoinRule optimizer rule")
+    extensions.injectOptimizerRule(session => new AriadneJoinRule(session))
   }
 }

--- a/src/main/scala/dev/cjfravel/ariadne/catalog/AriadneTable.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/catalog/AriadneTable.scala
@@ -1,88 +1,80 @@
 package dev.cjfravel.ariadne.catalog
 
+import java.util
+
 import dev.cjfravel.ariadne.IndexMetadata
-import org.apache.spark.sql.connector.catalog.{
-  SupportsRead,
-  Table,
-  TableCapability
-}
+import org.apache.spark.sql.connector.catalog.{SupportsRead, Table, TableCapability}
 import org.apache.spark.sql.connector.read.ScanBuilder
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
-import java.util
-
-/** Spark V2 table representing an Ariadne index's source data.
-  *
-  * When queried, this table reads the original data files that were indexed
-  * (not the index metadata tables). The schema is the source data schema stored
-  * in the index's `metadata.json`.
-  *
-  * This table supports batch reads only and is read-only. Write operations are
-  * not supported — index updates are performed via
-  * [[dev.cjfravel.ariadne.Index.update]].
-  *
-  * When used in a JOIN, the [[AriadneJoinRule]] optimizer rule rewrites the
-  * plan to use Ariadne's optimized file-pruning join path.
-  *
-  * '''Thread safety:''' This is an immutable case class. Instances are safe for
-  * concurrent read access from multiple threads.
-  *
-  * @param indexName
-  *   the name of the Ariadne index
-  * @param sourceSchema
-  *   the schema of the original source data files
-  * @param metadata
-  *   the index metadata containing format, indexes, and read options
-  *
-  * @see
-  *   [[AriadneCatalog]] for catalog-level operations
-  * @see
-  *   [[AriadneScanBuilder]] for the scan implementation
-  */
-case class AriadneTable(
-    indexName: String,
-    sourceSchema: StructType,
-    metadata: IndexMetadata
-) extends Table
+/**
+ * Spark V2 table representing an Ariadne index's source data.
+ *
+ * When queried, this table reads the original data files that were indexed (not the index metadata tables). The schema
+ * is the source data schema stored in the index's `metadata.json`.
+ *
+ * This table supports batch reads only and is read-only. Write operations are not supported — index updates are
+ * performed via [[dev.cjfravel.ariadne.Index.update]].
+ *
+ * When used in a JOIN, the [[AriadneJoinRule]] optimizer rule rewrites the plan to use Ariadne's optimized file-pruning
+ * join path.
+ *
+ * '''Thread safety:''' This is an immutable case class. Instances are safe for concurrent read access from multiple
+ * threads.
+ *
+ * @param indexName
+ *   the name of the Ariadne index
+ * @param sourceSchema
+ *   the schema of the original source data files
+ * @param metadata
+ *   the index metadata containing format, indexes, and read options
+ *
+ * @see
+ *   [[AriadneCatalog]] for catalog-level operations
+ * @see
+ *   [[AriadneScanBuilder]] for the scan implementation
+ */
+case class AriadneTable(indexName: String, sourceSchema: StructType, metadata: IndexMetadata)
+    extends Table
     with SupportsRead {
 
-  /** Returns the index name as the table name.
-    *
-    * @return
-    *   the Ariadne index name
-    */
+  /**
+   * Returns the index name as the table name.
+   *
+   * @return
+   *   the Ariadne index name
+   */
   override def name(): String = indexName
 
-  /** Returns the source data schema.
-    *
-    * @return
-    *   the schema of the original source data files
-    */
+  /**
+   * Returns the source data schema.
+   *
+   * @return
+   *   the schema of the original source data files
+   */
   override def schema(): StructType = sourceSchema
 
-  /** Returns the table capabilities.
-    *
-    * @return
-    *   a set containing only `BATCH_READ`
-    */
+  /**
+   * Returns the table capabilities.
+   *
+   * @return
+   *   a set containing only `BATCH_READ`
+   */
   override def capabilities(): util.Set[TableCapability] = {
     val caps = new util.HashSet[TableCapability]()
     caps.add(TableCapability.BATCH_READ)
     caps
   }
 
-  /** Creates a new scan builder for reading this table's source data.
-    *
-    * @param options
-    *   scan options (currently unused; filter pushdown is configured via the
-    *   [[AriadneScanBuilder]])
-    * @return
-    *   a new [[AriadneScanBuilder]]
-    */
-  override def newScanBuilder(
-      options: CaseInsensitiveStringMap
-  ): ScanBuilder = {
+  /**
+   * Creates a new scan builder for reading this table's source data.
+   *
+   * @param options
+   *   scan options (currently unused; filter pushdown is configured via the [[AriadneScanBuilder]])
+   * @return
+   *   a new [[AriadneScanBuilder]]
+   */
+  override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder =
     new AriadneScanBuilder(indexName, sourceSchema, metadata)
-  }
 }

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/AriadneException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/AriadneException.scala
@@ -1,29 +1,26 @@
 package dev.cjfravel.ariadne.exceptions
 
-/** Base exception class for all Ariadne library errors.
-  *
-  * Extends `RuntimeException` following Scala conventions for unchecked
-  * exceptions. All domain-specific exceptions in the Ariadne library extend
-  * this class, enabling callers to catch any Ariadne error with a single
-  * handler if desired.
-  *
-  * '''Thread safety:''' Instances are immutable after construction and safe to
-  * share across threads.
-  *
-  * {{{
-  * try {
-  *   index.update("abfss://data@mystorage.dfs.core.windows.net/")
-  * } catch {
-  *   case e: AriadneException =>
-  *     // handles any Ariadne-specific error
-  *     logger.error(s"Ariadne operation failed: \${e.getMessage}", e)
-  * }
-  * }}}
-  *
-  * @param message
-  *   descriptive error message
-  * @param cause
-  *   optional underlying cause of the error
-  */
-class AriadneException(message: String, cause: Throwable = null)
-    extends RuntimeException(message, cause)
+/**
+ * Base exception class for all Ariadne library errors.
+ *
+ * Extends `RuntimeException` following Scala conventions for unchecked exceptions. All domain-specific exceptions in
+ * the Ariadne library extend this class, enabling callers to catch any Ariadne error with a single handler if desired.
+ *
+ * '''Thread safety:''' Instances are immutable after construction and safe to share across threads.
+ *
+ * {{{
+ * try {
+ *   index.update("abfss://data@mystorage.dfs.core.windows.net/")
+ * } catch {
+ *   case e: AriadneException =>
+ *     // handles any Ariadne-specific error
+ *     logger.error(s"Ariadne operation failed: \${e.getMessage}", e)
+ * }
+ * }}}
+ *
+ * @param message
+ *   descriptive error message
+ * @param cause
+ *   optional underlying cause of the error
+ */
+class AriadneException(message: String, cause: Throwable = null) extends RuntimeException(message, cause)

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/ColumnNotFoundException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/ColumnNotFoundException.scala
@@ -1,29 +1,24 @@
 package dev.cjfravel.ariadne.exceptions
 
-/** Thrown when a specified column is not found in the DataFrame schema or index
-  * configuration.
-  *
-  * This exception is raised by index build and query operations when a column
-  * referenced in the index configuration does not exist in the data schema.
-  * Callers include `Index.addIndex`, `Index.addBloomIndex`,
-  * `Index.addTemporalIndex`, `Index.addRangeIndex`,
-  * `Index.addExplodedFieldIndex`, `Index.addComputedIndex`,
-  * `IndexJoinOperations.joinDf`, and `Index.select`.
-  *
-  * '''Recovery:''' Verify that the column name exists in the DataFrame schema
-  * (check spelling and case sensitivity). Use `df.schema.fieldNames` to list
-  * available columns.
-  *
-  * '''Thread safety:''' Instances are immutable after construction and safe to
-  * share across threads.
-  *
-  * {{{
-  * // Throws ColumnNotFoundException if "nonexistent_col" is not in the schema
-  * index.addIndex("nonexistent_col")
-  * }}}
-  *
-  * @param column
-  *   The name of the column that was not found
-  */
-class ColumnNotFoundException(column: String)
-    extends AriadneException(s"Column $column was not found in the dataframe")
+/**
+ * Thrown when a specified column is not found in the DataFrame schema or index configuration.
+ *
+ * This exception is raised by index build and query operations when a column referenced in the index configuration does
+ * not exist in the data schema. Callers include `Index.addIndex`, `Index.addBloomIndex`, `Index.addTemporalIndex`,
+ * `Index.addRangeIndex`, `Index.addExplodedFieldIndex`, `Index.addComputedIndex`, `IndexJoinOperations.joinDf`, and
+ * `Index.select`.
+ *
+ * '''Recovery:''' Verify that the column name exists in the DataFrame schema (check spelling and case sensitivity). Use
+ * `df.schema.fieldNames` to list available columns.
+ *
+ * '''Thread safety:''' Instances are immutable after construction and safe to share across threads.
+ *
+ * {{{
+ * // Throws ColumnNotFoundException if "nonexistent_col" is not in the schema
+ * index.addIndex("nonexistent_col")
+ * }}}
+ *
+ * @param column
+ *   The name of the column that was not found
+ */
+class ColumnNotFoundException(column: String) extends AriadneException(s"Column $column was not found in the dataframe")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/FileListNotFoundException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/FileListNotFoundException.scala
@@ -1,27 +1,24 @@
 package dev.cjfravel.ariadne.exceptions
 
-/** Thrown when a FileList with the specified name cannot be found on storage.
-  *
-  * Raised by `FileList.remove` when the Delta table backing the file list does
-  * not exist. Also encountered indirectly via `IndexPathUtils.remove` and
-  * `IndexCatalog.remove` when cleaning up an index whose file list has already
-  * been deleted.
-  *
-  * '''Recovery:''' This is typically non-fatal during cleanup operations. If
-  * encountered during `IndexCatalog.remove`, it is caught and logged
-  * internally. If encountered directly, the file list has already been deleted
-  * and no further action is needed.
-  *
-  * '''Thread safety:''' Instances are immutable after construction and safe to
-  * share across threads.
-  *
-  * {{{
-  * // Throws FileListNotFoundException if the file list was already removed
-  * FileList.remove("[ariadne_index] myIndex")
-  * }}}
-  *
-  * @param name
-  *   The name of the FileList that was not found
-  */
-class FileListNotFoundException(name: String)
-    extends AriadneException(s"FileList $name was not found")
+/**
+ * Thrown when a FileList with the specified name cannot be found on storage.
+ *
+ * Raised by `FileList.remove` when the Delta table backing the file list does not exist. Also encountered indirectly
+ * via `IndexPathUtils.remove` and `IndexCatalog.remove` when cleaning up an index whose file list has already been
+ * deleted.
+ *
+ * '''Recovery:''' This is typically non-fatal during cleanup operations. If encountered during `IndexCatalog.remove`,
+ * it is caught and logged internally. If encountered directly, the file list has already been deleted and no further
+ * action is needed.
+ *
+ * '''Thread safety:''' Instances are immutable after construction and safe to share across threads.
+ *
+ * {{{
+ * // Throws FileListNotFoundException if the file list was already removed
+ * FileList.remove("[ariadne_index] myIndex")
+ * }}}
+ *
+ * @param name
+ *   The name of the FileList that was not found
+ */
+class FileListNotFoundException(name: String) extends AriadneException(s"FileList $name was not found")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/FormatMismatchException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/FormatMismatchException.scala
@@ -1,37 +1,30 @@
 package dev.cjfravel.ariadne.exceptions
 
-/** Thrown when the data format provided for an index operation does not match
-  * the format stored in the index metadata.
-  *
-  * Raised by `Index.apply` when reconnecting to an existing index with a
-  * different format than what was originally configured (e.g., creating an
-  * index as "parquet" then attempting to use it as "json").
-  *
-  * '''Recovery:''' Use the correct format matching the stored metadata, or
-  * delete and re-create the index with the desired format. Call
-  * `IndexCatalog.describe(name)` to inspect the stored format.
-  *
-  * '''Thread safety:''' Instances are immutable after construction and safe to
-  * share across threads.
-  *
-  * {{{
-  * // First creation stores format = "parquet"
-  * Index("myIndex", schema, "parquet")
-  * // Throws FormatMismatchException — format conflict
-  * Index("myIndex", schema, "json")
-  * }}}
-  *
-  * @param indexName
-  *   the name of the index with the format conflict
-  * @param expected
-  *   the format stored in existing metadata
-  * @param actual
-  *   the format that was provided and does not match
-  */
-class FormatMismatchException(
-    indexName: String,
-    expected: String,
-    actual: String
-) extends AriadneException(
-      s"Format mismatch for index '$indexName': stored format is '$expected' but '$actual' was provided"
-    )
+/**
+ * Thrown when the data format provided for an index operation does not match the format stored in the index metadata.
+ *
+ * Raised by `Index.apply` when reconnecting to an existing index with a different format than what was originally
+ * configured (e.g., creating an index as "parquet" then attempting to use it as "json").
+ *
+ * '''Recovery:''' Use the correct format matching the stored metadata, or delete and re-create the index with the
+ * desired format. Call `IndexCatalog.describe(name)` to inspect the stored format.
+ *
+ * '''Thread safety:''' Instances are immutable after construction and safe to share across threads.
+ *
+ * {{{
+ * // First creation stores format = "parquet"
+ * Index("myIndex", schema, "parquet")
+ * // Throws FormatMismatchException — format conflict
+ * Index("myIndex", schema, "json")
+ * }}}
+ *
+ * @param indexName
+ *   the name of the index with the format conflict
+ * @param expected
+ *   the format stored in existing metadata
+ * @param actual
+ *   the format that was provided and does not match
+ */
+class FormatMismatchException(indexName: String, expected: String, actual: String)
+    extends AriadneException(
+      s"Format mismatch for index '$indexName': stored format is '$expected' but '$actual' was provided")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexLockException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexLockException.scala
@@ -1,74 +1,67 @@
 package dev.cjfravel.ariadne.exceptions
 
-/** Thrown when a distributed lock for an index operation cannot be acquired.
-  *
-  * This may occur when another process holds the lock and the maximum wait time
-  * (`lockMaxWait`) is exceeded, when lock acquisition is interrupted, or when a
-  * corrupt lock file cannot be recovered after multiple attempts.
-  *
-  * Raised by [[dev.cjfravel.ariadne.IndexLock.acquire]] and propagated through
-  * `Index.update`, `Index.compact`, `Index.vacuum`, and `Index.deleteFiles`.
-  *
-  * '''Recovery:''' Retry the operation after a delay, increase the
-  * `lockMaxWait` configuration, or check for stale/orphaned lock files in the
-  * index storage path. Lock files are stored as `.update.lock` and
-  * `.filelist.lock` under the index directory.
-  *
-  * '''Thread safety:''' Instances are immutable after construction and safe to
-  * share across threads. Note that lock contention is inherently a concurrency
-  * concern — `IndexLock.acquire` is not reentrant.
-  *
-  * {{{
-  * try {
-  *   index.update("abfss://data@mystorage.dfs.core.windows.net/")
-  * } catch {
-  *   case e: IndexLockException =>
-  *     // Another process holds the lock or lock file is corrupt
-  *     logger.error(s"Lock contention: \${e.getMessage}")
-  * }
-  * }}}
-  *
-  * @param message
-  *   A descriptive error message including index name and lock holder details
-  */
+/**
+ * Thrown when a distributed lock for an index operation cannot be acquired.
+ *
+ * This may occur when another process holds the lock and the maximum wait time (`lockMaxWait`) is exceeded, when lock
+ * acquisition is interrupted, or when a corrupt lock file cannot be recovered after multiple attempts.
+ *
+ * Raised by [[dev.cjfravel.ariadne.IndexLock.acquire]] and propagated through `Index.update`, `Index.compact`,
+ * `Index.vacuum`, and `Index.deleteFiles`.
+ *
+ * '''Recovery:''' Retry the operation after a delay, increase the `lockMaxWait` configuration, or check for
+ * stale/orphaned lock files in the index storage path. Lock files are stored as `.update.lock` and `.filelist.lock`
+ * under the index directory.
+ *
+ * '''Thread safety:''' Instances are immutable after construction and safe to share across threads. Note that lock
+ * contention is inherently a concurrency concern — `IndexLock.acquire` is not reentrant.
+ *
+ * {{{
+ * try {
+ *   index.update("abfss://data@mystorage.dfs.core.windows.net/")
+ * } catch {
+ *   case e: IndexLockException =>
+ *     // Another process holds the lock or lock file is corrupt
+ *     logger.error(s"Lock contention: \${e.getMessage}")
+ * }
+ * }}}
+ *
+ * @param message
+ *   A descriptive error message including index name and lock holder details
+ */
 class IndexLockException(message: String) extends AriadneException(message) {
 
-  /** Creates an `IndexLockException` with details about the current lock
-    * holder.
-    *
-    * @param indexName
-    *   the name of the index whose lock could not be acquired
-    * @param holderCorrelationId
-    *   the correlation ID of the process holding the lock
-    * @param holderOwner
-    *   the owner identifier of the process holding the lock
-    */
-  def this(
-      indexName: String,
-      holderCorrelationId: String,
-      holderOwner: String
-  ) =
+  /**
+   * Creates an `IndexLockException` with details about the current lock holder.
+   *
+   * @param indexName
+   *   the name of the index whose lock could not be acquired
+   * @param holderCorrelationId
+   *   the correlation ID of the process holding the lock
+   * @param holderOwner
+   *   the owner identifier of the process holding the lock
+   */
+  def this(indexName: String, holderCorrelationId: String, holderOwner: String) =
     this(
-      s"Could not acquire lock for index '$indexName'. Currently held by correlationId='$holderCorrelationId', owner='$holderOwner'"
-    )
+      s"Could not acquire lock for index '$indexName'. " +
+        s"Currently held by correlationId='$holderCorrelationId', owner='$holderOwner'")
 }
 
-/** Factory for [[IndexLockException]] instances.
-  *
-  * Provides a convenient `apply` method to create timeout-based lock exceptions
-  * without specifying holder details.
-  */
+/**
+ * Factory for [[IndexLockException]] instances.
+ *
+ * Provides a convenient `apply` method to create timeout-based lock exceptions without specifying holder details.
+ */
 object IndexLockException {
 
-  /** Creates an [[IndexLockException]] for a lock acquisition timeout.
-    *
-    * @param indexName
-    *   the name of the index whose lock could not be acquired
-    * @return
-    *   a new `IndexLockException` with a timeout message
-    */
+  /**
+   * Creates an [[IndexLockException]] for a lock acquisition timeout.
+   *
+   * @param indexName
+   *   the name of the index whose lock could not be acquired
+   * @return
+   *   a new `IndexLockException` with a timeout message
+   */
   def apply(indexName: String): IndexLockException =
-    new IndexLockException(
-      s"Could not acquire lock for index '$indexName' within the configured timeout"
-    )
+    new IndexLockException(s"Could not acquire lock for index '$indexName' within the configured timeout")
 }

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexNotFoundException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexNotFoundException.scala
@@ -1,26 +1,22 @@
 package dev.cjfravel.ariadne.exceptions
 
-/** Thrown when an index with the specified name does not exist in storage.
-  *
-  * Raised by `IndexCatalog.get`, `IndexCatalog.remove`,
-  * `IndexCatalog.describe`, `IndexPathUtils.remove`, and `Index.remove` when
-  * the requested index name cannot be found in the configured
-  * `spark.ariadne.storagePath`.
-  *
-  * '''Recovery:''' Verify the index name is correct and that
-  * `spark.ariadne.storagePath` points to the expected storage location. Use
-  * `IndexCatalog.list()` to see available indexes.
-  *
-  * '''Thread safety:''' Instances are immutable after construction and safe to
-  * share across threads.
-  *
-  * {{{
-  * // Throws IndexNotFoundException if "missing" does not exist
-  * val index = IndexCatalog.get("missing")
-  * }}}
-  *
-  * @param name
-  *   The name of the index that was not found
-  */
-class IndexNotFoundException(name: String)
-    extends AriadneException(s"Index $name was not found")
+/**
+ * Thrown when an index with the specified name does not exist in storage.
+ *
+ * Raised by `IndexCatalog.get`, `IndexCatalog.remove`, `IndexCatalog.describe`, `IndexPathUtils.remove`, and
+ * `Index.remove` when the requested index name cannot be found in the configured `spark.ariadne.storagePath`.
+ *
+ * '''Recovery:''' Verify the index name is correct and that `spark.ariadne.storagePath` points to the expected storage
+ * location. Use `IndexCatalog.list()` to see available indexes.
+ *
+ * '''Thread safety:''' Instances are immutable after construction and safe to share across threads.
+ *
+ * {{{
+ * // Throws IndexNotFoundException if "missing" does not exist
+ * val index = IndexCatalog.get("missing")
+ * }}}
+ *
+ * @param name
+ *   The name of the index that was not found
+ */
+class IndexNotFoundException(name: String) extends AriadneException(s"Index $name was not found")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexNotFoundInNewSchemaException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/IndexNotFoundInNewSchemaException.scala
@@ -1,29 +1,25 @@
 package dev.cjfravel.ariadne.exceptions
 
-/** Thrown when a previously indexed column is not found in the new schema
-  * during a schema evolution check.
-  *
-  * Raised by `Index.apply` when `allowSchemaMismatch = true` and the provided
-  * schema is missing a column that the existing index tracks. When schema
-  * mismatch is allowed, Ariadne still validates that all indexed columns exist
-  * in the new schema to prevent silent data loss where an indexed column would
-  * become inaccessible.
-  *
-  * '''Recovery:''' Add the missing column to the new schema, or remove the
-  * index on that column (via `Index.removeIndex`) before changing the schema.
-  *
-  * '''Thread safety:''' Instances are immutable after construction and safe to
-  * share across threads.
-  *
-  * {{{
-  * // Original index has column "user_id"
-  * val newSchema = StructType(Seq(StructField("name", StringType)))
-  * // Throws IndexNotFoundInNewSchemaException — "user_id" is missing
-  * Index("myIndex", newSchema, "parquet", allowSchemaMismatch = true)
-  * }}}
-  *
-  * @param col
-  *   The name of the indexed column missing from the new schema
-  */
-class IndexNotFoundInNewSchemaException(col: String)
-    extends AriadneException(s"Index $col was not found in new schema")
+/**
+ * Thrown when a previously indexed column is not found in the new schema during a schema evolution check.
+ *
+ * Raised by `Index.apply` when `allowSchemaMismatch = true` and the provided schema is missing a column that the
+ * existing index tracks. When schema mismatch is allowed, Ariadne still validates that all indexed columns exist in the
+ * new schema to prevent silent data loss where an indexed column would become inaccessible.
+ *
+ * '''Recovery:''' Add the missing column to the new schema, or remove the index on that column (via
+ * `Index.removeIndex`) before changing the schema.
+ *
+ * '''Thread safety:''' Instances are immutable after construction and safe to share across threads.
+ *
+ * {{{
+ * // Original index has column "user_id"
+ * val newSchema = StructType(Seq(StructField("name", StringType)))
+ * // Throws IndexNotFoundInNewSchemaException — "user_id" is missing
+ * Index("myIndex", newSchema, "parquet", allowSchemaMismatch = true)
+ * }}}
+ *
+ * @param col
+ *   The name of the indexed column missing from the new schema
+ */
+class IndexNotFoundInNewSchemaException(col: String) extends AriadneException(s"Index $col was not found in new schema")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/MetadataMissingOrCorruptException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/MetadataMissingOrCorruptException.scala
@@ -1,33 +1,28 @@
 package dev.cjfravel.ariadne.exceptions
 
-/** Thrown when the index metadata file (`metadata.json`) is missing, empty, or
-  * cannot be parsed into a valid [[dev.cjfravel.ariadne.IndexMetadata]].
-  *
-  * Raised by `IndexMetadataOperations.refreshMetadata` when the file does not
-  * exist or contains invalid JSON, and by `IndexMetadata.apply` when the JSON
-  * string is null, empty, or deserializes to null. Recovery typically requires
-  * deleting the corrupt index and re-creating it.
-  *
-  * '''Thread safety:''' Instances are immutable after construction and safe to
-  * share across threads.
-  *
-  * {{{
-  * try {
-  *   val index = Index("corruptIndex")
-  *   index.metadata // triggers read
-  * } catch {
-  *   case e: MetadataMissingOrCorruptException =>
-  *     // Delete and re-create the index
-  *     IndexCatalog.remove("corruptIndex")
-  * }
-  * }}}
-  *
-  * @param cause
-  *   The underlying exception that caused the parse failure, or null if the
-  *   file is missing
-  */
+/**
+ * Thrown when the index metadata file (`metadata.json`) is missing, empty, or cannot be parsed into a valid
+ * [[dev.cjfravel.ariadne.IndexMetadata]].
+ *
+ * Raised by `IndexMetadataOperations.refreshMetadata` when the file does not exist or contains invalid JSON, and by
+ * `IndexMetadata.apply` when the JSON string is null, empty, or deserializes to null. Recovery typically requires
+ * deleting the corrupt index and re-creating it.
+ *
+ * '''Thread safety:''' Instances are immutable after construction and safe to share across threads.
+ *
+ * {{{
+ * try {
+ *   val index = Index("corruptIndex")
+ *   index.metadata // triggers read
+ * } catch {
+ *   case e: MetadataMissingOrCorruptException =>
+ *     // Delete and re-create the index
+ *     IndexCatalog.remove("corruptIndex")
+ * }
+ * }}}
+ *
+ * @param cause
+ *   The underlying exception that caused the parse failure, or null if the file is missing
+ */
 class MetadataMissingOrCorruptException(cause: Throwable = null)
-    extends AriadneException(
-      "Index metadata is missing or corrupt. Delete and re-create the index.",
-      cause
-    )
+    extends AriadneException("Index metadata is missing or corrupt. Delete and re-create the index.", cause)

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/MissingFormatException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/MissingFormatException.scala
@@ -1,22 +1,19 @@
 package dev.cjfravel.ariadne.exceptions
 
-/** Thrown when an index does not have a file format specified in its metadata.
-  *
-  * Raised by `Index.apply` when creating a new index without providing a
-  * format, or when the existing `IndexMetadata.format` is null or empty
-  * (indicating a corrupt or manually edited metadata file).
-  *
-  * '''Recovery:''' Provide the `format` parameter when creating a new index
-  * (e.g., `Index("myIndex", schema, "parquet")`). If the metadata is corrupt,
-  * delete and re-create the index.
-  *
-  * '''Thread safety:''' Instances are immutable after construction and safe to
-  * share across threads.
-  *
-  * {{{
-  * // Throws MissingFormatException if no format is provided for a new index
-  * Index("newIndex", schema)  // missing format parameter
-  * }}}
-  */
-class MissingFormatException
-    extends AriadneException("Index doesn't have a specified fileformat")
+/**
+ * Thrown when an index does not have a file format specified in its metadata.
+ *
+ * Raised by `Index.apply` when creating a new index without providing a format, or when the existing
+ * `IndexMetadata.format` is null or empty (indicating a corrupt or manually edited metadata file).
+ *
+ * '''Recovery:''' Provide the `format` parameter when creating a new index (e.g.,
+ * `Index("myIndex", schema, "parquet")`). If the metadata is corrupt, delete and re-create the index.
+ *
+ * '''Thread safety:''' Instances are immutable after construction and safe to share across threads.
+ *
+ * {{{
+ * // Throws MissingFormatException if no format is provided for a new index
+ * Index("newIndex", schema)  // missing format parameter
+ * }}}
+ */
+class MissingFormatException extends AriadneException("Index doesn't have a specified fileformat")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/MissingSchemaException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/MissingSchemaException.scala
@@ -1,21 +1,18 @@
 package dev.cjfravel.ariadne.exceptions
 
-/** Thrown when the schema field is missing from the index metadata.
-  *
-  * Raised by `IndexFileOperations.storedSchema` when `IndexMetadata.schema` is
-  * null or empty. This typically indicates a corrupt or manually edited
-  * metadata file, since `Index.apply` always writes a schema during creation.
-  *
-  * '''Recovery:''' Delete and re-create the index, or restore the metadata file
-  * from a backup.
-  *
-  * '''Thread safety:''' Instances are immutable after construction and safe to
-  * share across threads.
-  *
-  * {{{
-  * // A metadata file with no "schema" field will trigger this
-  * val schema = index.storedSchema // throws MissingSchemaException
-  * }}}
-  */
-class MissingSchemaException
-    extends AriadneException("Schema missing from metadata")
+/**
+ * Thrown when the schema field is missing from the index metadata.
+ *
+ * Raised by `IndexFileOperations.storedSchema` when `IndexMetadata.schema` is null or empty. This typically indicates a
+ * corrupt or manually edited metadata file, since `Index.apply` always writes a schema during creation.
+ *
+ * '''Recovery:''' Delete and re-create the index, or restore the metadata file from a backup.
+ *
+ * '''Thread safety:''' Instances are immutable after construction and safe to share across threads.
+ *
+ * {{{
+ * // A metadata file with no "schema" field will trigger this
+ * val schema = index.storedSchema // throws MissingSchemaException
+ * }}}
+ */
+class MissingSchemaException extends AriadneException("Schema missing from metadata")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/SchemaMismatchException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/SchemaMismatchException.scala
@@ -1,33 +1,30 @@
 package dev.cjfravel.ariadne.exceptions
 
-/** Thrown when the schema provided for an index operation does not match the
-  * schema stored in the existing index metadata.
-  *
-  * Raised by `Index.apply` when reconnecting to an existing index and the
-  * provided schema differs from the persisted one, with `allowSchemaMismatch =
-  * false` (the default).
-  *
-  * '''Recovery:''' Use the same schema as stored in the index, or pass
-  * `allowSchemaMismatch = true` to `Index.apply` to update the stored schema.
-  * Note that allowing schema mismatch still requires all indexed columns to
-  * exist in the new schema.
-  *
-  * '''Thread safety:''' Instances are immutable after construction and safe to
-  * share across threads.
-  *
-  * {{{
-  * val schema1 = StructType(Seq(StructField("id", IntegerType)))
-  * Index("myIndex", schema1, "parquet")
-  * val schema2 = StructType(Seq(StructField("id", StringType)))
-  * // Throws SchemaMismatchException — type changed from Int to String
-  * Index("myIndex", schema2, "parquet")
-  * }}}
-  *
-  * @param indexName
-  *   the name of the index with the schema conflict
-  */
+/**
+ * Thrown when the schema provided for an index operation does not match the schema stored in the existing index
+ * metadata.
+ *
+ * Raised by `Index.apply` when reconnecting to an existing index and the provided schema differs from the persisted
+ * one, with `allowSchemaMismatch = false` (the default).
+ *
+ * '''Recovery:''' Use the same schema as stored in the index, or pass `allowSchemaMismatch = true` to `Index.apply` to
+ * update the stored schema. Note that allowing schema mismatch still requires all indexed columns to exist in the new
+ * schema.
+ *
+ * '''Thread safety:''' Instances are immutable after construction and safe to share across threads.
+ *
+ * {{{
+ * val schema1 = StructType(Seq(StructField("id", IntegerType)))
+ * Index("myIndex", schema1, "parquet")
+ * val schema2 = StructType(Seq(StructField("id", StringType)))
+ * // Throws SchemaMismatchException — type changed from Int to String
+ * Index("myIndex", schema2, "parquet")
+ * }}}
+ *
+ * @param indexName
+ *   the name of the index with the schema conflict
+ */
 class SchemaMismatchException(indexName: String)
     extends AriadneException(
       s"Schema mismatch for index '$indexName': provided schema does not match stored schema. " +
-        "Use allowSchemaMismatch=true to update the stored schema."
-    )
+        "Use allowSchemaMismatch=true to update the stored schema.")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/SchemaNotProvidedException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/SchemaNotProvidedException.scala
@@ -1,25 +1,19 @@
 package dev.cjfravel.ariadne.exceptions
 
-/** Thrown when no existing metadata is found and no schema was provided to
-  * create a new index.
-  *
-  * Raised by `Index.apply` when the index does not yet exist on storage and the
-  * caller did not supply a schema. A schema is required for first-time index
-  * creation so that column validation can be performed.
-  *
-  * '''Recovery:''' Provide a schema when creating a new index, e.g.,
-  * `Index("myIndex", schema, "parquet")`.
-  *
-  * '''Thread safety:''' Instances are immutable after construction and safe to
-  * share across threads.
-  *
-  * {{{
-  * // Index "newIndex" does not exist yet — schema is required
-  * Index("newIndex")                       // throws SchemaNotProvidedException
-  * Index("newIndex", schema, "parquet")    // OK
-  * }}}
-  */
-class SchemaNotProvidedException
-    extends AriadneException(
-      "No existing metadata found, schema must be provided"
-    )
+/**
+ * Thrown when no existing metadata is found and no schema was provided to create a new index.
+ *
+ * Raised by `Index.apply` when the index does not yet exist on storage and the caller did not supply a schema. A schema
+ * is required for first-time index creation so that column validation can be performed.
+ *
+ * '''Recovery:''' Provide a schema when creating a new index, e.g., `Index("myIndex", schema, "parquet")`.
+ *
+ * '''Thread safety:''' Instances are immutable after construction and safe to share across threads.
+ *
+ * {{{
+ * // Index "newIndex" does not exist yet — schema is required
+ * Index("newIndex")                       // throws SchemaNotProvidedException
+ * Index("newIndex", schema, "parquet")    // OK
+ * }}}
+ */
+class SchemaNotProvidedException extends AriadneException("No existing metadata found, schema must be provided")

--- a/src/main/scala/dev/cjfravel/ariadne/exceptions/SchemaParseException.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/exceptions/SchemaParseException.scala
@@ -1,24 +1,20 @@
 package dev.cjfravel.ariadne.exceptions
 
-/** Thrown when a schema string is found in metadata but cannot be parsed into a
-  * valid Spark `StructType`.
-  *
-  * Raised by `IndexFileOperations.storedSchema` when `DataType.fromJson` cannot
-  * deserialize the schema string stored in `IndexMetadata.schema`. This
-  * typically indicates a corrupt metadata file or a metadata file written by an
-  * incompatible version of Spark.
-  *
-  * '''Recovery:''' Delete and re-create the index. If the metadata was written
-  * by a different Spark version, ensure the same Spark major version is used to
-  * read the index.
-  *
-  * '''Thread safety:''' Instances are immutable after construction and safe to
-  * share across threads.
-  *
-  * {{{
-  * // A metadata file with schema = "not valid json" triggers this
-  * val schema = index.storedSchema // throws SchemaParseException
-  * }}}
-  */
-class SchemaParseException
-    extends AriadneException("Schema was found, but could not be parsed")
+/**
+ * Thrown when a schema string is found in metadata but cannot be parsed into a valid Spark `StructType`.
+ *
+ * Raised by `IndexFileOperations.storedSchema` when `DataType.fromJson` cannot deserialize the schema string stored in
+ * `IndexMetadata.schema`. This typically indicates a corrupt metadata file or a metadata file written by an
+ * incompatible version of Spark.
+ *
+ * '''Recovery:''' Delete and re-create the index. If the metadata was written by a different Spark version, ensure the
+ * same Spark major version is used to read the index.
+ *
+ * '''Thread safety:''' Instances are immutable after construction and safe to share across threads.
+ *
+ * {{{
+ * // A metadata file with schema = "not valid json" triggers this
+ * val schema = index.storedSchema // throws SchemaParseException
+ * }}}
+ */
+class SchemaParseException extends AriadneException("Schema was found, but could not be parsed")

--- a/src/main/scala/org/apache/spark/sql/AriadneInternalHelper.scala
+++ b/src/main/scala/org/apache/spark/sql/AriadneInternalHelper.scala
@@ -2,29 +2,29 @@ package org.apache.spark.sql
 
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 
-/** Bridge helper to access `private[sql]` Spark APIs from Ariadne.
-  *
-  * This follows the standard pattern used by Delta Lake and other Spark
-  * connectors: placing a helper in the `org.apache.spark.sql` package to access
-  * `private[sql]` members like `Dataset.ofRows`.
-  *
-  * @see
-  *   [[dev.cjfravel.ariadne.catalog.AriadneJoinRule]] for the primary consumer
-  */
+/**
+ * Bridge helper to access `private[sql]` Spark APIs from Ariadne.
+ *
+ * This follows the standard pattern used by Delta Lake and other Spark connectors: placing a helper in the
+ * `org.apache.spark.sql` package to access `private[sql]` members like `Dataset.ofRows`.
+ *
+ * @see
+ *   [[dev.cjfravel.ariadne.catalog.AriadneJoinRule]] for the primary consumer
+ */
 object AriadneInternalHelper {
 
-  /** Creates a DataFrame from a resolved LogicalPlan.
-    *
-    * Wraps `Dataset.ofRows()` which is `private[sql]`.
-    *
-    * @param spark
-    *   the active SparkSession
-    * @param plan
-    *   a resolved (analyzed) logical plan
-    * @return
-    *   a DataFrame wrapping the plan
-    */
-  def dataFrameFromPlan(spark: SparkSession, plan: LogicalPlan): DataFrame = {
+  /**
+   * Creates a DataFrame from a resolved LogicalPlan.
+   *
+   * Wraps `Dataset.ofRows()` which is `private[sql]`.
+   *
+   * @param spark
+   *   the active SparkSession
+   * @param plan
+   *   a resolved (analyzed) logical plan
+   * @return
+   *   a DataFrame wrapping the plan
+   */
+  def dataFrameFromPlan(spark: SparkSession, plan: LogicalPlan): DataFrame =
     Dataset.ofRows(spark, plan)
-  }
 }

--- a/src/test/scala/dev/cjfravel/AriadneContextTests.scala
+++ b/src/test/scala/dev/cjfravel/AriadneContextTests.scala
@@ -2,17 +2,18 @@ package dev.cjfravel
 
 import dev.cjfravel.ariadne.{AriadneContextUser, SparkTests}
 
-/** Tests for [[dev.cjfravel.ariadne.AriadneContextUser]] verifying that the
-  * implicit SparkSession is available and HDFS filesystem access works
-  * correctly.
-  */
+/**
+ * Tests for [[dev.cjfravel.ariadne.AriadneContextUser]] verifying that the implicit SparkSession is available and HDFS
+ * filesystem access works correctly.
+ */
 class AriadneContextTests extends SparkTests {
   test("implicit spark is available") {
     // Test that implicit spark is properly set up
-    val contextUser = new AriadneContextUser {
-      implicit def spark: org.apache.spark.sql.SparkSession =
-        AriadneContextTests.this.spark
-    }
+    val contextUser =
+      new AriadneContextUser {
+        implicit def spark: org.apache.spark.sql.SparkSession =
+          AriadneContextTests.this.spark
+      }
     assert(contextUser.storagePath != null)
     assert(contextUser.fs != null)
   }

--- a/src/test/scala/dev/cjfravel/ariadne/AriadneContextTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/AriadneContextTests.scala
@@ -1,14 +1,15 @@
 package dev.cjfravel.ariadne
 
-/** Tests for [[AriadneContextUser]] verifying storage path configuration is
-  * correctly read from the SparkSession.
-  */
+/**
+ * Tests for [[AriadneContextUser]] verifying storage path configuration is correctly read from the SparkSession.
+ */
 class AriadneContextTests extends SparkTests {
   test("storagePath") {
-    val contextUser = new AriadneContextUser {
-      implicit def spark: org.apache.spark.sql.SparkSession =
-        AriadneContextTests.this.spark
-    }
+    val contextUser =
+      new AriadneContextUser {
+        implicit def spark: org.apache.spark.sql.SparkSession =
+          AriadneContextTests.this.spark
+      }
     assert(contextUser.storagePath.toString === tempDir.toString)
   }
 }

--- a/src/test/scala/dev/cjfravel/ariadne/AutoBloomLargeIndexTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/AutoBloomLargeIndexTests.scala
@@ -1,25 +1,25 @@
 package dev.cjfravel.ariadne
 
-import org.scalatest.matchers.should.Matchers
-import org.apache.spark.sql.types._
-import org.apache.spark.sql.functions._
-import org.apache.hadoop.fs.Path
-import scala.collection.JavaConverters._
 import java.nio.charset.StandardCharsets
 
-/** Tests for automatic bloom filter creation on large index columns, verifying
-  * that auto-bloom filters are built during `update` and used to pre-filter
-  * large index queries.
-  */
+import scala.collection.JavaConverters._
+
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.types._
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Tests for automatic bloom filter creation on large index columns, verifying that auto-bloom filters are built during
+ * `update` and used to pre-filter large index queries.
+ */
 class AutoBloomLargeIndexTests extends SparkTests with Matchers {
 
-  val testSchema = StructType(
-    Seq(
-      StructField("Id", IntegerType, nullable = false),
-      StructField("Version", IntegerType, nullable = false),
-      StructField("Value", DoubleType, nullable = false)
-    )
-  )
+  val testSchema =
+    StructType(
+      Seq(
+        StructField("Id", IntegerType, nullable = false),
+        StructField("Version", IntegerType, nullable = false),
+        StructField("Value", DoubleType, nullable = false)))
 
   private def readMetadata(index: Index): IndexMetadata = {
     val metadataPath = new Path(index.storagePath, "metadata.json")
@@ -36,20 +36,16 @@ class AutoBloomLargeIndexTests extends SparkTests with Matchers {
   test("should automatically create bloom filter for large columns") {
     spark.conf.set("spark.ariadne.largeIndexLimit", "1")
     try {
-      val index = Index(
-        "auto_bloom_create_test",
-        testSchema,
-        "csv",
-        Map("header" -> "true")
-      )
+      val index = Index("auto_bloom_create_test", testSchema, "csv", Map("header" -> "true"))
       index.addFile(resourcePath("/data/table1_part0.csv"))
       index.addIndex("Id")
       index.update
 
       // Verify auto_bloom column exists in the main index
-      val indexDf = spark.read
-        .format("delta")
-        .load(new Path(index.storagePath, "index").toString)
+      val indexDf =
+        spark.read
+          .format("delta")
+          .load(new Path(index.storagePath, "index").toString)
       indexDf.columns should contain("auto_bloom_Id")
 
       // Verify metadata tracks auto_bloom_indexes
@@ -63,12 +59,7 @@ class AutoBloomLargeIndexTests extends SparkTests with Matchers {
   test("should use auto-bloom to filter large index queries") {
     spark.conf.set("spark.ariadne.largeIndexLimit", "1")
     try {
-      val index = Index(
-        "auto_bloom_query_test",
-        testSchema,
-        "csv",
-        Map("header" -> "true")
-      )
+      val index = Index("auto_bloom_query_test", testSchema, "csv", Map("header" -> "true"))
       index.addFile(resourcePath("/data/table1_part0.csv"))
       index.addFile(resourcePath("/data/table1_part1.csv"))
       index.addIndex("Id")
@@ -110,12 +101,7 @@ class AutoBloomLargeIndexTests extends SparkTests with Matchers {
   test("should not create auto-bloom for columns under limit") {
     // Use the default large limit so nothing triggers auto-bloom
     spark.conf.set("spark.ariadne.largeIndexLimit", "500000")
-    val index = Index(
-      "auto_bloom_no_trigger_test",
-      testSchema,
-      "csv",
-      Map("header" -> "true")
-    )
+    val index = Index("auto_bloom_no_trigger_test", testSchema, "csv", Map("header" -> "true"))
     index.addFile(resourcePath("/data/table1_part0.csv"))
     index.addIndex("Id")
     index.update
@@ -129,17 +115,10 @@ class AutoBloomLargeIndexTests extends SparkTests with Matchers {
     files should not be empty
   }
 
-  test(
-    "should correctly identify files with auto-bloom filter via DataFrame join"
-  ) {
+  test("should correctly identify files with auto-bloom filter via DataFrame join") {
     spark.conf.set("spark.ariadne.largeIndexLimit", "1")
     try {
-      val index = Index(
-        "auto_bloom_join_test",
-        testSchema,
-        "csv",
-        Map("header" -> "true")
-      )
+      val index = Index("auto_bloom_join_test", testSchema, "csv", Map("header" -> "true"))
       index.addFile(resourcePath("/data/table1_part0.csv"))
       index.addFile(resourcePath("/data/table1_part1.csv"))
       index.addIndex("Id")
@@ -165,12 +144,7 @@ class AutoBloomLargeIndexTests extends SparkTests with Matchers {
   test("should work with multiple auto-bloom columns") {
     spark.conf.set("spark.ariadne.largeIndexLimit", "1")
     try {
-      val index = Index(
-        "auto_bloom_multi_col_test",
-        testSchema,
-        "csv",
-        Map("header" -> "true")
-      )
+      val index = Index("auto_bloom_multi_col_test", testSchema, "csv", Map("header" -> "true"))
       index.addFile(resourcePath("/data/table1_part0.csv"))
       index.addFile(resourcePath("/data/table1_part1.csv"))
       index.addIndex("Id")
@@ -183,9 +157,10 @@ class AutoBloomLargeIndexTests extends SparkTests with Matchers {
       meta.auto_bloom_indexes.asScala should contain("Version")
 
       // Verify index has both auto_bloom columns
-      val indexDf = spark.read
-        .format("delta")
-        .load(new Path(index.storagePath, "index").toString)
+      val indexDf =
+        spark.read
+          .format("delta")
+          .load(new Path(index.storagePath, "index").toString)
       indexDf.columns should contain("auto_bloom_Id")
       indexDf.columns should contain("auto_bloom_Version")
 

--- a/src/test/scala/dev/cjfravel/ariadne/BatchedIndexUpdateTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/BatchedIndexUpdateTests.scala
@@ -1,35 +1,26 @@
 package dev.cjfravel.ariadne
-
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
-import org.apache.spark.sql.types._
-import org.apache.spark.sql.functions._
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.types._
+import org.scalatest.matchers.should.Matchers
 
-/** Tests for batched index updates, verifying that files are grouped into
-  * optimal batches based on distinct value limits and staged correctly before
-  * consolidation.
-  */
+/**
+ * Tests for batched index updates, verifying that files are grouped into optimal batches based on distinct value limits
+ * and staged correctly before consolidation.
+ */
 class BatchedIndexUpdateTests extends SparkTests with Matchers {
 
-  val testSchema = StructType(
-    Seq(
-      StructField("Id", IntegerType, nullable = false),
-      StructField("Version", IntegerType, nullable = false),
-      StructField("Category", StringType, nullable = false),
-      StructField("Value", DoubleType, nullable = false)
-    )
-  )
+  val testSchema =
+    StructType(
+      Seq(
+        StructField("Id", IntegerType, nullable = false),
+        StructField("Version", IntegerType, nullable = false),
+        StructField("Category", StringType, nullable = false),
+        StructField("Value", DoubleType, nullable = false)))
 
   private def createTestFile(id: Int, distinctValues: Int): (String, String) = {
-    val testData = (1 to distinctValues).map { j =>
-      Row(j, id % 10, s"category_${id}_${j}", j.toDouble)
-    }
+    val testData = (1 to distinctValues).map(j => Row(j, id % 10, s"category_${id}_$j", j.toDouble))
 
-    val df = spark.createDataFrame(
-      spark.sparkContext.parallelize(testData),
-      testSchema
-    )
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(testData), testSchema)
 
     val tempPath =
       s"${System.getProperty("java.io.tmpdir")}/batch_test_${id}_${System.currentTimeMillis()}"
@@ -39,13 +30,14 @@ class BatchedIndexUpdateTests extends SparkTests with Matchers {
       .mode("overwrite")
       .csv(tempPath)
 
-    val fileName = java.nio.file.Files
-      .walk(java.nio.file.Paths.get(tempPath))
-      .filter(java.nio.file.Files.isRegularFile(_))
-      .filter(_.getFileName.toString.endsWith(".csv"))
-      .findFirst()
-      .get()
-      .toString
+    val fileName =
+      java.nio.file.Files
+        .walk(java.nio.file.Paths.get(tempPath))
+        .filter(java.nio.file.Files.isRegularFile(_))
+        .filter(_.getFileName.toString.endsWith(".csv"))
+        .findFirst()
+        .get()
+        .toString
 
     (tempPath, "file://" + fileName)
   }
@@ -53,25 +45,14 @@ class BatchedIndexUpdateTests extends SparkTests with Matchers {
   test("should create multiple batches based on distinct value limits") {
     // Create files that force multiple batches due to distinct value accumulation
     // Total distinct values across files will exceed largeIndexLimit (500k), forcing batching
-    val tempFiles = Seq(
-      createTestFile(1, 150000), // 150k distinct values
-      createTestFile(
-        2,
-        150000
-      ), // 150k distinct values - can batch with file 1 (300k total < 500k)
-      createTestFile(
-        3,
-        200000
-      ), // 200k distinct values - cannot fit with files 1&2, starts new batch
-      createTestFile(
-        4,
-        100000
-      ), // 100k distinct values - can batch with file 3 (300k total < 500k)
-      createTestFile(
-        5,
-        250000
-      ) // 250k distinct values - cannot fit with files 3&4, starts new batch
-    )
+    val tempFiles =
+      Seq(
+        createTestFile(1, 150000), // 150k distinct values
+        createTestFile(2, 150000), // 150k distinct values - can batch with file 1 (300k total < 500k)
+        createTestFile(3, 200000), // 200k distinct values - cannot fit with files 1&2, starts new batch
+        createTestFile(4, 100000), // 100k distinct values - can batch with file 3 (300k total < 500k)
+        createTestFile(5, 250000) // 250k distinct values - cannot fit with files 3&4, starts new batch
+      )
 
     try {
       val index =
@@ -86,15 +67,9 @@ class BatchedIndexUpdateTests extends SparkTests with Matchers {
       index.update
 
       // Verify the index works across all batches
-      val files1 = index.locateFiles(
-        Map("Id" -> Array(75000))
-      ) // Should find in first batch
-      val files2 = index.locateFiles(
-        Map("Id" -> Array(175000))
-      ) // Should find in second batch
-      val files3 = index.locateFiles(
-        Map("Id" -> Array(225000))
-      ) // Should find in third batch
+      val files1 = index.locateFiles(Map("Id" -> Array(75000))) // Should find in first batch
+      val files2 = index.locateFiles(Map("Id" -> Array(175000))) // Should find in second batch
+      val files3 = index.locateFiles(Map("Id" -> Array(225000))) // Should find in third batch
 
       files1 should not be empty
       files2 should not be empty
@@ -103,8 +78,9 @@ class BatchedIndexUpdateTests extends SparkTests with Matchers {
     } finally {
       // Cleanup
       tempFiles.foreach { case (tempPath, _) =>
-        val fs = org.apache.hadoop.fs.FileSystem
-          .get(spark.sparkContext.hadoopConfiguration)
+        val fs =
+          org.apache.hadoop.fs.FileSystem
+            .get(spark.sparkContext.hadoopConfiguration)
         fs.delete(new org.apache.hadoop.fs.Path(tempPath), true)
       }
     }
@@ -112,22 +88,14 @@ class BatchedIndexUpdateTests extends SparkTests with Matchers {
 
   test("should handle files exceeding largeIndexLimit individually") {
     // Create files that individually exceed the largeIndexLimit (500k distinct values)
-    val tempFiles = Seq(
-      createTestFile(
-        1,
-        600000
-      ), // Exceeds largeIndexLimit - processed individually
-      createTestFile(2, 100000), // Small file - can be batched
-      createTestFile(3, 150000), // Small file - can be batched with file 2
-      createTestFile(
-        4,
-        700000
-      ), // Exceeds largeIndexLimit - processed individually
-      createTestFile(
-        5,
-        200000
-      ) // Small file - can be batched with files 2&3 or separate batch
-    )
+    val tempFiles =
+      Seq(
+        createTestFile(1, 600000), // Exceeds largeIndexLimit - processed individually
+        createTestFile(2, 100000), // Small file - can be batched
+        createTestFile(3, 150000), // Small file - can be batched with file 2
+        createTestFile(4, 700000), // Exceeds largeIndexLimit - processed individually
+        createTestFile(5, 200000) // Small file - can be batched with files 2&3 or separate batch
+      )
 
     try {
       val index =
@@ -142,14 +110,10 @@ class BatchedIndexUpdateTests extends SparkTests with Matchers {
       index.update
 
       // Verify functionality across all files
-      val files1 = index.locateFiles(
-        Map("Id" -> Array(300000))
-      ) // Should find large file 1
+      val files1 = index.locateFiles(Map("Id" -> Array(300000))) // Should find large file 1
       val files2 =
         index.locateFiles(Map("Id" -> Array(50000))) // Should find small files
-      val files3 = index.locateFiles(
-        Map("Id" -> Array(400000))
-      ) // Should find large file 4
+      val files3 = index.locateFiles(Map("Id" -> Array(400000))) // Should find large file 4
 
       files1 should not be empty
       files2 should not be empty
@@ -158,8 +122,9 @@ class BatchedIndexUpdateTests extends SparkTests with Matchers {
     } finally {
       // Cleanup
       tempFiles.foreach { case (tempPath, _) =>
-        val fs = org.apache.hadoop.fs.FileSystem
-          .get(spark.sparkContext.hadoopConfiguration)
+        val fs =
+          org.apache.hadoop.fs.FileSystem
+            .get(spark.sparkContext.hadoopConfiguration)
         fs.delete(new org.apache.hadoop.fs.Path(tempPath), true)
       }
     }
@@ -167,45 +132,20 @@ class BatchedIndexUpdateTests extends SparkTests with Matchers {
 
   test("should optimize batching with intelligent bin-packing") {
     // Create files with varying distinct value counts to test intelligent bin-packing
-    val tempFiles = Seq(
-      createTestFile(1, 200000), // 200k distinct values
-      createTestFile(
-        2,
-        250000
-      ), // 250k distinct values - can batch with file 1 (450k < 500k)
-      createTestFile(
-        3,
-        100000
-      ), // 100k distinct values - cannot fit with files 1&2, new batch
-      createTestFile(
-        4,
-        300000
-      ), // 300k distinct values - can batch with file 3 (400k < 500k)
-      createTestFile(
-        5,
-        50000
-      ), // 50k distinct values - can fit with files 3&4 (450k < 500k)
-      createTestFile(
-        6,
-        150000
-      ), // 150k distinct values - cannot fit with files 3,4,5, new batch
-      createTestFile(
-        7,
-        200000
-      ), // 200k distinct values - can batch with file 6 (350k < 500k)
-      createTestFile(
-        8,
-        100000
-      ) // 100k distinct values - can batch with files 6&7 (450k < 500k)
-    )
+    val tempFiles =
+      Seq(
+        createTestFile(1, 200000), // 200k distinct values
+        createTestFile(2, 250000), // 250k distinct values - can batch with file 1 (450k < 500k)
+        createTestFile(3, 100000), // 100k distinct values - cannot fit with files 1&2, new batch
+        createTestFile(4, 300000), // 300k distinct values - can batch with file 3 (400k < 500k)
+        createTestFile(5, 50000), // 50k distinct values - can fit with files 3&4 (450k < 500k)
+        createTestFile(6, 150000), // 150k distinct values - cannot fit with files 3,4,5, new batch
+        createTestFile(7, 200000), // 200k distinct values - can batch with file 6 (350k < 500k)
+        createTestFile(8, 100000) // 100k distinct values - can batch with files 6&7 (450k < 500k)
+      )
 
     try {
-      val index = Index(
-        "optimized_batch_test",
-        testSchema,
-        "csv",
-        Map("header" -> "true")
-      )
+      val index = Index("optimized_batch_test", testSchema, "csv", Map("header" -> "true"))
 
       // Add all files at once for cleaner logs
       index.addFile(tempFiles.map(_._2): _*)
@@ -216,15 +156,9 @@ class BatchedIndexUpdateTests extends SparkTests with Matchers {
       index.update
 
       // Verify all data is indexed correctly across multiple batches
-      val files1 = index.locateFiles(
-        Map("Id" -> Array(50000))
-      ) // Should find in small files
-      val files2 = index.locateFiles(
-        Map("Id" -> Array(150000))
-      ) // Should find in medium files
-      val files3 = index.locateFiles(
-        Map("Id" -> Array(250000))
-      ) // Should find in larger files
+      val files1 = index.locateFiles(Map("Id" -> Array(50000))) // Should find in small files
+      val files2 = index.locateFiles(Map("Id" -> Array(150000))) // Should find in medium files
+      val files3 = index.locateFiles(Map("Id" -> Array(250000))) // Should find in larger files
 
       files1 should not be empty
       files2 should not be empty
@@ -233,8 +167,9 @@ class BatchedIndexUpdateTests extends SparkTests with Matchers {
     } finally {
       // Cleanup
       tempFiles.foreach { case (tempPath, _) =>
-        val fs = org.apache.hadoop.fs.FileSystem
-          .get(spark.sparkContext.hadoopConfiguration)
+        val fs =
+          org.apache.hadoop.fs.FileSystem
+            .get(spark.sparkContext.hadoopConfiguration)
         fs.delete(new org.apache.hadoop.fs.Path(tempPath), true)
       }
     }
@@ -260,22 +195,25 @@ class BatchedIndexUpdateTests extends SparkTests with Matchers {
 
     } finally {
       // Cleanup
-      val fs = org.apache.hadoop.fs.FileSystem
-        .get(spark.sparkContext.hadoopConfiguration)
+      val fs =
+        org.apache.hadoop.fs.FileSystem
+          .get(spark.sparkContext.hadoopConfiguration)
       fs.delete(new org.apache.hadoop.fs.Path(tempFile._1), true)
     }
   }
 
   test("should handle mixed file sizes with optimal batching") {
     // Create a realistic scenario with mixed file sizes
-    val tempFiles = (1 to 25).map { i =>
-      val distinctValues = i match {
-        case x if x <= 5  => 1000 // Large files
-        case x if x <= 15 => 300 // Medium files
-        case _            => 100 // Small files
+    val tempFiles =
+      (1 to 25).map { i =>
+        val distinctValues =
+          i match {
+            case x if x <= 5 => 1000 // Large files
+            case x if x <= 15 => 300 // Medium files
+            case _ => 100 // Small files
+          }
+        createTestFile(i, distinctValues)
       }
-      createTestFile(i, distinctValues)
-    }
 
     try {
       val index =
@@ -305,8 +243,9 @@ class BatchedIndexUpdateTests extends SparkTests with Matchers {
     } finally {
       // Cleanup
       tempFiles.foreach { case (tempPath, _) =>
-        val fs = org.apache.hadoop.fs.FileSystem
-          .get(spark.sparkContext.hadoopConfiguration)
+        val fs =
+          org.apache.hadoop.fs.FileSystem
+            .get(spark.sparkContext.hadoopConfiguration)
         fs.delete(new org.apache.hadoop.fs.Path(tempPath), true)
       }
     }

--- a/src/test/scala/dev/cjfravel/ariadne/BloomFilterOperationsTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/BloomFilterOperationsTests.scala
@@ -1,26 +1,23 @@
 package dev.cjfravel.ariadne
 
 import dev.cjfravel.ariadne.exceptions.ColumnNotFoundException
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
-import org.apache.spark.sql.types._
-import org.apache.spark.sql.functions._
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.types._
+import org.scalatest.matchers.should.Matchers
 
-/** Tests for [[BloomFilterOperations]] covering bloom filter index creation,
-  * custom false-positive-rate validation, and bloom-filter-based file location
-  * queries.
-  */
+/**
+ * Tests for [[BloomFilterOperations]] covering bloom filter index creation, custom false-positive-rate validation, and
+ * bloom-filter-based file location queries.
+ */
 class BloomFilterOperationsTests extends SparkTests with Matchers {
 
-  val testSchema = StructType(
-    Seq(
-      StructField("Id", IntegerType, nullable = false),
-      StructField("UserId", LongType, nullable = false),
-      StructField("Category", StringType, nullable = false),
-      StructField("Value", DoubleType, nullable = false)
-    )
-  )
+  val testSchema =
+    StructType(
+      Seq(
+        StructField("Id", IntegerType, nullable = false),
+        StructField("UserId", LongType, nullable = false),
+        StructField("Category", StringType, nullable = false),
+        StructField("Value", DoubleType, nullable = false)))
 
   test("addBloomIndex should add a bloom index configuration") {
     val index =
@@ -41,12 +38,7 @@ class BloomFilterOperationsTests extends SparkTests with Matchers {
   }
 
   test("addBloomIndex should reject FPR outside valid range") {
-    val index = Index(
-      "bloom_invalid_fpr_test",
-      testSchema,
-      "csv",
-      Map("header" -> "true")
-    )
+    val index = Index("bloom_invalid_fpr_test", testSchema, "csv", Map("header" -> "true"))
 
     an[IllegalArgumentException] should be thrownBy {
       index.addBloomIndex("UserId", fpr = 0.0)
@@ -62,12 +54,7 @@ class BloomFilterOperationsTests extends SparkTests with Matchers {
   }
 
   test("addBloomIndex should reject non-existent columns") {
-    val index = Index(
-      "bloom_nonexistent_test",
-      testSchema,
-      "csv",
-      Map("header" -> "true")
-    )
+    val index = Index("bloom_nonexistent_test", testSchema, "csv", Map("header" -> "true"))
 
     a[ColumnNotFoundException] should be thrownBy {
       index.addBloomIndex("NonExistentColumn")
@@ -131,12 +118,7 @@ class BloomFilterOperationsTests extends SparkTests with Matchers {
   }
 
   test("bloom filter should return empty for definitely non-existent values") {
-    val index = Index(
-      "bloom_nonexistent_value_test",
-      testSchema,
-      "csv",
-      Map("header" -> "true")
-    )
+    val index = Index("bloom_nonexistent_value_test", testSchema, "csv", Map("header" -> "true"))
 
     val csvPath = resourcePath("/data/table1_part0.csv")
     index.addFile(csvPath)
@@ -146,7 +128,7 @@ class BloomFilterOperationsTests extends SparkTests with Matchers {
     // Query for values that definitely don't exist
     // Note: Due to false positives, this might occasionally return files
     // But with small data and high cardinality values, it should be empty
-    val files = index.locateFiles(Map("Id" -> Array(999999, 888888)))
+    index.locateFiles(Map("Id" -> Array(999999, 888888)))
     // We can't guarantee empty due to FPR, but this tests the code path
   }
 
@@ -175,17 +157,10 @@ class BloomFilterOperationsTests extends SparkTests with Matchers {
     index.update
 
     // Create a query DataFrame
-    val queryData = Seq(
-      Row(1),
-      Row(2),
-      Row(3)
-    )
+    val queryData = Seq(Row(1), Row(2), Row(3))
     val querySchema =
       StructType(Seq(StructField("Id", IntegerType, nullable = false)))
-    val queryDf = spark.createDataFrame(
-      spark.sparkContext.parallelize(queryData),
-      querySchema
-    )
+    val queryDf = spark.createDataFrame(spark.sparkContext.parallelize(queryData), querySchema)
 
     // Join should work
     val result = index.join(queryDf, Seq("Id"), "inner")
@@ -194,14 +169,9 @@ class BloomFilterOperationsTests extends SparkTests with Matchers {
 
   test("should handle multiple bloom indexes") {
     // Create test data with multiple columns
-    val multiColData = (1 to 100).map { i =>
-      Row(i, i.toLong * 1000, s"category_${i % 5}", i.toDouble)
-    }
+    val multiColData = (1 to 100).map(i => Row(i, i.toLong * 1000, s"category_${i % 5}", i.toDouble))
 
-    val df = spark.createDataFrame(
-      spark.sparkContext.parallelize(multiColData),
-      testSchema
-    )
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(multiColData), testSchema)
 
     val tempPath =
       s"${System.getProperty("java.io.tmpdir")}/bloom_multi_test_${System.currentTimeMillis()}"
@@ -212,20 +182,16 @@ class BloomFilterOperationsTests extends SparkTests with Matchers {
       .csv(tempPath)
 
     try {
-      val fileName = java.nio.file.Files
-        .walk(java.nio.file.Paths.get(tempPath))
-        .filter(java.nio.file.Files.isRegularFile(_))
-        .filter(_.getFileName.toString.endsWith(".csv"))
-        .findFirst()
-        .get()
-        .toString
+      val fileName =
+        java.nio.file.Files
+          .walk(java.nio.file.Paths.get(tempPath))
+          .filter(java.nio.file.Files.isRegularFile(_))
+          .filter(_.getFileName.toString.endsWith(".csv"))
+          .findFirst()
+          .get()
+          .toString
 
-      val index = Index(
-        "bloom_multi_col_test",
-        testSchema,
-        "csv",
-        Map("header" -> "true")
-      )
+      val index = Index("bloom_multi_col_test", testSchema, "csv", Map("header" -> "true"))
       index.addFile("file://" + fileName)
       index.addBloomIndex("Id")
       index.addBloomIndex("UserId", fpr = 0.001)
@@ -243,22 +209,18 @@ class BloomFilterOperationsTests extends SparkTests with Matchers {
       files2 should not be empty
 
     } finally {
-      val fs = org.apache.hadoop.fs.FileSystem
-        .get(spark.sparkContext.hadoopConfiguration)
+      val fs =
+        org.apache.hadoop.fs.FileSystem
+          .get(spark.sparkContext.hadoopConfiguration)
       fs.delete(new org.apache.hadoop.fs.Path(tempPath), true)
     }
   }
 
   test("bloom filter should have acceptable false positive rate") {
     // Create test data with known values
-    val testData = (1 to 1000).map { i =>
-      Row(i, i.toLong * 1000, s"category_${i % 5}", i.toDouble)
-    }
+    val testData = (1 to 1000).map(i => Row(i, i.toLong * 1000, s"category_${i % 5}", i.toDouble))
 
-    val df = spark.createDataFrame(
-      spark.sparkContext.parallelize(testData),
-      testSchema
-    )
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(testData), testSchema)
 
     val tempPath =
       s"${System.getProperty("java.io.tmpdir")}/bloom_fpr_empirical_test_${System.currentTimeMillis()}"
@@ -269,20 +231,16 @@ class BloomFilterOperationsTests extends SparkTests with Matchers {
       .csv(tempPath)
 
     try {
-      val fileName = java.nio.file.Files
-        .walk(java.nio.file.Paths.get(tempPath))
-        .filter(java.nio.file.Files.isRegularFile(_))
-        .filter(_.getFileName.toString.endsWith(".csv"))
-        .findFirst()
-        .get()
-        .toString
+      val fileName =
+        java.nio.file.Files
+          .walk(java.nio.file.Paths.get(tempPath))
+          .filter(java.nio.file.Files.isRegularFile(_))
+          .filter(_.getFileName.toString.endsWith(".csv"))
+          .findFirst()
+          .get()
+          .toString
 
-      val index = Index(
-        "bloom_fpr_empirical_test",
-        testSchema,
-        "csv",
-        Map("header" -> "true")
-      )
+      val index = Index("bloom_fpr_empirical_test", testSchema, "csv", Map("header" -> "true"))
       index.addFile("file://" + fileName)
       index.addBloomIndex("Id", fpr = 0.01) // 1% FPR
       index.update
@@ -294,14 +252,13 @@ class BloomFilterOperationsTests extends SparkTests with Matchers {
       // Test with many values that don't exist
       // With 1% FPR and single file, we expect about 1% false positives
       val nonExistentValues = (10001 to 10100).toArray
-      val fpResults = index.locateFiles(
-        Map("Id" -> nonExistentValues.map(_.asInstanceOf[Any]))
-      )
+      index.locateFiles(Map("Id" -> nonExistentValues.map(_.asInstanceOf[Any])))
       // We can't guarantee exact FPR in tests, but verify the mechanism works
 
     } finally {
-      val fs = org.apache.hadoop.fs.FileSystem
-        .get(spark.sparkContext.hadoopConfiguration)
+      val fs =
+        org.apache.hadoop.fs.FileSystem
+          .get(spark.sparkContext.hadoopConfiguration)
       fs.delete(new org.apache.hadoop.fs.Path(tempPath), true)
     }
   }

--- a/src/test/scala/dev/cjfravel/ariadne/BugFixTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/BugFixTests.scala
@@ -1,55 +1,38 @@
 package dev.cjfravel.ariadne
-
-import dev.cjfravel.ariadne.exceptions._
-import org.apache.spark.sql.types._
-import org.apache.spark.sql.functions._
-import org.apache.spark.sql.Row
 import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types._
 
-/** TDD tests for bugs H2, H3, H5, H7, M4, M8, M9, M10, M11 identified during
-  * the beta bug audit.
-  */
+/**
+ * TDD tests for bugs H2, H3, H5, H7, M4, M8, M9, M10, M11 identified during the beta bug audit.
+ */
 class BugFixTests extends SparkTests {
 
-  val basicSchema = StructType(
-    Seq(
-      StructField("Id", IntegerType, nullable = false),
-      StructField("Value", StringType, nullable = false)
-    )
-  )
+  val basicSchema =
+    StructType(
+      Seq(StructField("Id", IntegerType, nullable = false), StructField("Value", StringType, nullable = false)))
 
   // ---------- H2: Exploded field duplicate array_column in buildExplodedFieldIndexes ----------
 
-  test(
-    "H2 - two exploded fields from same array column should not collide during build"
-  ) {
-    val arrayTestSchema = StructType(
-      Seq(
-        StructField("event_id", StringType, nullable = false),
-        StructField(
-          "users",
-          ArrayType(
-            StructType(
-              Seq(
-                StructField("id", IntegerType, nullable = false),
-                StructField("name", StringType, nullable = false)
-              )
-            )
-          ),
-          nullable = false
-        )
-      )
-    )
-
-    val testData = spark.createDataFrame(
-      spark.sparkContext.parallelize(
+  test("H2 - two exploded fields from same array column should not collide during build") {
+    val arrayTestSchema =
+      StructType(
         Seq(
-          Row("e1", Array(Row(100, "Alice"), Row(101, "Bob"))),
-          Row("e2", Array(Row(102, "Charlie")))
-        )
-      ),
-      arrayTestSchema
-    )
+          StructField("event_id", StringType, nullable = false),
+          StructField(
+            "users",
+            ArrayType(
+              StructType(Seq(
+                StructField("id", IntegerType, nullable = false),
+                StructField("name", StringType, nullable = false)))),
+            nullable = false)))
+
+    val testData =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(
+          Seq(Row("e1", Array(Row(100, "Alice"), Row(101, "Bob"))), Row("e2", Array(Row(102, "Charlie"))))),
+        arrayTestSchema)
 
     val tempPath =
       s"${System.getProperty("java.io.tmpdir")}/h2_test_${System.currentTimeMillis()}"
@@ -64,17 +47,17 @@ class BugFixTests extends SparkTests {
     index.update
 
     // Both columns should be queryable
-    val userIdQuery = spark.createDataFrame(
-      spark.sparkContext.parallelize(Seq(Row(100))),
-      StructType(Seq(StructField("user_id", IntegerType, nullable = false)))
-    )
+    val userIdQuery =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(Seq(Row(100))),
+        StructType(Seq(StructField("user_id", IntegerType, nullable = false))))
     val result = userIdQuery.join(index, Seq("user_id"))
     assert(result.count() > 0, "Should find rows matching user_id=100")
 
-    val userNameQuery = spark.createDataFrame(
-      spark.sparkContext.parallelize(Seq(Row("Alice"))),
-      StructType(Seq(StructField("user_name", StringType, nullable = false)))
-    )
+    val userNameQuery =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(Seq(Row("Alice"))),
+        StructType(Seq(StructField("user_name", StringType, nullable = false))))
     val nameResult = userNameQuery.join(index, Seq("user_name"))
     assert(nameResult.count() > 0, "Should find rows matching user_name=Alice")
   }
@@ -84,19 +67,13 @@ class BugFixTests extends SparkTests {
   test("H5 - joinDf should warn or error when join columns have no index") {
     val index = Index("h5_test", basicSchema, "parquet")
     // Add a file but NO indexes — columns exist in schema but are not indexed
-    val testData = spark.createDataFrame(
-      spark.sparkContext.parallelize(Seq(Row(1, "a"), Row(2, "b"))),
-      basicSchema
-    )
+    val testData = spark.createDataFrame(spark.sparkContext.parallelize(Seq(Row(1, "a"), Row(2, "b"))), basicSchema)
     val tempPath =
       s"${System.getProperty("java.io.tmpdir")}/h5_test_${System.currentTimeMillis()}"
     testData.write.mode("overwrite").parquet(tempPath)
     index.addFile(tempPath)
 
-    val queryDf = spark.createDataFrame(
-      spark.sparkContext.parallelize(Seq(Row(1, "a"))),
-      basicSchema
-    )
+    val queryDf = spark.createDataFrame(spark.sparkContext.parallelize(Seq(Row(1, "a"))), basicSchema)
 
     // Joining on columns that exist in schema but have no index should throw
     assertThrows[IllegalArgumentException] {
@@ -119,22 +96,18 @@ class BugFixTests extends SparkTests {
 
     // Verify the metadata on disk matches in-memory
     val reloadedIndex = Index("h7_test")
-    assert(
-      reloadedIndex.indexes.contains("Id"),
-      "Reloaded index should have 'Id' in indexes"
-    )
+    assert(reloadedIndex.indexes.contains("Id"), "Reloaded index should have 'Id' in indexes")
   }
 
   // ---------- M8: Overly broad IOException catch in lock acquisition ----------
 
-  test(
-    "M8 - lock IOException catch should not mask non-lock-contention errors"
-  ) {
+  test("M8 - lock IOException catch should not mask non-lock-contention errors") {
     // Create a lock and verify it handles FileAlreadyExistsException correctly
     // (existing behavior) vs other IOExceptions
     val lockPath = new Path(new Path(tempDir.toUri), "m8-test-lock.json")
-    val fs = org.apache.hadoop.fs.FileSystem
-      .get(tempDir.toUri, spark.sparkContext.hadoopConfiguration)
+    val fs =
+      org.apache.hadoop.fs.FileSystem
+        .get(tempDir.toUri, spark.sparkContext.hadoopConfiguration)
     if (fs.exists(lockPath)) fs.delete(lockPath, true)
 
     val lock = IndexLock(lockPath, "m8-test")
@@ -151,17 +124,11 @@ class BugFixTests extends SparkTests {
     val index = Index("m9_remove_test", basicSchema, "parquet")
     // Create the storage directory by writing metadata
     index.addIndex("Id")
-    assert(
-      IndexPathUtils.exists("m9_remove_test"),
-      "Index should exist after creation"
-    )
+    assert(IndexPathUtils.exists("m9_remove_test"), "Index should exist after creation")
 
     // Remove it — should succeed even if file list doesn't exist
     IndexPathUtils.remove("m9_remove_test")
-    assert(
-      !IndexPathUtils.exists("m9_remove_test"),
-      "Index should be gone after remove"
-    )
+    assert(!IndexPathUtils.exists("m9_remove_test"), "Index should be gone after remove")
   }
 
   // ---------- M10: cleanFileName empty result ----------
@@ -184,46 +151,30 @@ class BugFixTests extends SparkTests {
     index.addIndex("Id")
 
     // Both should report it exists
-    assert(
-      IndexPathUtils.exists("m11_catalog_test"),
-      "IndexPathUtils.exists should be true"
-    )
-    assert(
-      IndexCatalog.exists("m11_catalog_test"),
-      "IndexCatalog.exists should be true"
-    )
+    assert(IndexPathUtils.exists("m11_catalog_test"), "IndexPathUtils.exists should be true")
+    assert(IndexCatalog.exists("m11_catalog_test"), "IndexCatalog.exists should be true")
   }
 
   // ---------- Migration: old array_column indexes auto-migrate to as_column ----------
 
   test("Migration - old exploded field indexes are auto-migrated on read") {
-    val arrayTestSchema = StructType(
-      Seq(
-        StructField("event_id", StringType, nullable = false),
-        StructField(
-          "users",
-          ArrayType(
-            StructType(
-              Seq(
-                StructField("id", IntegerType, nullable = false),
-                StructField("name", StringType, nullable = false)
-              )
-            )
-          ),
-          nullable = false
-        )
-      )
-    )
-
-    val testData = spark.createDataFrame(
-      spark.sparkContext.parallelize(
+    val arrayTestSchema =
+      StructType(
         Seq(
-          Row("e1", Array(Row(100, "Alice"), Row(101, "Bob"))),
-          Row("e2", Array(Row(102, "Charlie")))
-        )
-      ),
-      arrayTestSchema
-    )
+          StructField("event_id", StringType, nullable = false),
+          StructField(
+            "users",
+            ArrayType(
+              StructType(Seq(
+                StructField("id", IntegerType, nullable = false),
+                StructField("name", StringType, nullable = false)))),
+            nullable = false)))
+
+    val testData =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(
+          Seq(Row("e1", Array(Row(100, "Alice"), Row(101, "Bob"))), Row("e2", Array(Row(102, "Charlie"))))),
+        arrayTestSchema)
 
     val tempPath =
       s"${System.getProperty("java.io.tmpdir")}/migration_test_${System.currentTimeMillis()}"
@@ -236,14 +187,16 @@ class BugFixTests extends SparkTests {
 
     // Manually build an OLD-STYLE index with array_column as storage name
     // by directly writing a Delta table with "users" column instead of "user_id"
-    val baseDf = spark.read
-      .parquet(tempPath)
-      .withColumn("filename", input_file_name())
-    val oldStyleIndex = baseDf
-      .select("filename", "users")
-      .withColumn("temp", explode(col("users.id")))
-      .groupBy("filename")
-      .agg(collect_set(col("temp")).alias("users")) // OLD: stored as "users"
+    val baseDf =
+      spark.read
+        .parquet(tempPath)
+        .withColumn("filename", input_file_name())
+    val oldStyleIndex =
+      baseDf
+        .select("filename", "users")
+        .withColumn("temp", explode(col("users.id")))
+        .groupBy("filename")
+        .agg(collect_set(col("temp")).alias("users")) // OLD: stored as "users"
 
     val indexPath =
       new Path(new Path(IndexPathUtils.storagePath, "migration_test"), "index")
@@ -253,20 +206,15 @@ class BugFixTests extends SparkTests {
       .save(indexPath.toString)
 
     // Verify the Delta table has "users" column (old style)
-    val beforeSchema = spark.read
-      .format("delta")
-      .load(indexPath.toString)
-      .schema
-      .fieldNames
-      .toSet
-    assert(
-      beforeSchema.contains("users"),
-      "Pre-migration: should have 'users' column"
-    )
-    assert(
-      !beforeSchema.contains("user_id"),
-      "Pre-migration: should NOT have 'user_id' column"
-    )
+    val beforeSchema =
+      spark.read
+        .format("delta")
+        .load(indexPath.toString)
+        .schema
+        .fieldNames
+        .toSet
+    assert(beforeSchema.contains("users"), "Pre-migration: should have 'users' column")
+    assert(!beforeSchema.contains("user_id"), "Pre-migration: should NOT have 'user_id' column")
 
     // Now reconnect and query — migration should happen automatically
     val index2 = Index("migration_test")
@@ -274,19 +222,14 @@ class BugFixTests extends SparkTests {
     assert(files.nonEmpty, "Should find files after auto-migration")
 
     // Verify the Delta table now has "user_id" column (new style)
-    val afterSchema = spark.read
-      .format("delta")
-      .load(indexPath.toString)
-      .schema
-      .fieldNames
-      .toSet
-    assert(
-      afterSchema.contains("user_id"),
-      "Post-migration: should have 'user_id' column"
-    )
-    assert(
-      !afterSchema.contains("users"),
-      "Post-migration: should NOT have 'users' column"
-    )
+    val afterSchema =
+      spark.read
+        .format("delta")
+        .load(indexPath.toString)
+        .schema
+        .fieldNames
+        .toSet
+    assert(afterSchema.contains("user_id"), "Post-migration: should have 'user_id' column")
+    assert(!afterSchema.contains("users"), "Post-migration: should NOT have 'users' column")
   }
 }

--- a/src/test/scala/dev/cjfravel/ariadne/ColumnBackfillTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/ColumnBackfillTests.scala
@@ -1,32 +1,24 @@
 package dev.cjfravel.ariadne
-
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.functions._
-import org.apache.spark.sql.Row
+import org.scalatest.matchers.should.Matchers
 
-/** Tests for column backfill functionality, verifying that newly added regular
-  * and computed index columns are correctly populated for previously indexed
-  * files.
-  */
+/**
+ * Tests for column backfill functionality, verifying that newly added regular and computed index columns are correctly
+ * populated for previously indexed files.
+ */
 class ColumnBackfillTests extends SparkTests with Matchers {
 
-  val testSchema = StructType(
-    Seq(
-      StructField("Id", IntegerType, nullable = false),
-      StructField("Version", IntegerType, nullable = false),
-      StructField("Value", DoubleType, nullable = false)
-    )
-  )
+  val testSchema =
+    StructType(
+      Seq(
+        StructField("Id", IntegerType, nullable = false),
+        StructField("Version", IntegerType, nullable = false),
+        StructField("Value", DoubleType, nullable = false)))
 
   test("should backfill new regular index column on existing files") {
     val csvOptions = Map("header" -> "true")
     val index = Index("backfill_regular", testSchema, "csv", csvOptions)
-    val paths = Array(
-      resourcePath("/data/table1_part0.csv"),
-      resourcePath("/data/table1_part1.csv")
-    )
+    val paths = Array(resourcePath("/data/table1_part0.csv"), resourcePath("/data/table1_part1.csv"))
     index.addFile(paths: _*)
     index.addIndex("Id")
     index.update
@@ -54,10 +46,7 @@ class ColumnBackfillTests extends SparkTests with Matchers {
   test("should backfill new computed index column on existing files") {
     val csvOptions = Map("header" -> "true")
     val index = Index("backfill_computed", testSchema, "csv", csvOptions)
-    val paths = Array(
-      resourcePath("/data/table1_part0.csv"),
-      resourcePath("/data/table1_part1.csv")
-    )
+    val paths = Array(resourcePath("/data/table1_part0.csv"), resourcePath("/data/table1_part1.csv"))
     index.addFile(paths: _*)
     index.addIndex("Id")
     index.update
@@ -78,10 +67,7 @@ class ColumnBackfillTests extends SparkTests with Matchers {
   test("should backfill new bloom index column on existing files") {
     val csvOptions = Map("header" -> "true")
     val index = Index("backfill_bloom", testSchema, "csv", csvOptions)
-    val paths = Array(
-      resourcePath("/data/table1_part0.csv"),
-      resourcePath("/data/table1_part1.csv")
-    )
+    val paths = Array(resourcePath("/data/table1_part0.csv"), resourcePath("/data/table1_part1.csv"))
     index.addFile(paths: _*)
     index.addIndex("Id")
     index.update
@@ -100,20 +86,16 @@ class ColumnBackfillTests extends SparkTests with Matchers {
   }
 
   test("should backfill new temporal index column on existing files") {
-    val temporalSchema = StructType(
-      Seq(
-        StructField("Id", IntegerType, nullable = false),
-        StructField("Value", DoubleType, nullable = false),
-        StructField("UpdatedAt", TimestampType, nullable = true)
-      )
-    )
+    val temporalSchema =
+      StructType(
+        Seq(
+          StructField("Id", IntegerType, nullable = false),
+          StructField("Value", DoubleType, nullable = false),
+          StructField("UpdatedAt", TimestampType, nullable = true)))
 
     val csvOptions = Map("header" -> "true")
     val index = Index("backfill_temporal", temporalSchema, "csv", csvOptions)
-    val paths = Array(
-      resourcePath("/data/temporal_part0.csv"),
-      resourcePath("/data/temporal_part1.csv")
-    )
+    val paths = Array(resourcePath("/data/temporal_part0.csv"), resourcePath("/data/temporal_part1.csv"))
     index.addFile(paths: _*)
     index.addIndex("Value")
     index.update
@@ -134,10 +116,7 @@ class ColumnBackfillTests extends SparkTests with Matchers {
   test("should handle multiple new columns added at once") {
     val csvOptions = Map("header" -> "true")
     val index = Index("backfill_multiple", testSchema, "csv", csvOptions)
-    val paths = Array(
-      resourcePath("/data/table1_part0.csv"),
-      resourcePath("/data/table1_part1.csv")
-    )
+    val paths = Array(resourcePath("/data/table1_part0.csv"), resourcePath("/data/table1_part1.csv"))
     index.addFile(paths: _*)
     index.addIndex("Id")
     index.update
@@ -162,10 +141,7 @@ class ColumnBackfillTests extends SparkTests with Matchers {
   test("should be idempotent - second update after backfill is a no-op") {
     val csvOptions = Map("header" -> "true")
     val index = Index("backfill_idempotent", testSchema, "csv", csvOptions)
-    val paths = Array(
-      resourcePath("/data/table1_part0.csv"),
-      resourcePath("/data/table1_part1.csv")
-    )
+    val paths = Array(resourcePath("/data/table1_part0.csv"), resourcePath("/data/table1_part1.csv"))
     index.addFile(paths: _*)
     index.addIndex("Id")
     index.update

--- a/src/test/scala/dev/cjfravel/ariadne/CompactionTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/CompactionTests.scala
@@ -1,20 +1,19 @@
 package dev.cjfravel.ariadne
 
-import org.scalatest.matchers.should.Matchers
 import org.apache.spark.sql.types._
+import org.scalatest.matchers.should.Matchers
 
-/** Tests for `compact` and `vacuum` operations on the main index and large
-  * index Delta tables.
-  */
+/**
+ * Tests for `compact` and `vacuum` operations on the main index and large index Delta tables.
+ */
 class CompactionTests extends SparkTests with Matchers {
 
-  val testSchema: StructType = StructType(
-    Seq(
-      StructField("Id", IntegerType, nullable = false),
-      StructField("Version", IntegerType, nullable = false),
-      StructField("Value", DoubleType, nullable = false)
-    )
-  )
+  val testSchema: StructType =
+    StructType(
+      Seq(
+        StructField("Id", IntegerType, nullable = false),
+        StructField("Version", IntegerType, nullable = false),
+        StructField("Value", DoubleType, nullable = false)))
 
   val csvOptions: Map[String, String] = Map("header" -> "true")
 

--- a/src/test/scala/dev/cjfravel/ariadne/ConsolidatedLargeIndexTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/ConsolidatedLargeIndexTests.scala
@@ -1,37 +1,28 @@
 package dev.cjfravel.ariadne
-
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
-import org.apache.spark.sql.types._
-import org.apache.spark.sql.functions._
-import org.apache.spark.sql.Row
 import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types._
+import org.scalatest.matchers.should.Matchers
 
-/** Tests for large index consolidation, verifying that exploded per-column
-  * Delta tables are correctly created and queried for columns exceeding the
-  * `largeIndexLimit`.
-  */
+/**
+ * Tests for large index consolidation, verifying that exploded per-column Delta tables are correctly created and
+ * queried for columns exceeding the `largeIndexLimit`.
+ */
 class ConsolidatedLargeIndexTests extends SparkTests with Matchers {
 
-  val testSchema = StructType(
-    Seq(
-      StructField("Id", IntegerType, nullable = false),
-      StructField("Version", IntegerType, nullable = false),
-      StructField("Category", StringType, nullable = false),
-      StructField("Value", DoubleType, nullable = false)
-    )
-  )
+  val testSchema =
+    StructType(
+      Seq(
+        StructField("Id", IntegerType, nullable = false),
+        StructField("Version", IntegerType, nullable = false),
+        StructField("Category", StringType, nullable = false),
+        StructField("Value", DoubleType, nullable = false)))
 
   test("should consolidate large indexes into single delta table per column") {
     // Create test data that will trigger large index threshold (500,000+ distinct values per column)
-    val largeData = (1 to 600000).map { i =>
-      Row(i, i % 1000, s"category_${i}", i.toDouble)
-    }
+    val largeData = (1 to 600000).map(i => Row(i, i % 1000, s"category_$i", i.toDouble))
 
-    val df = spark.createDataFrame(
-      spark.sparkContext.parallelize(largeData),
-      testSchema
-    )
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(largeData), testSchema)
 
     val tempPath =
       s"${System.getProperty("java.io.tmpdir")}/consolidated_test_${System.currentTimeMillis()}"
@@ -42,13 +33,14 @@ class ConsolidatedLargeIndexTests extends SparkTests with Matchers {
       .csv(tempPath)
 
     try {
-      val fileName = java.nio.file.Files
-        .walk(java.nio.file.Paths.get(tempPath))
-        .filter(java.nio.file.Files.isRegularFile(_))
-        .filter(_.getFileName.toString.endsWith(".csv"))
-        .findFirst()
-        .get()
-        .toString
+      val fileName =
+        java.nio.file.Files
+          .walk(java.nio.file.Paths.get(tempPath))
+          .filter(java.nio.file.Files.isRegularFile(_))
+          .filter(_.getFileName.toString.endsWith(".csv"))
+          .findFirst()
+          .get()
+          .toString
 
       val index =
         Index("consolidated_test", testSchema, "csv", Map("header" -> "true"))
@@ -61,18 +53,20 @@ class ConsolidatedLargeIndexTests extends SparkTests with Matchers {
       val largeIndexesPath = new Path(index.storagePath, "large_indexes")
 
       if (index.exists(largeIndexesPath)) {
-        val columnDirs = index.fs
-          .listStatus(largeIndexesPath)
-          .filter(_.isDirectory)
-          .map(_.getPath.getName)
+        val columnDirs =
+          index.fs
+            .listStatus(largeIndexesPath)
+            .filter(_.isDirectory)
+            .map(_.getPath.getName)
 
         // Should have consolidated tables, not file subdirectories
         columnDirs.foreach { columnName =>
           val columnPath = new Path(largeIndexesPath, columnName)
-          val subDirs = index.fs
-            .listStatus(columnPath)
-            .filter(_.isDirectory)
-            .map(_.getPath.getName)
+          val subDirs =
+            index.fs
+              .listStatus(columnPath)
+              .filter(_.isDirectory)
+              .map(_.getPath.getName)
 
           // Should not have file subdirectories in new consolidated format
           subDirs.foreach { subDir =>
@@ -87,29 +81,20 @@ class ConsolidatedLargeIndexTests extends SparkTests with Matchers {
       files should not be empty
 
     } finally {
-      val fs = org.apache.hadoop.fs.FileSystem
-        .get(spark.sparkContext.hadoopConfiguration)
+      val fs =
+        org.apache.hadoop.fs.FileSystem
+          .get(spark.sparkContext.hadoopConfiguration)
       fs.delete(new org.apache.hadoop.fs.Path(tempPath), true)
     }
   }
 
   test("should handle incremental updates to consolidated large indexes") {
-    val testData1 = (1 to 300000).map { i =>
-      Row(i, i % 1000, s"batch1_${i}", i.toDouble)
-    }
+    val testData1 = (1 to 300000).map(i => Row(i, i % 1000, s"batch1_$i", i.toDouble))
 
-    val testData2 = (300001 to 600000).map { i =>
-      Row(i, i % 1000, s"batch2_${i}", i.toDouble)
-    }
+    val testData2 = (300001 to 600000).map(i => Row(i, i % 1000, s"batch2_$i", i.toDouble))
 
-    val df1 = spark.createDataFrame(
-      spark.sparkContext.parallelize(testData1),
-      testSchema
-    )
-    val df2 = spark.createDataFrame(
-      spark.sparkContext.parallelize(testData2),
-      testSchema
-    )
+    val df1 = spark.createDataFrame(spark.sparkContext.parallelize(testData1), testSchema)
+    val df2 = spark.createDataFrame(spark.sparkContext.parallelize(testData2), testSchema)
 
     val tempPath1 =
       s"${System.getProperty("java.io.tmpdir")}/incremental1_${System.currentTimeMillis()}"
@@ -130,28 +115,25 @@ class ConsolidatedLargeIndexTests extends SparkTests with Matchers {
       .csv(tempPath2)
 
     try {
-      val fileName1 = java.nio.file.Files
-        .walk(java.nio.file.Paths.get(tempPath1))
-        .filter(java.nio.file.Files.isRegularFile(_))
-        .filter(_.getFileName.toString.endsWith(".csv"))
-        .findFirst()
-        .get()
-        .toString
+      val fileName1 =
+        java.nio.file.Files
+          .walk(java.nio.file.Paths.get(tempPath1))
+          .filter(java.nio.file.Files.isRegularFile(_))
+          .filter(_.getFileName.toString.endsWith(".csv"))
+          .findFirst()
+          .get()
+          .toString
 
-      val fileName2 = java.nio.file.Files
-        .walk(java.nio.file.Paths.get(tempPath2))
-        .filter(java.nio.file.Files.isRegularFile(_))
-        .filter(_.getFileName.toString.endsWith(".csv"))
-        .findFirst()
-        .get()
-        .toString
+      val fileName2 =
+        java.nio.file.Files
+          .walk(java.nio.file.Paths.get(tempPath2))
+          .filter(java.nio.file.Files.isRegularFile(_))
+          .filter(_.getFileName.toString.endsWith(".csv"))
+          .findFirst()
+          .get()
+          .toString
 
-      val index = Index(
-        "incremental_consolidated_test",
-        testSchema,
-        "csv",
-        Map("header" -> "true")
-      )
+      val index = Index("incremental_consolidated_test", testSchema, "csv", Map("header" -> "true"))
       index.addFile("file://" + fileName1)
       index.addIndex("Id")
       index.addIndex("Category")
@@ -166,21 +148,16 @@ class ConsolidatedLargeIndexTests extends SparkTests with Matchers {
       index.update
 
       // Should find files from both batches
-      val batch1Files = index.locateFiles(
-        Map("Category" -> Array("batch1_1", "batch1_100", "batch1_1000"))
-      )
-      val batch2Files = index.locateFiles(
-        Map(
-          "Category" -> Array("batch2_300001", "batch2_400000", "batch2_500000")
-        )
-      )
+      val batch1Files = index.locateFiles(Map("Category" -> Array("batch1_1", "batch1_100", "batch1_1000")))
+      val batch2Files = index.locateFiles(Map("Category" -> Array("batch2_300001", "batch2_400000", "batch2_500000")))
 
       batch1Files should not be empty
       batch2Files should not be empty
 
     } finally {
-      val fs = org.apache.hadoop.fs.FileSystem
-        .get(spark.sparkContext.hadoopConfiguration)
+      val fs =
+        org.apache.hadoop.fs.FileSystem
+          .get(spark.sparkContext.hadoopConfiguration)
       fs.delete(new org.apache.hadoop.fs.Path(tempPath1), true)
       fs.delete(new org.apache.hadoop.fs.Path(tempPath2), true)
     }
@@ -188,19 +165,16 @@ class ConsolidatedLargeIndexTests extends SparkTests with Matchers {
 
   test("should handle mixed large and small indexes correctly") {
     // Create data where some columns will be large and others small
-    val mixedData = (1 to 600000).map { i =>
-      Row(
-        i % 5, // Small index (only 5 distinct values)
-        i % 10, // Medium index
-        s"large_category_${i}", // Large index (600,000 distinct values)
-        i.toDouble
-      )
-    }
+    val mixedData =
+      (1 to 600000).map { i =>
+        Row(
+          i % 5, // Small index (only 5 distinct values)
+          i % 10, // Medium index
+          s"large_category_$i", // Large index (600,000 distinct values)
+          i.toDouble)
+      }
 
-    val df = spark.createDataFrame(
-      spark.sparkContext.parallelize(mixedData),
-      testSchema
-    )
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(mixedData), testSchema)
 
     val tempPath =
       s"${System.getProperty("java.io.tmpdir")}/mixed_index_test_${System.currentTimeMillis()}"
@@ -211,13 +185,14 @@ class ConsolidatedLargeIndexTests extends SparkTests with Matchers {
       .csv(tempPath)
 
     try {
-      val fileName = java.nio.file.Files
-        .walk(java.nio.file.Paths.get(tempPath))
-        .filter(java.nio.file.Files.isRegularFile(_))
-        .filter(_.getFileName.toString.endsWith(".csv"))
-        .findFirst()
-        .get()
-        .toString
+      val fileName =
+        java.nio.file.Files
+          .walk(java.nio.file.Paths.get(tempPath))
+          .filter(java.nio.file.Files.isRegularFile(_))
+          .filter(_.getFileName.toString.endsWith(".csv"))
+          .findFirst()
+          .get()
+          .toString
 
       val index =
         Index("mixed_index_test", testSchema, "csv", Map("header" -> "true"))
@@ -234,23 +209,17 @@ class ConsolidatedLargeIndexTests extends SparkTests with Matchers {
       val mediumIndexFiles = index.locateFiles(Map("Version" -> Array(3, 4)))
       mediumIndexFiles should not be empty
 
-      val largeIndexFiles = index.locateFiles(
-        Map("Category" -> Array("large_category_100", "large_category_200"))
-      )
+      val largeIndexFiles = index.locateFiles(Map("Category" -> Array("large_category_100", "large_category_200")))
       largeIndexFiles should not be empty
 
       // Combined queries should also work
-      val combinedFiles = index.locateFiles(
-        Map(
-          "Id" -> Array(1),
-          "Category" -> Array("large_category_100")
-        )
-      )
+      val combinedFiles = index.locateFiles(Map("Id" -> Array(1), "Category" -> Array("large_category_100")))
       combinedFiles should not be empty
 
     } finally {
-      val fs = org.apache.hadoop.fs.FileSystem
-        .get(spark.sparkContext.hadoopConfiguration)
+      val fs =
+        org.apache.hadoop.fs.FileSystem
+          .get(spark.sparkContext.hadoopConfiguration)
       fs.delete(new org.apache.hadoop.fs.Path(tempPath), true)
     }
   }

--- a/src/test/scala/dev/cjfravel/ariadne/DeleteFilesTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/DeleteFilesTests.scala
@@ -1,22 +1,22 @@
 package dev.cjfravel.ariadne
 
-import org.scalatest.matchers.should.Matchers
-import org.apache.spark.sql.types._
-import org.apache.spark.sql.Row
 import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types._
+import org.scalatest.matchers.should.Matchers
 
-/** Tests for `deleteFiles` covering single and multi-file deletion from the
-  * main index, large index table cleanup, and file list removal.
-  */
+/**
+ * Tests for `deleteFiles` covering single and multi-file deletion from the main index, large index table cleanup, and
+ * file list removal.
+ */
 class DeleteFilesTests extends SparkTests with Matchers {
 
-  val table1Schema = StructType(
-    Seq(
-      StructField("Id", IntegerType, nullable = false),
-      StructField("Version", IntegerType, nullable = false),
-      StructField("Value", DoubleType, nullable = false)
-    )
-  )
+  val table1Schema =
+    StructType(
+      Seq(
+        StructField("Id", IntegerType, nullable = false),
+        StructField("Version", IntegerType, nullable = false),
+        StructField("Value", DoubleType, nullable = false)))
 
   test("should delete a single file from index") {
     val csvOptions = Map("header" -> "true")
@@ -55,23 +55,17 @@ class DeleteFilesTests extends SparkTests with Matchers {
   }
 
   test("should clean up large index tables on delete") {
-    val largeSchema = StructType(
-      Seq(
-        StructField("Id", IntegerType, nullable = false),
-        StructField("Category", StringType, nullable = false),
-        StructField("Value", DoubleType, nullable = false)
-      )
-    )
+    val largeSchema =
+      StructType(
+        Seq(
+          StructField("Id", IntegerType, nullable = false),
+          StructField("Category", StringType, nullable = false),
+          StructField("Value", DoubleType, nullable = false)))
 
     // Create data with enough distinct values to trigger large index (limit is 500,000)
-    val largeData = (1 to 600000).map { i =>
-      Row(i, s"cat_$i", i.toDouble)
-    }
+    val largeData = (1 to 600000).map(i => Row(i, s"cat_$i", i.toDouble))
 
-    val df = spark.createDataFrame(
-      spark.sparkContext.parallelize(largeData),
-      largeSchema
-    )
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(largeData), largeSchema)
 
     val tempPath =
       s"${System.getProperty("java.io.tmpdir")}/delete_large_test_${System.currentTimeMillis()}"
@@ -82,13 +76,14 @@ class DeleteFilesTests extends SparkTests with Matchers {
       .csv(tempPath)
 
     try {
-      val fileName = "file://" + java.nio.file.Files
-        .walk(java.nio.file.Paths.get(tempPath))
-        .filter(java.nio.file.Files.isRegularFile(_))
-        .filter(_.getFileName.toString.endsWith(".csv"))
-        .findFirst()
-        .get()
-        .toString
+      val fileName =
+        "file://" + java.nio.file.Files
+          .walk(java.nio.file.Paths.get(tempPath))
+          .filter(java.nio.file.Files.isRegularFile(_))
+          .filter(_.getFileName.toString.endsWith(".csv"))
+          .findFirst()
+          .get()
+          .toString
 
       val index =
         Index("delete_large", largeSchema, "csv", Map("header" -> "true"))

--- a/src/test/scala/dev/cjfravel/ariadne/FileListTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/FileListTests.scala
@@ -1,8 +1,9 @@
 package dev.cjfravel.ariadne
 
-/** Tests for [[FileList]] covering file addition (single and batch), existence
-  * checks, and removal from the tracked file list.
-  */
+/**
+ * Tests for [[FileList]] covering file addition (single and batch), existence checks, and removal from the tracked file
+ * list.
+ */
 class FileListTests extends SparkTests {
   test("addFile") {
     val filelist = FileList("test")
@@ -14,10 +15,7 @@ class FileListTests extends SparkTests {
 
   test("addFile(s)") {
     val filelist = FileList("test2")
-    val paths = Array(
-      resourcePath("/data/table1_part0.csv"),
-      resourcePath("/data/table1_part1.csv")
-    )
+    val paths = Array(resourcePath("/data/table1_part0.csv"), resourcePath("/data/table1_part1.csv"))
     paths.foreach(path => assert(filelist.hasFile(path) === false))
     filelist.addFile(paths: _*)
     paths.foreach(path => assert(filelist.hasFile(path) === true))

--- a/src/test/scala/dev/cjfravel/ariadne/FileSizeTrackingTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/FileSizeTrackingTests.scala
@@ -1,29 +1,29 @@
 package dev.cjfravel.ariadne
 
-import org.scalatest.matchers.should.Matchers
-import org.apache.spark.sql.types._
-import org.apache.spark.sql.functions._
-import scala.io.Source
 import java.nio.charset.StandardCharsets
 
-/** Tests for file size tracking, verifying that `file_size` is stored in the
-  * index table during `update` and accessible via index metadata.
-  */
+import scala.io.Source
+
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types._
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Tests for file size tracking, verifying that `file_size` is stored in the index table during `update` and accessible
+ * via index metadata.
+ */
 class FileSizeTrackingTests extends SparkTests with Matchers {
 
-  val table1Schema = StructType(
-    Seq(
-      StructField("Id", IntegerType, nullable = false),
-      StructField("Version", IntegerType, nullable = false),
-      StructField("Value", DoubleType, nullable = false)
-    )
-  )
+  val table1Schema =
+    StructType(
+      Seq(
+        StructField("Id", IntegerType, nullable = false),
+        StructField("Version", IntegerType, nullable = false),
+        StructField("Value", DoubleType, nullable = false)))
 
   /** Reads metadata from disk for the given index name. */
   private def readMetadataFromDisk(indexName: String): IndexMetadata = {
-    val metadataPath = new org.apache.hadoop.fs.Path(
-      tempDir.toString + "/indexes/" + indexName + "/metadata.json"
-    )
+    val metadataPath = new org.apache.hadoop.fs.Path(tempDir.toString + "/indexes/" + indexName + "/metadata.json")
     val fs = metadataPath.getFileSystem(spark.sparkContext.hadoopConfiguration)
     val inputStream = fs.open(metadataPath)
     val jsonString =
@@ -33,13 +33,8 @@ class FileSizeTrackingTests extends SparkTests with Matchers {
   }
 
   /** Writes metadata to disk for the given index name. */
-  private def writeMetadataToDisk(
-      indexName: String,
-      metadata: IndexMetadata
-  ): Unit = {
-    val metadataPath = new org.apache.hadoop.fs.Path(
-      tempDir.toString + "/indexes/" + indexName + "/metadata.json"
-    )
+  private def writeMetadataToDisk(indexName: String, metadata: IndexMetadata): Unit = {
+    val metadataPath = new org.apache.hadoop.fs.Path(tempDir.toString + "/indexes/" + indexName + "/metadata.json")
     val fs = metadataPath.getFileSystem(spark.sparkContext.hadoopConfiguration)
     val jsonString = new com.google.gson.Gson().toJson(metadata)
     val outputStream = fs.create(metadataPath, true)
@@ -106,18 +101,19 @@ class FileSizeTrackingTests extends SparkTests with Matchers {
 
     // Get size of file being deleted
     val indexDf = spark.read.format("delta").load(indexPath("filesize_delete"))
-    val file0Size = indexDf
-      .where(col("filename") === path0)
-      .select("file_size")
-      .head()
-      .getLong(0)
+    val file0Size =
+      indexDf
+        .where(col("filename") === path0)
+        .select("file_size")
+        .head()
+        .getLong(0)
     file0Size should be > 0L
 
     index.deleteFiles(path0)
 
     val metadataAfter = readMetadataFromDisk("filesize_delete")
     val totalAfter = metadataAfter.total_indexed_file_size.toLong
-    totalAfter shouldBe (totalBefore - file0Size)
+    totalAfter shouldBe totalBefore - file0Size
     totalAfter should be > 0L
   }
 
@@ -139,11 +135,12 @@ class FileSizeTrackingTests extends SparkTests with Matchers {
     // Simulate old index by nulling out file_size via Delta merge
     import io.delta.tables.DeltaTable
     val dt = DeltaTable.forPath(spark, indexPath("filesize_backfill"))
-    val allFiles = spark.read
-      .format("delta")
-      .load(indexPath("filesize_backfill"))
-      .select("filename")
-      .distinct()
+    val allFiles =
+      spark.read
+        .format("delta")
+        .load(indexPath("filesize_backfill"))
+        .select("filename")
+        .distinct()
     dt.as("target")
       .merge(allFiles.as("source"), "target.filename = source.filename")
       .whenMatched()

--- a/src/test/scala/dev/cjfravel/ariadne/IndexBuildOperationsTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexBuildOperationsTests.scala
@@ -1,42 +1,31 @@
 package dev.cjfravel.ariadne
-
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
-import org.apache.spark.sql.types._
-import org.apache.spark.sql.functions._
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.types._
+import org.scalatest.matchers.should.Matchers
 
-/** Tests for [[IndexBuildOperations]] verifying that regular and computed index
-  * columns are correctly built and persisted during the `update` workflow.
-  */
+/**
+ * Tests for [[IndexBuildOperations]] verifying that regular and computed index columns are correctly built and
+ * persisted during the `update` workflow.
+ */
 class IndexBuildOperationsTests extends SparkTests with Matchers {
 
-  val testSchema = StructType(
-    Seq(
-      StructField("Id", IntegerType, nullable = false),
-      StructField("Version", IntegerType, nullable = false),
-      StructField("Value", DoubleType, nullable = false)
-    )
-  )
+  val testSchema =
+    StructType(
+      Seq(
+        StructField("Id", IntegerType, nullable = false),
+        StructField("Version", IntegerType, nullable = false),
+        StructField("Value", DoubleType, nullable = false)))
 
-  val arraySchema = StructType(
-    Seq(
-      StructField("event_id", StringType, nullable = true),
-      StructField(
-        "users",
-        ArrayType(
-          StructType(
-            Seq(
-              StructField("id", LongType, nullable = true),
-              StructField("name", StringType, nullable = true)
-            )
-          )
-        ),
-        nullable = true
-      ),
-      StructField("tags", ArrayType(StringType), nullable = true)
-    )
-  )
+  val arraySchema =
+    StructType(
+      Seq(
+        StructField("event_id", StringType, nullable = true),
+        StructField(
+          "users",
+          ArrayType(StructType(
+            Seq(StructField("id", LongType, nullable = true), StructField("name", StringType, nullable = true)))),
+          nullable = true),
+        StructField("tags", ArrayType(StringType), nullable = true)))
 
   test("should build regular indexes correctly") {
     val index =
@@ -84,34 +73,22 @@ class IndexBuildOperationsTests extends SparkTests with Matchers {
     // Test exploded field build operations without the problematic update call
     // The issue is with the underlying join ambiguity in production code, not our test setup
 
-    val explodedSchema = StructType(
-      Seq(
-        StructField("event_id", StringType, nullable = true),
-        StructField(
-          "participants",
-          ArrayType(
-            StructType(
-              Seq(
-                StructField("id", LongType, nullable = true),
-                StructField("name", StringType, nullable = true)
-              )
-            )
-          ),
-          nullable = true
-        )
-      )
-    )
+    val explodedSchema =
+      StructType(
+        Seq(
+          StructField("event_id", StringType, nullable = true),
+          StructField(
+            "participants",
+            ArrayType(StructType(
+              Seq(StructField("id", LongType, nullable = true), StructField("name", StringType, nullable = true)))),
+            nullable = true)))
 
     // Create test data with different column name to avoid conflicts
-    val testData = spark.createDataFrame(
-      spark.sparkContext.parallelize(
-        Seq(
-          Row("evt1", Array(Row(100L, "Alice"), Row(101L, "Bob"))),
-          Row("evt2", Array(Row(102L, "Charlie")))
-        )
-      ),
-      explodedSchema
-    )
+    val testData =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(
+          Seq(Row("evt1", Array(Row(100L, "Alice"), Row(101L, "Bob"))), Row("evt2", Array(Row(102L, "Charlie"))))),
+        explodedSchema)
 
     // Write test data
     val tempPath =
@@ -138,43 +115,34 @@ class IndexBuildOperationsTests extends SparkTests with Matchers {
 
     } finally {
       // Clean up
-      val fs = org.apache.hadoop.fs.FileSystem
-        .get(spark.sparkContext.hadoopConfiguration)
+      val fs =
+        org.apache.hadoop.fs.FileSystem
+          .get(spark.sparkContext.hadoopConfiguration)
       fs.delete(new org.apache.hadoop.fs.Path(tempPath), true)
     }
   }
 
   test("should handle mixed index types correctly") {
     // Create test data with mixed content
-    val mixedSchema = StructType(
-      Seq(
-        StructField("event_id", StringType, nullable = true),
-        StructField("priority", IntegerType, nullable = true),
-        StructField(
-          "users",
-          ArrayType(
-            StructType(
-              Seq(
-                StructField("id", LongType, nullable = true),
-                StructField("role", StringType, nullable = true)
-              )
-            )
-          ),
-          nullable = true
-        )
-      )
-    )
-
-    val testData = spark.createDataFrame(
-      spark.sparkContext.parallelize(
+    val mixedSchema =
+      StructType(
         Seq(
-          Row("evt1", 1, Array(Row(100L, "admin"), Row(101L, "user"))),
-          Row("evt2", 2, Array(Row(102L, "user"))),
-          Row("evt3", 3, Array(Row(100L, "admin")))
-        )
-      ),
-      mixedSchema
-    )
+          StructField("event_id", StringType, nullable = true),
+          StructField("priority", IntegerType, nullable = true),
+          StructField(
+            "users",
+            ArrayType(StructType(
+              Seq(StructField("id", LongType, nullable = true), StructField("role", StringType, nullable = true)))),
+            nullable = true)))
+
+    val testData =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(
+          Seq(
+            Row("evt1", 1, Array(Row(100L, "admin"), Row(101L, "user"))),
+            Row("evt2", 2, Array(Row(102L, "user"))),
+            Row("evt3", 3, Array(Row(100L, "admin"))))),
+        mixedSchema)
 
     val tempPath =
       s"${System.getProperty("java.io.tmpdir")}/mixed_build_test_${System.currentTimeMillis()}"
@@ -188,10 +156,7 @@ class IndexBuildOperationsTests extends SparkTests with Matchers {
       // Regular index
       index.addIndex("event_id")
       // Computed index
-      index.addComputedIndex(
-        "priority_level",
-        "case when priority > 2 then 'high' else 'low' end"
-      )
+      index.addComputedIndex("priority_level", "case when priority > 2 then 'high' else 'low' end")
       // Exploded field index
       index.addExplodedFieldIndex("users", "id", "user_id")
       index.update
@@ -209,8 +174,9 @@ class IndexBuildOperationsTests extends SparkTests with Matchers {
       userFiles should not be empty
 
     } finally {
-      val fs = org.apache.hadoop.fs.FileSystem
-        .get(spark.sparkContext.hadoopConfiguration)
+      val fs =
+        org.apache.hadoop.fs.FileSystem
+          .get(spark.sparkContext.hadoopConfiguration)
       fs.delete(new org.apache.hadoop.fs.Path(tempPath), true)
     }
   }
@@ -259,14 +225,12 @@ class IndexBuildOperationsTests extends SparkTests with Matchers {
     // The actual threshold is configurable via spark.ariadne.largeIndexLimit
 
     // Create data with many repeated values to potentially trigger large index handling
-    val largeData = (1 to 1000).map { i =>
-      Row(i % 10, i % 5, i.toDouble) // This creates many repeated values
-    }
+    val largeData =
+      (1 to 1000).map { i =>
+        Row(i % 10, i % 5, i.toDouble) // This creates many repeated values
+      }
 
-    val df = spark.createDataFrame(
-      spark.sparkContext.parallelize(largeData),
-      testSchema
-    )
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(largeData), testSchema)
 
     val tempPath =
       s"${System.getProperty("java.io.tmpdir")}/large_index_test_${System.currentTimeMillis()}"
@@ -277,13 +241,14 @@ class IndexBuildOperationsTests extends SparkTests with Matchers {
       .csv(tempPath)
 
     try {
-      val fileName = java.nio.file.Files
-        .walk(java.nio.file.Paths.get(tempPath))
-        .filter(java.nio.file.Files.isRegularFile(_))
-        .filter(_.getFileName.toString.endsWith(".csv"))
-        .findFirst()
-        .get()
-        .toString
+      val fileName =
+        java.nio.file.Files
+          .walk(java.nio.file.Paths.get(tempPath))
+          .filter(java.nio.file.Files.isRegularFile(_))
+          .filter(_.getFileName.toString.endsWith(".csv"))
+          .findFirst()
+          .get()
+          .toString
 
       val index =
         Index("large_index_test", testSchema, "csv", Map("header" -> "true"))
@@ -297,8 +262,9 @@ class IndexBuildOperationsTests extends SparkTests with Matchers {
       files should not be empty
 
     } finally {
-      val fs = org.apache.hadoop.fs.FileSystem
-        .get(spark.sparkContext.hadoopConfiguration)
+      val fs =
+        org.apache.hadoop.fs.FileSystem
+          .get(spark.sparkContext.hadoopConfiguration)
       fs.delete(new org.apache.hadoop.fs.Path(tempPath), true)
     }
   }

--- a/src/test/scala/dev/cjfravel/ariadne/IndexCatalogTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexCatalogTests.scala
@@ -3,43 +3,34 @@ package dev.cjfravel.ariadne
 import dev.cjfravel.ariadne.exceptions.IndexNotFoundException
 import org.apache.spark.sql.types._
 
-/** Tests for [[IndexCatalog]] covering discovery, inspection, retrieval,
-  * DataFrame conversion, and removal of indexes from the catalog.
-  */
+/**
+ * Tests for [[IndexCatalog]] covering discovery, inspection, retrieval, DataFrame conversion, and removal of indexes
+ * from the catalog.
+ */
 class IndexCatalogTests extends SparkTests {
 
-  val schema1 = StructType(
-    Seq(
-      StructField("Id", IntegerType, nullable = false),
-      StructField("Version", IntegerType, nullable = false),
-      StructField("Value", DoubleType, nullable = false)
-    )
-  )
+  val schema1 =
+    StructType(
+      Seq(
+        StructField("Id", IntegerType, nullable = false),
+        StructField("Version", IntegerType, nullable = false),
+        StructField("Value", DoubleType, nullable = false)))
 
-  val schema2 = StructType(
-    Seq(
-      StructField("UserId", StringType, nullable = false),
-      StructField("Status", StringType, nullable = false),
-      StructField("UpdatedAt", TimestampType, nullable = false)
-    )
-  )
+  val schema2 =
+    StructType(
+      Seq(
+        StructField("UserId", StringType, nullable = false),
+        StructField("Status", StringType, nullable = false),
+        StructField("UpdatedAt", TimestampType, nullable = false)))
 
-  val schemaWithArray = StructType(
-    Seq(
-      StructField("Id", IntegerType, nullable = false),
-      StructField(
-        "Tags",
-        ArrayType(
-          StructType(
-            Seq(
-              StructField("name", StringType, nullable = false)
-            )
-          )
-        ),
-        nullable = false
-      )
-    )
-  )
+  val schemaWithArray =
+    StructType(
+      Seq(
+        StructField("Id", IntegerType, nullable = false),
+        StructField(
+          "Tags",
+          ArrayType(StructType(Seq(StructField("name", StringType, nullable = false)))),
+          nullable = false)))
 
   // --- list ---
 
@@ -150,9 +141,7 @@ class IndexCatalogTests extends SparkTests {
     assert(summary.columns.contains("Version"))
   }
 
-  test(
-    "describe returns correct summary for index with exploded field indexes"
-  ) {
+  test("describe returns correct summary for index with exploded field indexes") {
     val index = Index("catalog_desc_exploded", schemaWithArray, "parquet")
     index.addExplodedFieldIndex("Tags", "name", "tag_name")
 
@@ -294,18 +283,18 @@ class IndexCatalogTests extends SparkTests {
     Index("catalog_df_schema", schema1, "parquet")
 
     val df = IndexCatalog.toDF()
-    val expectedColumns = Set(
-      "name",
-      "format",
-      "regular_indexes",
-      "bloom_indexes",
-      "computed_indexes",
-      "temporal_indexes",
-      "range_indexes",
-      "exploded_field_indexes",
-      "file_count",
-      "total_indexed_file_size"
-    )
+    val expectedColumns =
+      Set(
+        "name",
+        "format",
+        "regular_indexes",
+        "bloom_indexes",
+        "computed_indexes",
+        "temporal_indexes",
+        "range_indexes",
+        "exploded_field_indexes",
+        "file_count",
+        "total_indexed_file_size")
     assert(df.columns.toSet == expectedColumns)
   }
 

--- a/src/test/scala/dev/cjfravel/ariadne/IndexFileOperationsTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexFileOperationsTests.scala
@@ -1,44 +1,30 @@
 package dev.cjfravel.ariadne
-
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.functions._
-import org.apache.spark.sql.Row
-import java.nio.file.Files
+import org.scalatest.matchers.should.Matchers
 
-/** Tests for file I/O operations on indexes, covering CSV and JSON formats with
-  * various read options (multiLine, headers, delimiters) and schema
-  * round-trips.
-  */
+/**
+ * Tests for file I/O operations on indexes, covering CSV and JSON formats with various read options (multiLine,
+ * headers, delimiters) and schema round-trips.
+ */
 class IndexFileOperationsTests extends SparkTests with Matchers {
 
-  val csvSchema = StructType(
-    Seq(
-      StructField("Id", IntegerType, nullable = false),
-      StructField("Version", IntegerType, nullable = false),
-      StructField("Value", DoubleType, nullable = false)
-    )
-  )
+  val csvSchema =
+    StructType(
+      Seq(
+        StructField("Id", IntegerType, nullable = false),
+        StructField("Version", IntegerType, nullable = false),
+        StructField("Value", DoubleType, nullable = false)))
 
-  val jsonSchema = StructType(
-    Seq(
-      StructField("event_id", StringType, nullable = true),
-      StructField("event_type", StringType, nullable = true),
-      StructField(
-        "users",
-        ArrayType(
-          StructType(
-            Seq(
-              StructField("id", LongType, nullable = true),
-              StructField("name", StringType, nullable = true)
-            )
-          )
-        ),
-        nullable = true
-      )
-    )
-  )
+  val jsonSchema =
+    StructType(
+      Seq(
+        StructField("event_id", StringType, nullable = true),
+        StructField("event_type", StringType, nullable = true),
+        StructField(
+          "users",
+          ArrayType(StructType(
+            Seq(StructField("id", LongType, nullable = true), StructField("name", StringType, nullable = true)))),
+          nullable = true)))
 
   test("storedSchema should return correct schema") {
     val index = Index("file_ops_schema_test", csvSchema, "csv")
@@ -96,23 +82,15 @@ class IndexFileOperationsTests extends SparkTests with Matchers {
 
   test("should apply exploded field transformations correctly") {
     // Test exploded field functionality with existing JSON test file
-    val explodedSchema = StructType(
-      Seq(
-        StructField("event_id", StringType, nullable = true),
-        StructField(
-          "users",
-          ArrayType(
-            StructType(
-              Seq(
-                StructField("id", LongType, nullable = true),
-                StructField("name", StringType, nullable = true)
-              )
-            )
-          ),
-          nullable = true
-        )
-      )
-    )
+    val explodedSchema =
+      StructType(
+        Seq(
+          StructField("event_id", StringType, nullable = true),
+          StructField(
+            "users",
+            ArrayType(StructType(
+              Seq(StructField("id", LongType, nullable = true), StructField("name", StringType, nullable = true)))),
+            nullable = true)))
 
     val readOptions = Map("multiLine" -> "true")
     val index =
@@ -161,12 +139,7 @@ class IndexFileOperationsTests extends SparkTests with Matchers {
   }
 
   test("should handle read options correctly") {
-    val customOptions = Map(
-      "header" -> "true",
-      "delimiter" -> ",",
-      "quote" -> "\"",
-      "escape" -> "\\"
-    )
+    val customOptions = Map("header" -> "true", "delimiter" -> ",", "quote" -> "\"", "escape" -> "\\")
 
     val index = Index("read_options_test", csvSchema, "csv", customOptions)
 
@@ -176,48 +149,26 @@ class IndexFileOperationsTests extends SparkTests with Matchers {
   }
 
   test("should combine computed indexes and exploded fields") {
-    val combinedSchema = StructType(
-      Seq(
-        StructField("event_id", StringType, nullable = true),
-        StructField("priority", IntegerType, nullable = true),
-        StructField(
-          "users",
-          ArrayType(
-            StructType(
-              Seq(
-                StructField("id", LongType, nullable = true),
-                StructField("role", StringType, nullable = true)
-              )
-            )
-          ),
-          nullable = true
-        )
-      )
-    )
+    val combinedSchema =
+      StructType(
+        Seq(
+          StructField("event_id", StringType, nullable = true),
+          StructField("priority", IntegerType, nullable = true),
+          StructField(
+            "users",
+            ArrayType(StructType(
+              Seq(StructField("id", LongType, nullable = true), StructField("role", StringType, nullable = true)))),
+            nullable = true)))
 
     // Create test data
-    val testData = spark.createDataFrame(
-      spark.sparkContext.parallelize(
-        Seq(
-          org.apache.spark.sql.Row(
-            "evt1",
-            1,
-            Array(
-              org.apache.spark.sql.Row(100L, "admin"),
-              org.apache.spark.sql.Row(101L, "user")
-            )
-          ),
-          org.apache.spark.sql.Row(
-            "evt2",
-            2,
-            Array(
-              org.apache.spark.sql.Row(102L, "user")
-            )
-          )
-        )
-      ),
-      combinedSchema
-    )
+    val testData =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(
+          Seq(
+            org.apache.spark.sql
+              .Row("evt1", 1, Array(org.apache.spark.sql.Row(100L, "admin"), org.apache.spark.sql.Row(101L, "user"))),
+            org.apache.spark.sql.Row("evt2", 2, Array(org.apache.spark.sql.Row(102L, "user"))))),
+        combinedSchema)
 
     // Write test data
     val tempPath =
@@ -229,10 +180,7 @@ class IndexFileOperationsTests extends SparkTests with Matchers {
       val index = Index("combined_test", combinedSchema, "json", readOptions)
 
       index.addFile(tempPath)
-      index.addComputedIndex(
-        "high_priority",
-        "case when priority > 1 then 'high' else 'low' end"
-      )
+      index.addComputedIndex("high_priority", "case when priority > 1 then 'high' else 'low' end")
       index.addExplodedFieldIndex("users", "id", "user_id")
       index.update
 
@@ -250,8 +198,9 @@ class IndexFileOperationsTests extends SparkTests with Matchers {
 
     } finally {
       // Clean up
-      val fs = org.apache.hadoop.fs.FileSystem
-        .get(spark.sparkContext.hadoopConfiguration)
+      val fs =
+        org.apache.hadoop.fs.FileSystem
+          .get(spark.sparkContext.hadoopConfiguration)
       fs.delete(new org.apache.hadoop.fs.Path(tempPath), true)
     }
   }

--- a/src/test/scala/dev/cjfravel/ariadne/IndexJoinOperationsTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexJoinOperationsTests.scala
@@ -1,50 +1,35 @@
 package dev.cjfravel.ariadne
-
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
-import org.apache.spark.sql.types._
-import org.apache.spark.sql.functions._
-import org.apache.spark.sql.Row
 import dev.cjfravel.ariadne.Index.DataFrameOps
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types._
+import org.scalatest.matchers.should.Matchers
 
-/** Tests for [[IndexJoinOperations]] verifying index-accelerated joins between
-  * a DataFrame and indexed data, including both `index.join(df)` and
-  * `df.join(index)` directions.
-  */
+/**
+ * Tests for [[IndexJoinOperations]] verifying index-accelerated joins between a DataFrame and indexed data, including
+ * both `index.join(df)` and `df.join(index)` directions.
+ */
 class IndexJoinOperationsTests extends SparkTests with Matchers {
 
-  val indexSchema = StructType(
-    Seq(
-      StructField("Id", IntegerType, nullable = false),
-      StructField("Version", IntegerType, nullable = false),
-      StructField("Value", DoubleType, nullable = false)
-    )
-  )
+  val indexSchema =
+    StructType(
+      Seq(
+        StructField("Id", IntegerType, nullable = false),
+        StructField("Version", IntegerType, nullable = false),
+        StructField("Value", DoubleType, nullable = false)))
 
-  val querySchema = StructType(
-    Seq(
-      StructField("Id", IntegerType, nullable = false),
-      StructField("Version", IntegerType, nullable = false)
-    )
-  )
+  val querySchema =
+    StructType(
+      Seq(StructField("Id", IntegerType, nullable = false), StructField("Version", IntegerType, nullable = false)))
 
-  val explodedSchema = StructType(
-    Seq(
-      StructField("event_id", StringType, nullable = true),
-      StructField(
-        "users",
-        ArrayType(
-          StructType(
-            Seq(
-              StructField("id", LongType, nullable = true),
-              StructField("name", StringType, nullable = true)
-            )
-          )
-        ),
-        nullable = true
-      )
-    )
-  )
+  val explodedSchema =
+    StructType(
+      Seq(
+        StructField("event_id", StringType, nullable = true),
+        StructField(
+          "users",
+          ArrayType(StructType(
+            Seq(StructField("id", LongType, nullable = true), StructField("name", StringType, nullable = true)))),
+          nullable = true)))
 
   test("should perform basic inner join correctly") {
     val index =
@@ -57,15 +42,7 @@ class IndexJoinOperationsTests extends SparkTests with Matchers {
     index.update
 
     // Create query DataFrame
-    val queryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(
-        Seq(
-          Row(1, 1),
-          Row(2, 2)
-        )
-      ),
-      querySchema
-    )
+    val queryData = spark.createDataFrame(spark.sparkContext.parallelize(Seq(Row(1, 1), Row(2, 2))), querySchema)
 
     // Test DataFrame.join(index, ...)
     val result1 = queryData.join(index, Seq("Id", "Version"), "inner")
@@ -87,20 +64,19 @@ class IndexJoinOperationsTests extends SparkTests with Matchers {
     index.addIndex("Id")
     index.update
 
-    val queryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(
-        Seq(
-          Row(1, 1),
-          Row(2, 2),
-          Row(999, 999) // This ID shouldn't exist in the index
-        )
-      ),
-      querySchema
-    )
+    val queryData =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(
+          Seq(
+            Row(1, 1),
+            Row(2, 2),
+            Row(999, 999) // This ID shouldn't exist in the index
+          )),
+        querySchema)
 
     val result = queryData.join(index, Seq("Id"), "left_semi")
     result.count() should be < queryData.count()
-    result.columns should not contain ("Value") // Semi join should only return left side columns
+    result.columns should not contain "Value" // Semi join should only return left side columns
   }
 
   test("should perform full outer join correctly") {
@@ -112,15 +88,14 @@ class IndexJoinOperationsTests extends SparkTests with Matchers {
     index.addIndex("Id")
     index.update
 
-    val queryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(
-        Seq(
-          Row(1, 1),
-          Row(999, 999) // This ID shouldn't exist in the index
-        )
-      ),
-      querySchema
-    )
+    val queryData =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(
+          Seq(
+            Row(1, 1),
+            Row(999, 999) // This ID shouldn't exist in the index
+          )),
+        querySchema)
 
     val result = index.join(queryData, Seq("Id"), "fullouter")
     result.count() should be >= queryData.count()
@@ -138,15 +113,7 @@ class IndexJoinOperationsTests extends SparkTests with Matchers {
 
     val singleColumnSchema =
       StructType(Seq(StructField("Version", IntegerType, nullable = false)))
-    val queryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(
-        Seq(
-          Row(1),
-          Row(2)
-        )
-      ),
-      singleColumnSchema
-    )
+    val queryData = spark.createDataFrame(spark.sparkContext.parallelize(Seq(Row(1), Row(2))), singleColumnSchema)
 
     val result = queryData.join(index, Seq("Version"), "inner")
     result.count() should be > 0L
@@ -155,16 +122,14 @@ class IndexJoinOperationsTests extends SparkTests with Matchers {
 
   test("should handle joins with exploded field indexes") {
     // Create test data with arrays
-    val testData = spark.createDataFrame(
-      spark.sparkContext.parallelize(
-        Seq(
-          Row("evt1", Array(Row(100L, "Alice"), Row(101L, "Bob"))),
-          Row("evt2", Array(Row(102L, "Charlie"))),
-          Row("evt3", Array(Row(100L, "Alice"), Row(103L, "David")))
-        )
-      ),
-      explodedSchema
-    )
+    val testData =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(
+          Seq(
+            Row("evt1", Array(Row(100L, "Alice"), Row(101L, "Bob"))),
+            Row("evt2", Array(Row(102L, "Charlie"))),
+            Row("evt3", Array(Row(100L, "Alice"), Row(103L, "David"))))),
+        explodedSchema)
 
     val tempPath =
       s"${System.getProperty("java.io.tmpdir")}/join_exploded_test_${System.currentTimeMillis()}"
@@ -182,23 +147,16 @@ class IndexJoinOperationsTests extends SparkTests with Matchers {
       // Create query data using the exploded field column name
       val userQuerySchema =
         StructType(Seq(StructField("user_id", LongType, nullable = false)))
-      val queryData = spark.createDataFrame(
-        spark.sparkContext.parallelize(
-          Seq(
-            Row(100L),
-            Row(101L)
-          )
-        ),
-        userQuerySchema
-      )
+      val queryData = spark.createDataFrame(spark.sparkContext.parallelize(Seq(Row(100L), Row(101L))), userQuerySchema)
 
       val result = queryData.join(index, Seq("user_id"), "inner")
       result.count() should be > 0L
       result.columns should contain allOf ("user_id", "event_id")
 
     } finally {
-      val fs = org.apache.hadoop.fs.FileSystem
-        .get(spark.sparkContext.hadoopConfiguration)
+      val fs =
+        org.apache.hadoop.fs.FileSystem
+          .get(spark.sparkContext.hadoopConfiguration)
       fs.delete(new org.apache.hadoop.fs.Path(tempPath), true)
     }
   }
@@ -214,16 +172,15 @@ class IndexJoinOperationsTests extends SparkTests with Matchers {
 
     val computedSchema =
       StructType(Seq(StructField("id_doubled", IntegerType, nullable = false)))
-    val queryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(
-        Seq(
-          Row(2), // 2 * 1
-          Row(4), // 2 * 2
-          Row(6) // 2 * 3
-        )
-      ),
-      computedSchema
-    )
+    val queryData =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(
+          Seq(
+            Row(2), // 2 * 1
+            Row(4), // 2 * 2
+            Row(6) // 2 * 3
+          )),
+        computedSchema)
 
     val result = queryData.join(index, Seq("id_doubled"), "inner")
     result.count() should be > 0L
@@ -231,35 +188,25 @@ class IndexJoinOperationsTests extends SparkTests with Matchers {
   }
 
   test("should handle joins with mixed index types") {
-    val mixedSchema = StructType(
-      Seq(
-        StructField("event_id", StringType, nullable = true),
-        StructField("priority", IntegerType, nullable = true),
-        StructField(
-          "users",
-          ArrayType(
-            StructType(
-              Seq(
-                StructField("id", LongType, nullable = true),
-                StructField("role", StringType, nullable = true)
-              )
-            )
-          ),
-          nullable = true
-        )
-      )
-    )
-
-    val testData = spark.createDataFrame(
-      spark.sparkContext.parallelize(
+    val mixedSchema =
+      StructType(
         Seq(
-          Row("evt1", 1, Array(Row(100L, "admin"))),
-          Row("evt2", 2, Array(Row(101L, "user"))),
-          Row("evt3", 3, Array(Row(102L, "admin")))
-        )
-      ),
-      mixedSchema
-    )
+          StructField("event_id", StringType, nullable = true),
+          StructField("priority", IntegerType, nullable = true),
+          StructField(
+            "users",
+            ArrayType(StructType(
+              Seq(StructField("id", LongType, nullable = true), StructField("role", StringType, nullable = true)))),
+            nullable = true)))
+
+    val testData =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(
+          Seq(
+            Row("evt1", 1, Array(Row(100L, "admin"))),
+            Row("evt2", 2, Array(Row(101L, "user"))),
+            Row("evt3", 3, Array(Row(102L, "admin"))))),
+        mixedSchema)
 
     val tempPath =
       s"${System.getProperty("java.io.tmpdir")}/join_mixed_test_${System.currentTimeMillis()}"
@@ -271,43 +218,31 @@ class IndexJoinOperationsTests extends SparkTests with Matchers {
 
       index.addFile(tempPath)
       index.addIndex("event_id") // Regular index
-      index.addComputedIndex(
-        "priority_level",
-        "case when priority > 2 then 'high' else 'low' end"
-      ) // Computed
+      index.addComputedIndex("priority_level", "case when priority > 2 then 'high' else 'low' end") // Computed
       index.addExplodedFieldIndex("users", "id", "user_id") // Exploded field
       index.update
 
       // Test join with all three index types
-      val multiQuerySchema = StructType(
-        Seq(
-          StructField("event_id", StringType, nullable = false),
-          StructField("priority_level", StringType, nullable = false),
-          StructField("user_id", LongType, nullable = false)
-        )
-      )
-
-      val queryData = spark.createDataFrame(
-        spark.sparkContext.parallelize(
+      val multiQuerySchema =
+        StructType(
           Seq(
-            Row("evt1", "low", 100L),
-            Row("evt3", "high", 102L)
-          )
-        ),
-        multiQuerySchema
-      )
+            StructField("event_id", StringType, nullable = false),
+            StructField("priority_level", StringType, nullable = false),
+            StructField("user_id", LongType, nullable = false)))
 
-      val result = queryData.join(
-        index,
-        Seq("event_id", "priority_level", "user_id"),
-        "inner"
-      )
+      val queryData =
+        spark.createDataFrame(
+          spark.sparkContext.parallelize(Seq(Row("evt1", "low", 100L), Row("evt3", "high", 102L))),
+          multiQuerySchema)
+
+      val result = queryData.join(index, Seq("event_id", "priority_level", "user_id"), "inner")
       result.count() should be > 0L
       result.columns should contain allOf ("event_id", "priority_level", "user_id", "priority")
 
     } finally {
-      val fs = org.apache.hadoop.fs.FileSystem
-        .get(spark.sparkContext.hadoopConfiguration)
+      val fs =
+        org.apache.hadoop.fs.FileSystem
+          .get(spark.sparkContext.hadoopConfiguration)
       fs.delete(new org.apache.hadoop.fs.Path(tempPath), true)
     }
   }
@@ -321,15 +256,8 @@ class IndexJoinOperationsTests extends SparkTests with Matchers {
     index.addIndex("Id")
     index.update
 
-    val queryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(
-        Seq(
-          Row(999, 999),
-          Row(998, 998)
-        )
-      ),
-      querySchema
-    )
+    val queryData =
+      spark.createDataFrame(spark.sparkContext.parallelize(Seq(Row(999, 999), Row(998, 998))), querySchema)
 
     // Inner join should return no results
     val innerResult = queryData.join(index, Seq("Id"), "inner")
@@ -349,15 +277,7 @@ class IndexJoinOperationsTests extends SparkTests with Matchers {
     index.addIndex("Id")
     index.update
 
-    val queryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(
-        Seq(
-          Row(1, 1),
-          Row(2, 2)
-        )
-      ),
-      querySchema
-    )
+    val queryData = spark.createDataFrame(spark.sparkContext.parallelize(Seq(Row(1, 1), Row(2, 2))), querySchema)
 
     // First join - should populate cache
     val result1 = queryData.join(index, Seq("Id"), "inner")
@@ -374,12 +294,7 @@ class IndexJoinOperationsTests extends SparkTests with Matchers {
   test("should handle joins with repartition option set") {
     spark.conf.set("spark.ariadne.indexRepartitionCount", "4")
     try {
-      val index = Index(
-        "join_repartition_test",
-        indexSchema,
-        "csv",
-        Map("header" -> "true")
-      )
+      val index = Index("join_repartition_test", indexSchema, "csv", Map("header" -> "true"))
 
       val csvPath = resourcePath("/data/table1_part0.csv")
       index.addFile(csvPath)
@@ -387,15 +302,7 @@ class IndexJoinOperationsTests extends SparkTests with Matchers {
       index.addIndex("Version")
       index.update
 
-      val queryData = spark.createDataFrame(
-        spark.sparkContext.parallelize(
-          Seq(
-            Row(1, 1),
-            Row(2, 2)
-          )
-        ),
-        querySchema
-      )
+      val queryData = spark.createDataFrame(spark.sparkContext.parallelize(Seq(Row(1, 1), Row(2, 2))), querySchema)
 
       // Test DataFrame.join(index, ...) with repartitioning enabled
       val result1 = queryData.join(index, Seq("Id", "Version"), "inner")
@@ -415,12 +322,7 @@ class IndexJoinOperationsTests extends SparkTests with Matchers {
   }
 
   test("should produce same results with and without repartitioning") {
-    val index = Index(
-      "join_repartition_compare_test",
-      indexSchema,
-      "csv",
-      Map("header" -> "true")
-    )
+    val index = Index("join_repartition_compare_test", indexSchema, "csv", Map("header" -> "true"))
 
     val csvPath0 = resourcePath("/data/table1_part0.csv")
     val csvPath1 = resourcePath("/data/table1_part1.csv")
@@ -429,16 +331,8 @@ class IndexJoinOperationsTests extends SparkTests with Matchers {
     index.addIndex("Id")
     index.update
 
-    val queryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(
-        Seq(
-          Row(1, 1),
-          Row(2, 2),
-          Row(3, 3)
-        )
-      ),
-      querySchema
-    )
+    val queryData =
+      spark.createDataFrame(spark.sparkContext.parallelize(Seq(Row(1, 1), Row(2, 2), Row(3, 3))), querySchema)
 
     // Join without repartitioning
     val resultWithout = queryData.join(index, Seq("Id"), "inner")

--- a/src/test/scala/dev/cjfravel/ariadne/IndexLockTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexLockTests.scala
@@ -1,16 +1,18 @@
 package dev.cjfravel.ariadne
 
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+
+import scala.io.Source
+
 import com.google.gson.Gson
 import dev.cjfravel.ariadne.exceptions.IndexLockException
 import org.apache.hadoop.fs.{FileSystem, Path}
 
-import java.nio.charset.StandardCharsets
-import java.time.Instant
-import scala.io.Source
-
-/** Tests for [[IndexLock]] covering lock acquisition, release, refresh, stale
-  * lock auto-healing, and contention behavior.
-  */
+/**
+ * Tests for [[IndexLock]] covering lock acquisition, release, refresh, stale lock auto-healing, and contention
+ * behavior.
+ */
 class IndexLockTests extends SparkTests {
 
   private val gson = new Gson()
@@ -21,11 +23,10 @@ class IndexLockTests extends SparkTests {
   private def lockPath(testName: String): Path =
     new Path(new Path(tempDir.toUri), s"index-lock-$testName.json")
 
-  private def cleanup(path: Path): Unit = {
+  private def cleanup(path: Path): Unit =
     if (fileSystem.exists(path)) {
       fileSystem.delete(path, true)
     }
-  }
 
   private def readLock(path: Path): LockInfo = {
     val in = fileSystem.open(path)
@@ -47,18 +48,17 @@ class IndexLockTests extends SparkTests {
     }
   }
 
-  private def withConfigOverrides[T](
-      overrides: (String, String)*
-  )(block: => T): T = {
-    val originals = overrides.map { case (key, _) =>
-      key -> spark.conf.getOption(key)
-    }
+  private def withConfigOverrides[T](overrides: (String, String)*)(block: => T): T = {
+    val originals =
+      overrides.map { case (key, _) =>
+        key -> spark.conf.getOption(key)
+      }
     overrides.foreach { case (key, value) => spark.conf.set(key, value) }
     try block
     finally {
       originals.foreach {
         case (key, Some(value)) => spark.conf.set(key, value)
-        case (key, None)        => spark.conf.unset(key)
+        case (key, None) => spark.conf.unset(key)
       }
     }
   }
@@ -172,10 +172,7 @@ class IndexLockTests extends SparkTests {
     cleanup(path)
 
     try {
-      withConfigOverrides(
-        "spark.ariadne.lockMaxWait" -> "1",
-        "spark.ariadne.lockRetryInterval" -> "1"
-      ) {
+      withConfigOverrides("spark.ariadne.lockMaxWait" -> "1", "spark.ariadne.lockRetryInterval" -> "1") {
         val lockA = IndexLock(path, "test-index")
         val lockB = IndexLock(path, "test-index")
 

--- a/src/test/scala/dev/cjfravel/ariadne/IndexMetadataOperationsTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexMetadataOperationsTests.scala
@@ -1,25 +1,20 @@
 package dev.cjfravel.ariadne
-
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
-import org.apache.spark.sql.types._
 import dev.cjfravel.ariadne.exceptions._
-import java.util
-import java.util.Collections
+import org.apache.spark.sql.types._
+import org.scalatest.matchers.should.Matchers
 
-/** Tests for [[IndexMetadataOperations]] covering metadata read/write
-  * round-trips, format handling, schema storage, and configuration of regular,
-  * exploded, and computed indexes.
-  */
+/**
+ * Tests for [[IndexMetadataOperations]] covering metadata read/write round-trips, format handling, schema storage, and
+ * configuration of regular, exploded, and computed indexes.
+ */
 class IndexMetadataOperationsTests extends SparkTests with Matchers {
 
-  val testSchema = StructType(
-    Seq(
-      StructField("Id", IntegerType, nullable = false),
-      StructField("Name", StringType, nullable = false),
-      StructField("Value", DoubleType, nullable = false)
-    )
-  )
+  val testSchema =
+    StructType(
+      Seq(
+        StructField("Id", IntegerType, nullable = false),
+        StructField("Name", StringType, nullable = false),
+        StructField("Value", DoubleType, nullable = false)))
 
   test("format property should work correctly") {
     val testIndex = Index("format_test", testSchema, "csv")
@@ -38,27 +33,21 @@ class IndexMetadataOperationsTests extends SparkTests with Matchers {
 
     testIndex.indexes should contain("Id")
     testIndex.indexes should contain("Name")
-    testIndex.indexes should not contain ("Value")
+    testIndex.indexes should not contain "Value"
   }
 
   test("metadata should handle exploded field indexes") {
-    val arraySchema = StructType(
-      Seq(
-        StructField("Id", IntegerType, nullable = false),
-        StructField(
-          "users",
-          ArrayType(
-            StructType(
-              Seq(
+    val arraySchema =
+      StructType(
+        Seq(
+          StructField("Id", IntegerType, nullable = false),
+          StructField(
+            "users",
+            ArrayType(
+              StructType(Seq(
                 StructField("id", IntegerType, nullable = false),
-                StructField("name", StringType, nullable = false)
-              )
-            )
-          ),
-          nullable = false
-        )
-      )
-    )
+                StructField("name", StringType, nullable = false)))),
+            nullable = false)))
 
     val testIndex = Index("exploded_test", arraySchema, "csv")
     testIndex.addIndex("Id")
@@ -119,33 +108,29 @@ class IndexMetadataOperationsTests extends SparkTests with Matchers {
 
   test("metadata format validation should work") {
     val indexName = "format_validation_test"
-    val index1 = Index(indexName, testSchema, "csv")
+    Index(indexName, testSchema, "csv")
 
     // Should throw exception when trying to use different format
     assertThrows[FormatMismatchException] {
-      val index2 = Index(indexName, testSchema, "parquet")
+      Index(indexName, testSchema, "parquet")
     }
   }
 
   test("metadata schema validation should work") {
     val indexName = "schema_validation_test"
-    val index1 = Index(indexName, testSchema, "csv")
+    Index(indexName, testSchema, "csv")
 
-    val differentSchema = StructType(
-      Seq(
-        StructField("DifferentField", StringType, nullable = false)
-      )
-    )
+    val differentSchema = StructType(Seq(StructField("DifferentField", StringType, nullable = false)))
 
     // Should throw exception when trying to use different schema
     assertThrows[SchemaMismatchException] {
-      val index2 = Index(indexName, differentSchema, "csv")
+      Index(indexName, differentSchema, "csv")
     }
   }
 
   test("metadata should require schema for new index") {
     assertThrows[SchemaNotProvidedException] {
-      val index = Index("no_schema_test")
+      Index("no_schema_test")
     }
   }
 
@@ -154,12 +139,9 @@ class IndexMetadataOperationsTests extends SparkTests with Matchers {
     val index1 = Index(indexName, testSchema, "csv")
     index1.addIndex("Id")
 
-    val newSchema = StructType(
-      Seq(
-        StructField("Id", IntegerType, nullable = false),
-        StructField("NewField", StringType, nullable = false)
-      )
-    )
+    val newSchema =
+      StructType(
+        Seq(StructField("Id", IntegerType, nullable = false), StructField("NewField", StringType, nullable = false)))
 
     // Should work with allowSchemaMismatch = true
     val index2 = Index(indexName, newSchema, "csv", true)

--- a/src/test/scala/dev/cjfravel/ariadne/IndexMetadataTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexMetadataTests.scala
@@ -1,17 +1,15 @@
 package dev.cjfravel.ariadne
 
-import org.scalatest.funsuite.AnyFunSuite
-import scala.io.Source
 import java.nio.charset.StandardCharsets
-import com.google.gson.Gson
-import java.nio.file.Paths
-import java.nio.file.Files
-import collection.JavaConverters._
 
-/** Tests for [[IndexMetadata]] JSON parsing and version migration logic,
-  * verifying forward-compatible deserialization from v1 through the latest
-  * schema version.
-  */
+import scala.collection.JavaConverters._
+
+import org.scalatest.funsuite.AnyFunSuite
+
+/**
+ * Tests for [[IndexMetadata]] JSON parsing and version migration logic, verifying forward-compatible deserialization
+ * from v1 through the latest schema version.
+ */
 class IndexMetadataTests extends AnyFunSuite {
   test("v1") {
     val stream = getClass.getResourceAsStream("/index_metadata/v1.json")

--- a/src/test/scala/dev/cjfravel/ariadne/IndexPathUtilsTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexPathUtilsTests.scala
@@ -1,32 +1,22 @@
 package dev.cjfravel.ariadne
-
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.BeforeAndAfterEach
+import dev.cjfravel.ariadne.exceptions.IndexNotFoundException
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.types._
-import dev.cjfravel.ariadne.exceptions.IndexNotFoundException
+import org.scalatest.matchers.should.Matchers
 
-/** Tests for index path utility methods covering file list naming, special
-  * character handling in file names, path existence checks, and directory
-  * removal.
-  */
+/**
+ * Tests for index path utility methods covering file list naming, special character handling in file names, path
+ * existence checks, and directory removal.
+ */
 class IndexPathUtilsTests extends SparkTests with Matchers {
 
-  val basicSchema = StructType(
-    Seq(
-      StructField("Id", IntegerType, nullable = false),
-      StructField("Value", StringType, nullable = false)
-    )
-  )
+  val basicSchema =
+    StructType(
+      Seq(StructField("Id", IntegerType, nullable = false), StructField("Value", StringType, nullable = false)))
 
   test("fileListName should format correctly") {
-    IndexPathUtils.fileListName("test_index") should be(
-      "[ariadne_index] test_index"
-    )
-    IndexPathUtils.fileListName("my-index") should be(
-      "[ariadne_index] my-index"
-    )
+    IndexPathUtils.fileListName("test_index") should be("[ariadne_index] test_index")
+    IndexPathUtils.fileListName("my-index") should be("[ariadne_index] my-index")
     assertThrows[IllegalArgumentException] {
       IndexPathUtils.fileListName("")
     }
@@ -34,9 +24,7 @@ class IndexPathUtilsTests extends SparkTests with Matchers {
 
   test("cleanFileName should handle special characters") {
     IndexPathUtils.cleanFileName("file.txt") should be("file_txt")
-    IndexPathUtils.cleanFileName("file-name_123.csv") should be(
-      "file_name_123_csv"
-    )
+    IndexPathUtils.cleanFileName("file-name_123.csv") should be("file_name_123_csv")
     IndexPathUtils.cleanFileName("file@#$%^&*()name") should be("file_name")
     IndexPathUtils.cleanFileName("___file___") should be("file")
     IndexPathUtils.cleanFileName("file____name") should be("file_name")
@@ -57,7 +45,7 @@ class IndexPathUtilsTests extends SparkTests with Matchers {
   }
 
   test("storagePath should be correct") {
-    val expectedPath = new Path(IndexPathUtils.storagePath.getParent, "indexes")
+    new Path(IndexPathUtils.storagePath.getParent, "indexes")
     IndexPathUtils.storagePath.toString should endWith("indexes")
   }
 
@@ -103,9 +91,8 @@ class IndexPathUtilsTests extends SparkTests with Matchers {
   }
 
   test("validateIndexName accepts safe names") {
-    Seq("orders", "my_index", "customer-data", "v2.final", "A1B2").foreach {
-      name =>
-        IndexPathUtils.validateIndexName(name)
+    Seq("orders", "my_index", "customer-data", "v2.final", "A1B2").foreach { name =>
+      IndexPathUtils.validateIndexName(name)
     }
   }
 }

--- a/src/test/scala/dev/cjfravel/ariadne/IndexQueryOperationsTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexQueryOperationsTests.scala
@@ -1,42 +1,31 @@
 package dev.cjfravel.ariadne
-
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
-import org.apache.spark.sql.types._
-import org.apache.spark.sql.functions._
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.types._
+import org.scalatest.matchers.should.Matchers
 
-/** Tests for [[IndexQueryOperations]] covering `locateFiles` queries against
-  * single and multiple index values, including empty-result scenarios.
-  */
+/**
+ * Tests for [[IndexQueryOperations]] covering `locateFiles` queries against single and multiple index values, including
+ * empty-result scenarios.
+ */
 class IndexQueryOperationsTests extends SparkTests with Matchers {
 
-  val testSchema = StructType(
-    Seq(
-      StructField("Id", IntegerType, nullable = false),
-      StructField("Version", IntegerType, nullable = false),
-      StructField("Value", DoubleType, nullable = false)
-    )
-  )
+  val testSchema =
+    StructType(
+      Seq(
+        StructField("Id", IntegerType, nullable = false),
+        StructField("Version", IntegerType, nullable = false),
+        StructField("Value", DoubleType, nullable = false)))
 
-  val arraySchema = StructType(
-    Seq(
-      StructField("event_id", StringType, nullable = true),
-      StructField(
-        "users",
-        ArrayType(
-          StructType(
-            Seq(
-              StructField("id", LongType, nullable = true),
-              StructField("name", StringType, nullable = true)
-            )
-          )
-        ),
-        nullable = true
-      ),
-      StructField("tags", ArrayType(StringType), nullable = true)
-    )
-  )
+  val arraySchema =
+    StructType(
+      Seq(
+        StructField("event_id", StringType, nullable = true),
+        StructField(
+          "users",
+          ArrayType(StructType(
+            Seq(StructField("id", LongType, nullable = true), StructField("name", StringType, nullable = true)))),
+          nullable = true),
+        StructField("tags", ArrayType(StringType), nullable = true)))
 
   test("should locate files by single index value") {
     val index =
@@ -96,19 +85,13 @@ class IndexQueryOperationsTests extends SparkTests with Matchers {
 
   test("should locate files using exploded field indexes") {
     // Create test data with arrays
-    val testData = spark.createDataFrame(
-      spark.sparkContext.parallelize(
-        Seq(
-          Row(
-            "evt1",
-            Array(Row(100L, "Alice"), Row(101L, "Bob")),
-            Array("tag1", "tag2")
-          ),
-          Row("evt2", Array(Row(102L, "Charlie")), Array("tag3"))
-        )
-      ),
-      arraySchema
-    )
+    val testData =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(
+          Seq(
+            Row("evt1", Array(Row(100L, "Alice"), Row(101L, "Bob")), Array("tag1", "tag2")),
+            Row("evt2", Array(Row(102L, "Charlie")), Array("tag3")))),
+        arraySchema)
 
     val tempPath =
       s"${System.getProperty("java.io.tmpdir")}/query_exploded_test_${System.currentTimeMillis()}"
@@ -128,8 +111,9 @@ class IndexQueryOperationsTests extends SparkTests with Matchers {
       files.exists(_.contains("query_exploded_test")) should be(true)
 
     } finally {
-      val fs = org.apache.hadoop.fs.FileSystem
-        .get(spark.sparkContext.hadoopConfiguration)
+      val fs =
+        org.apache.hadoop.fs.FileSystem
+          .get(spark.sparkContext.hadoopConfiguration)
       fs.delete(new org.apache.hadoop.fs.Path(tempPath), true)
     }
   }
@@ -165,12 +149,7 @@ class IndexQueryOperationsTests extends SparkTests with Matchers {
   }
 
   test("should handle statistics for empty index") {
-    val index = Index(
-      "query_empty_stats_test",
-      testSchema,
-      "csv",
-      Map("header" -> "true")
-    )
+    val index = Index("query_empty_stats_test", testSchema, "csv", Map("header" -> "true"))
     // Don't add any files or update
 
     val stats = index.stats()
@@ -178,12 +157,7 @@ class IndexQueryOperationsTests extends SparkTests with Matchers {
   }
 
   test("should provide statistics for computed indexes") {
-    val index = Index(
-      "query_computed_stats_test",
-      testSchema,
-      "csv",
-      Map("header" -> "true")
-    )
+    val index = Index("query_computed_stats_test", testSchema, "csv", Map("header" -> "true"))
 
     val csvPath = resourcePath("/data/table1_part0.csv")
     index.addFile(csvPath)
@@ -212,12 +186,7 @@ class IndexQueryOperationsTests extends SparkTests with Matchers {
   }
 
   test("should handle printMetadata without errors") {
-    val index = Index(
-      "query_metadata_print_test",
-      testSchema,
-      "csv",
-      Map("header" -> "true")
-    )
+    val index = Index("query_metadata_print_test", testSchema, "csv", Map("header" -> "true"))
 
     val csvPath = resourcePath("/data/table1_part0.csv")
     index.addFile(csvPath)
@@ -233,14 +202,12 @@ class IndexQueryOperationsTests extends SparkTests with Matchers {
     // This test verifies that the large index merging logic works correctly
     // We create data that should trigger the large index path
 
-    val largeData = (1 to 1000).map { i =>
-      Row(i % 10, i % 5, i.toDouble) // Creates repeated values
-    }
+    val largeData =
+      (1 to 1000).map { i =>
+        Row(i % 10, i % 5, i.toDouble) // Creates repeated values
+      }
 
-    val df = spark.createDataFrame(
-      spark.sparkContext.parallelize(largeData),
-      testSchema
-    )
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(largeData), testSchema)
 
     val tempPath =
       s"${System.getProperty("java.io.tmpdir")}/query_large_test_${System.currentTimeMillis()}"
@@ -251,13 +218,14 @@ class IndexQueryOperationsTests extends SparkTests with Matchers {
       .csv(tempPath)
 
     try {
-      val fileName = java.nio.file.Files
-        .walk(java.nio.file.Paths.get(tempPath))
-        .filter(java.nio.file.Files.isRegularFile(_))
-        .filter(_.getFileName.toString.endsWith(".csv"))
-        .findFirst()
-        .get()
-        .toString
+      val fileName =
+        java.nio.file.Files
+          .walk(java.nio.file.Paths.get(tempPath))
+          .filter(java.nio.file.Files.isRegularFile(_))
+          .filter(_.getFileName.toString.endsWith(".csv"))
+          .findFirst()
+          .get()
+          .toString
 
       val index =
         Index("query_large_test", testSchema, "csv", Map("header" -> "true"))
@@ -274,42 +242,33 @@ class IndexQueryOperationsTests extends SparkTests with Matchers {
       stats.count() should be(1)
 
     } finally {
-      val fs = org.apache.hadoop.fs.FileSystem
-        .get(spark.sparkContext.hadoopConfiguration)
+      val fs =
+        org.apache.hadoop.fs.FileSystem
+          .get(spark.sparkContext.hadoopConfiguration)
       fs.delete(new org.apache.hadoop.fs.Path(tempPath), true)
     }
   }
 
   test("should handle mixed queries across different index types") {
-    val mixedSchema = StructType(
-      Seq(
-        StructField("event_id", StringType, nullable = true),
-        StructField("priority", IntegerType, nullable = true),
-        StructField(
-          "users",
-          ArrayType(
-            StructType(
-              Seq(
-                StructField("id", LongType, nullable = true),
-                StructField("role", StringType, nullable = true)
-              )
-            )
-          ),
-          nullable = true
-        )
-      )
-    )
-
-    val testData = spark.createDataFrame(
-      spark.sparkContext.parallelize(
+    val mixedSchema =
+      StructType(
         Seq(
-          Row("evt1", 1, Array(Row(100L, "admin"))),
-          Row("evt2", 2, Array(Row(101L, "user"))),
-          Row("evt3", 3, Array(Row(100L, "admin")))
-        )
-      ),
-      mixedSchema
-    )
+          StructField("event_id", StringType, nullable = true),
+          StructField("priority", IntegerType, nullable = true),
+          StructField(
+            "users",
+            ArrayType(StructType(
+              Seq(StructField("id", LongType, nullable = true), StructField("role", StringType, nullable = true)))),
+            nullable = true)))
+
+    val testData =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(
+          Seq(
+            Row("evt1", 1, Array(Row(100L, "admin"))),
+            Row("evt2", 2, Array(Row(101L, "user"))),
+            Row("evt3", 3, Array(Row(100L, "admin"))))),
+        mixedSchema)
 
     val tempPath =
       s"${System.getProperty("java.io.tmpdir")}/query_mixed_test_${System.currentTimeMillis()}"
@@ -321,10 +280,7 @@ class IndexQueryOperationsTests extends SparkTests with Matchers {
 
       index.addFile(tempPath)
       index.addIndex("event_id") // Regular index
-      index.addComputedIndex(
-        "priority_level",
-        "case when priority > 2 then 'high' else 'low' end"
-      )
+      index.addComputedIndex("priority_level", "case when priority > 2 then 'high' else 'low' end")
       index.addExplodedFieldIndex("users", "id", "user_id")
       index.update
 
@@ -343,17 +299,13 @@ class IndexQueryOperationsTests extends SparkTests with Matchers {
       userFiles should not be empty
 
       // Test combined query
-      val combinedFiles = index.locateFiles(
-        Map(
-          "event_id" -> Array("evt1"),
-          "user_id" -> Array(100L)
-        )
-      )
+      val combinedFiles = index.locateFiles(Map("event_id" -> Array("evt1"), "user_id" -> Array(100L)))
       combinedFiles should not be empty
 
     } finally {
-      val fs = org.apache.hadoop.fs.FileSystem
-        .get(spark.sparkContext.hadoopConfiguration)
+      val fs =
+        org.apache.hadoop.fs.FileSystem
+          .get(spark.sparkContext.hadoopConfiguration)
       fs.delete(new org.apache.hadoop.fs.Path(tempPath), true)
     }
   }

--- a/src/test/scala/dev/cjfravel/ariadne/IndexTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexTests.scala
@@ -1,57 +1,48 @@
 package dev.cjfravel.ariadne
 
-import dev.cjfravel.ariadne.exceptions._
-import org.apache.spark.sql.types._
-import org.apache.spark.sql.functions._
-import org.apache.spark.sql.Row
-import dev.cjfravel.ariadne.Index.DataFrameOps
 import java.nio.file.Files
 
-/** Tests for the [[Index]] case class covering schema validation, index type
-  * mutual exclusivity, idempotent add operations, and configuration options.
-  */
+import dev.cjfravel.ariadne.Index.DataFrameOps
+import dev.cjfravel.ariadne.exceptions._
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types._
+
+/**
+ * Tests for the [[Index]] case class covering schema validation, index type mutual exclusivity, idempotent add
+ * operations, and configuration options.
+ */
 class IndexTests extends SparkTests {
-  val table1Schema = StructType(
-    Seq(
-      StructField("Id", IntegerType, nullable = false),
-      StructField("Version", IntegerType, nullable = false),
-      StructField("Value", DoubleType, nullable = false)
-    )
-  )
+  val table1Schema =
+    StructType(
+      Seq(
+        StructField("Id", IntegerType, nullable = false),
+        StructField("Version", IntegerType, nullable = false),
+        StructField("Value", DoubleType, nullable = false)))
 
-  val table2Schema = StructType(
-    Seq(
-      StructField("Id", IntegerType, nullable = false),
-      StructField("Version", IntegerType, nullable = false)
-    )
-  )
+  val table2Schema =
+    StructType(
+      Seq(StructField("Id", IntegerType, nullable = false), StructField("Version", IntegerType, nullable = false)))
 
-  val table3Schema = StructType(
-    Seq(
-      StructField("Id", StringType, nullable = false),
-      StructField("Value", DoubleType, nullable = false)
-    )
-  )
+  val table3Schema =
+    StructType(Seq(StructField("Id", StringType, nullable = false), StructField("Value", DoubleType, nullable = false)))
 
-  val table4Schema = StructType(
-    Seq(
-      StructField("Id", StringType, nullable = false),
-      StructField("Status", StringType, nullable = false)
-    )
-  )
+  val table4Schema =
+    StructType(
+      Seq(StructField("Id", StringType, nullable = false), StructField("Status", StringType, nullable = false)))
 
   test("Requires schema") {
     assertThrows[SchemaNotProvidedException] {
-      val index = Index("noschema")
+      Index("noschema")
     }
   }
 
   test("Requires same schema") {
     val csvOptions = Map("header" -> "true")
-    val index = Index("schema", table1Schema, "csv", csvOptions)
-    val index2 = Index("schema", table1Schema, "csv", csvOptions)
+    Index("schema", table1Schema, "csv", csvOptions)
+    Index("schema", table1Schema, "csv", csvOptions)
     assertThrows[SchemaMismatchException] {
-      val index3 = Index("schema", table2Schema, "csv", csvOptions)
+      Index("schema", table2Schema, "csv", csvOptions)
     }
   }
 
@@ -59,30 +50,30 @@ class IndexTests extends SparkTests {
     val csvOptions = Map("header" -> "true")
     val index = Index("schemachange", table1Schema, "csv", csvOptions)
     index.addIndex("Id")
-    val index2 = Index("schemachange", table2Schema, "csv", true, csvOptions)
+    Index("schemachange", table2Schema, "csv", true, csvOptions)
     assertThrows[IndexNotFoundInNewSchemaException] {
       val index3 = Index("schemachange2", table1Schema, "csv", csvOptions)
       index3.addIndex("Value")
-      val index4 = Index("schemachange2", table2Schema, "csv", true, csvOptions)
+      Index("schemachange2", table2Schema, "csv", true, csvOptions)
     }
   }
 
   test("Requires same format") {
     val csvOptions = Map("header" -> "true")
-    val index = Index("format", table1Schema, "csv", csvOptions)
-    val index2 = Index("format", table1Schema, "csv", csvOptions)
+    Index("format", table1Schema, "csv", csvOptions)
+    Index("format", table1Schema, "csv", csvOptions)
     assertThrows[FormatMismatchException] {
-      val index3 = Index("format", table1Schema, "parquet")
+      Index("format", table1Schema, "parquet")
     }
   }
 
   test("Only requires schema first time") {
     val csvOptions = Map("header" -> "true")
     assertThrows[SchemaNotProvidedException] {
-      val index = Index("noschema")
+      Index("noschema")
     }
-    val index = Index("schema", table1Schema, "csv", csvOptions)
-    val index2 = Index("schema")
+    Index("schema", table1Schema, "csv", csvOptions)
+    Index("schema")
   }
 
   test("Can retrieve same schema") {
@@ -103,10 +94,7 @@ class IndexTests extends SparkTests {
   test("Index addFiles") {
     val csvOptions = Map("header" -> "true")
     val index = Index("test2", table1Schema, "csv", csvOptions)
-    val paths = Array(
-      resourcePath("/data/table1_part0.csv"),
-      resourcePath("/data/table1_part1.csv")
-    )
+    val paths = Array(resourcePath("/data/table1_part0.csv"), resourcePath("/data/table1_part1.csv"))
     paths.foreach(path => assert(index.hasFile(path) === false))
     index.addFile(paths: _*)
     paths.foreach(path => assert(index.hasFile(path) === true))
@@ -116,31 +104,31 @@ class IndexTests extends SparkTests {
   }
 
   test("Read table1_part0") {
-    val df = spark.read
-      .option("header", "true")
-      .schema(table1Schema)
-      .csv(resourcePath("/data/table1_part0.csv"))
+    val df =
+      spark.read
+        .option("header", "true")
+        .schema(table1Schema)
+        .csv(resourcePath("/data/table1_part0.csv"))
 
     assert(df.count() == 4)
   }
 
   test("Read table1_part1") {
-    val df = spark.read
-      .option("header", "true")
-      .schema(table1Schema)
-      .csv(resourcePath("/data/table1_part1.csv"))
+    val df =
+      spark.read
+        .option("header", "true")
+        .schema(table1Schema)
+        .csv(resourcePath("/data/table1_part1.csv"))
 
     assert(df.count() == 4)
   }
 
   test("Read table1") {
-    val df = spark.read
-      .option("header", "true")
-      .schema(table1Schema)
-      .csv(
-        resourcePath("/data/table1_part0.csv"),
-        resourcePath("/data/table1_part1.csv")
-      )
+    val df =
+      spark.read
+        .option("header", "true")
+        .schema(table1Schema)
+        .csv(resourcePath("/data/table1_part0.csv"), resourcePath("/data/table1_part1.csv"))
 
     assert(df.count() == 8)
   }
@@ -148,10 +136,7 @@ class IndexTests extends SparkTests {
   test("Update index") {
     val csvOptions = Map("header" -> "true")
     val index = Index("update", table1Schema, "csv", csvOptions)
-    val paths = Array(
-      resourcePath("/data/table1_part0.csv"),
-      resourcePath("/data/table1_part1.csv")
-    )
+    val paths = Array(resourcePath("/data/table1_part0.csv"), resourcePath("/data/table1_part1.csv"))
     index.addFile(paths: _*)
     assert(index.unindexedFiles.size === 2)
     index.addIndex("Id")
@@ -165,55 +150,44 @@ class IndexTests extends SparkTests {
     assert(
       index
         .locateFiles(Map("Version" -> Array("3"), "Id" -> Array("1")))
-        .size === 1
-    )
+        .size === 1)
     assert(index.locateFiles(Map("Value" -> Array(4.5))).size === 1)
     assert(index.locateFiles(Map("Value" -> Array(-1))).size === 0)
   }
 
-  private def normalizeSchema(schema: StructType): StructType = StructType(
-    schema.fields
-      // spark will covert non-null to null when reading csv
-      .map(f => StructField(f.name.toLowerCase, f.dataType, nullable = false))
-      .sortBy(_.name)
-  )
+  private def normalizeSchema(schema: StructType): StructType =
+    StructType(
+      schema.fields
+        // spark will covert non-null to null when reading csv
+        .map(f => StructField(f.name.toLowerCase(java.util.Locale.ROOT), f.dataType, nullable = false))
+        .sortBy(_.name))
 
   test("Join") {
     val csvOptions = Map("header" -> "true")
     val index = Index("join", table1Schema, "csv", csvOptions)
-    val paths = Array(
-      resourcePath("/data/table1_part0.csv"),
-      resourcePath("/data/table1_part1.csv")
-    )
+    val paths = Array(resourcePath("/data/table1_part0.csv"), resourcePath("/data/table1_part1.csv"))
     index.addFile(paths: _*)
     index.addIndex("Id")
     index.addIndex("Version")
     index.update
 
-    val table2 = spark.read
-      .schema(table2Schema)
-      .option("header", "true")
-      .csv(resourcePath("/data/table2_part0.csv"))
+    val table2 =
+      spark.read
+        .schema(table2Schema)
+        .option("header", "true")
+        .csv(resourcePath("/data/table2_part0.csv"))
 
     assert(table2.join(index, Seq("Version", "Id"), "left_semi").count === 1)
     assert(table2.join(index, Seq("Version"), "fullouter").count === 4)
     // AND semantics: intersection reads only part1 (4 rows), so fullouter = 4
     assert(table2.join(index, Seq("Version", "Id"), "fullouter").count === 4)
-    assert(
-      normalizeSchema(
-        table2.join(index, Seq("Version"), "left_semi").schema
-      ) === normalizeSchema(table2Schema)
-    )
+    assert(normalizeSchema(table2.join(index, Seq("Version"), "left_semi").schema) === normalizeSchema(table2Schema))
 
     assert(index.join(table2, Seq("Version", "Id"), "left_semi").count === 1)
     assert(index.join(table2, Seq("Version"), "fullouter").count === 4)
     // AND semantics: intersection reads only part1 (4 rows), so fullouter = 4
     assert(index.join(table2, Seq("Version", "Id"), "fullouter").count === 4)
-    assert(
-      normalizeSchema(
-        index.join(table2, Seq("Version"), "left_semi").schema
-      ) === normalizeSchema(table1Schema)
-    )
+    assert(normalizeSchema(index.join(table2, Seq("Version"), "left_semi").schema) === normalizeSchema(table1Schema))
   }
 
   test("index exists") {
@@ -239,10 +213,7 @@ class IndexTests extends SparkTests {
   test("computed_index") {
     val csvOptions = Map("header" -> "true")
     val index = Index("computed", table3Schema, "csv", csvOptions)
-    val paths = Array(
-      resourcePath("/data/table3_part0.csv"),
-      resourcePath("/data/table3_part1.csv")
-    )
+    val paths = Array(resourcePath("/data/table3_part0.csv"), resourcePath("/data/table3_part1.csv"))
     index.addFile(paths: _*)
     val column = "substring(Id, 1, 4)"
     index.addComputedIndex("Category", column)
@@ -255,8 +226,7 @@ class IndexTests extends SparkTests {
         .csv(resourcePath("/data/table4_part0.csv"))
         .withColumn("Category", substring(col("Id"), 1, 4))
         .join(index, Seq("Category"), "inner")
-        .count == 3
-    )
+        .count == 3)
 
     assert(
       spark.read
@@ -265,8 +235,7 @@ class IndexTests extends SparkTests {
         .csv(resourcePath("/data/table4_part1.csv"))
         .withColumn("Category", substring(col("Id"), 1, 4))
         .join(index, Seq("Category"), "inner")
-        .count == 2
-    )
+        .count == 2)
 
     assert(
       spark.read
@@ -275,8 +244,7 @@ class IndexTests extends SparkTests {
         .csv(resourcePath("/data/table4_part0.csv"))
         .withColumn("Category", substring(col("Id"), 1, 4))
         .join(index, Seq("Category", "Id"), "inner")
-        .count == 1
-    )
+        .count == 1)
 
     assert(
       spark.read
@@ -285,15 +253,15 @@ class IndexTests extends SparkTests {
         .csv(resourcePath("/data/table4_part1.csv"))
         .withColumn("Category", substring(col("Id"), 1, 4))
         .join(index, Seq("Category", "Id"), "inner")
-        .count == 1
-    )
+        .count == 1)
   }
 
   test("large index") {
-    val df = spark
-      .range(0, 1500000)
-      .toDF("Id")
-      .withColumn("Guid", expr("uuid()").cast(StringType))
+    val df =
+      spark
+        .range(0, 1500000)
+        .toDF("Id")
+        .withColumn("Guid", expr("uuid()").cast(StringType))
 
     val path = tempDir.resolve("large_index")
     df.coalesce(1)
@@ -303,13 +271,14 @@ class IndexTests extends SparkTests {
       .mode("overwrite")
       .csv(path.toString)
 
-    val fileName = "file://" + Files
-      .walk(path)
-      .filter(Files.isRegularFile(_))
-      .filter(_.getFileName.toString.endsWith(".csv"))
-      .findFirst()
-      .get()
-      .toString
+    val fileName =
+      "file://" + Files
+        .walk(path)
+        .filter(Files.isRegularFile(_))
+        .filter(_.getFileName.toString.endsWith(".csv"))
+        .findFirst()
+        .get()
+        .toString
 
     val csvOptions = Map("header" -> "true")
     val index = Index("large_index", df.schema, "csv", csvOptions)
@@ -319,96 +288,76 @@ class IndexTests extends SparkTests {
     index.update
     assert(index.unindexedFiles.size === 0)
 
-    val joinTestId = df
-      .select("Id")
-      .sample(0.2)
-      .limit(100)
+    val joinTestId =
+      df
+        .select("Id")
+        .sample(0.2)
+        .limit(100)
     assert(
       index
         .join(joinTestId, Seq("Id"), "left_semi")
-        .count() === 100
-    )
+        .count() === 100)
 
-    val joinTestGuid = df
-      .select("Guid")
-      .sample(0.2)
-      .limit(100)
+    val joinTestGuid =
+      df
+        .select("Guid")
+        .sample(0.2)
+        .limit(100)
     assert(
       index
         .join(joinTestGuid, Seq("Guid"), "left_semi")
-        .count() === 100
-    )
+        .count() === 100)
 
-    val joinTestIdGuid = df
-      .select("Id", "Guid")
-      .sample(0.2)
-      .limit(100)
+    val joinTestIdGuid =
+      df
+        .select("Id", "Guid")
+        .sample(0.2)
+        .limit(100)
     assert(
       index
         .join(joinTestIdGuid, Seq("Id", "Guid"), "left_semi")
-        .count() === 100
-    )
+        .count() === 100)
   }
 
   test("Array indexing") {
     // Define schema for array test data
-    val arrayTestSchema = StructType(
-      Seq(
-        StructField("event_id", StringType, nullable = false),
-        StructField("event_type", StringType, nullable = false),
-        StructField(
-          "users",
-          ArrayType(
-            StructType(
-              Seq(
+    val arrayTestSchema =
+      StructType(
+        Seq(
+          StructField("event_id", StringType, nullable = false),
+          StructField("event_type", StringType, nullable = false),
+          StructField(
+            "users",
+            ArrayType(
+              StructType(Seq(
                 StructField("id", IntegerType, nullable = false),
-                StructField("name", StringType, nullable = false)
-              )
-            )
-          ),
-          nullable = false
-        ),
-        StructField(
-          "tags",
-          ArrayType(
-            StructType(
-              Seq(
+                StructField("name", StringType, nullable = false)))),
+            nullable = false),
+          StructField(
+            "tags",
+            ArrayType(
+              StructType(Seq(
                 StructField("name", StringType, nullable = false),
-                StructField("category", StringType, nullable = false)
-              )
-            )
-          ),
-          nullable = false
-        )
-      )
-    )
+                StructField("category", StringType, nullable = false)))),
+            nullable = false)))
 
     // Create test data using Row objects
-    val testData = spark.createDataFrame(
-      spark.sparkContext.parallelize(
-        Seq(
-          Row(
-            "e1",
-            "login",
-            Array(Row(100, "Alice"), Row(101, "Bob")),
-            Array(Row("security", "auth"), Row("monitoring", "system"))
-          ),
-          Row(
-            "e2",
-            "purchase",
-            Array(Row(101, "Bob"), Row(102, "Charlie")),
-            Array(Row("commerce", "sales"), Row("payment", "billing"))
-          ),
-          Row(
-            "e3",
-            "logout",
-            Array(Row(100, "Alice")),
-            Array(Row("security", "auth"))
-          )
-        )
-      ),
-      arrayTestSchema
-    )
+    val testData =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(
+          Seq(
+            Row(
+              "e1",
+              "login",
+              Array(Row(100, "Alice"), Row(101, "Bob")),
+              Array(Row("security", "auth"), Row("monitoring", "system"))),
+            Row(
+              "e2",
+              "purchase",
+              Array(Row(101, "Bob"), Row(102, "Charlie")),
+              Array(Row("commerce", "sales"), Row("payment", "billing"))),
+            Row("e3", "logout", Array(Row(100, "Alice")), Array(Row("security", "auth"))))),
+        arrayTestSchema)
 
     // Write test data to temporary location
     val tempPath =
@@ -419,109 +368,70 @@ class IndexTests extends SparkTests {
     val index = Index("array_test", arrayTestSchema, "parquet")
     index.addFile(tempPath)
     index.addIndex("event_type") // regular index
-    index.addExplodedFieldIndex(
-      "users",
-      "id",
-      "user_id"
-    ) // exploded field index: users[].id as "user_id"
-    index.addExplodedFieldIndex(
-      "tags",
-      "name",
-      "tag_name"
-    ) // exploded field index: tags[].name as "tag_name"
+    index.addExplodedFieldIndex("users", "id", "user_id") // exploded field index: users[].id as "user_id"
+    index.addExplodedFieldIndex("tags", "name", "tag_name") // exploded field index: tags[].name as "tag_name"
     index.update
 
     // Test that we can find files by user_id
     val userFiles = index.locateFiles(Map("user_id" -> Array(100, 101)))
-    assert(
-      userFiles.nonEmpty,
-      "Should find files containing user IDs 100 or 101"
-    )
+    assert(userFiles.nonEmpty, "Should find files containing user IDs 100 or 101")
 
     // Test that we can find files by tag
     val tagFiles = index.locateFiles(Map("tag_name" -> Array("security")))
     assert(tagFiles.nonEmpty, "Should find files containing security tag")
 
     // Test join with user_id
-    val userQueryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(
-        Seq(
-          Row(100, "login"),
-          Row(101, "purchase")
-        )
-      ),
-      StructType(
-        Seq(
-          StructField("user_id", IntegerType, nullable = false),
-          StructField("event_type", StringType, nullable = false)
-        )
-      )
-    )
+    val userQueryData =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(Seq(Row(100, "login"), Row(101, "purchase"))),
+        StructType(
+          Seq(
+            StructField("user_id", IntegerType, nullable = false),
+            StructField("event_type", StringType, nullable = false))))
     val userJoinResult = userQueryData.join(index, Seq("user_id", "event_type"))
-    assert(
-      userJoinResult.count() > 0,
-      "Should be able to join on user_id and event_type"
-    )
+    assert(userJoinResult.count() > 0, "Should be able to join on user_id and event_type")
 
     // Test join with tag_name
-    val tagQueryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(
-        Seq(
-          Row("security"),
-          Row("commerce")
-        )
-      ),
-      StructType(Seq(StructField("tag_name", StringType, nullable = false)))
-    )
+    val tagQueryData =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(Seq(Row("security"), Row("commerce"))),
+        StructType(Seq(StructField("tag_name", StringType, nullable = false))))
     val tagJoinResult = tagQueryData.join(index, Seq("tag_name"))
     assert(tagJoinResult.count() > 0, "Should be able to join on tag_name")
 
     // Test that array-derived columns appear in indexes
     assert(index.indexes.contains("user_id"), "user_id should be in indexes")
     assert(index.indexes.contains("tag_name"), "tag_name should be in indexes")
-    assert(
-      index.indexes.contains("event_type"),
-      "event_type should be in indexes"
-    )
+    assert(index.indexes.contains("event_type"), "event_type should be in indexes")
 
     // Clean up
-    val fs = org.apache.hadoop.fs.FileSystem
-      .get(spark.sparkContext.hadoopConfiguration)
+    val fs =
+      org.apache.hadoop.fs.FileSystem
+        .get(spark.sparkContext.hadoopConfiguration)
     fs.delete(new org.apache.hadoop.fs.Path(tempPath), true)
   }
 
   // JSON Support Test Cases
   test("JSON format support - basic indexing") {
     // Define schema that matches the JSON array structure
-    val jsonEventsSchema = StructType(
-      Seq(
-        StructField("event_id", StringType, nullable = true),
-        StructField(
-          "participants",
-          ArrayType(
-            StructType(
-              Seq(
+    val jsonEventsSchema =
+      StructType(
+        Seq(
+          StructField("event_id", StringType, nullable = true),
+          StructField(
+            "participants",
+            ArrayType(
+              StructType(Seq(
                 StructField("role", StringType, nullable = true),
-                StructField("user_id", LongType, nullable = true)
-              )
-            )
-          ),
-          nullable = true
-        ),
-        StructField(
-          "tags",
-          ArrayType(
-            StructType(
-              Seq(
+                StructField("user_id", LongType, nullable = true)))),
+            nullable = true),
+          StructField(
+            "tags",
+            ArrayType(
+              StructType(Seq(
                 StructField("category", StringType, nullable = true),
-                StructField("name", StringType, nullable = true)
-              )
-            )
-          ),
-          nullable = true
-        )
-      )
-    )
+                StructField("name", StringType, nullable = true)))),
+            nullable = true)))
 
     // Create index with JSON format and multiLine option for JSON arrays
     val readOptions = Map("multiLine" -> "true")
@@ -543,10 +453,7 @@ class IndexTests extends SparkTests {
 
     // Test file location by event_id
     val eventFiles = index.locateFiles(Map("event_id" -> Array("evt1", "evt2")))
-    assert(
-      eventFiles.nonEmpty,
-      "Should find files containing event IDs evt1 or evt2"
-    )
+    assert(eventFiles.nonEmpty, "Should find files containing event IDs evt1 or evt2")
 
     // Verify index stats
     val stats = index.stats()
@@ -555,25 +462,17 @@ class IndexTests extends SparkTests {
 
   test("JSON format support - exploded field indexing") {
     // Define schema for JSON test data (matching array_test.json structure)
-    val jsonTestSchema = StructType(
-      Seq(
-        StructField("event_id", StringType, nullable = true),
-        StructField("event_type", StringType, nullable = true),
-        StructField(
-          "users",
-          ArrayType(
-            StructType(
-              Seq(
-                StructField("id", LongType, nullable = true),
-                StructField("name", StringType, nullable = true)
-              )
-            )
-          ),
-          nullable = true
-        ),
-        StructField("tags", ArrayType(StringType), nullable = true)
-      )
-    )
+    val jsonTestSchema =
+      StructType(
+        Seq(
+          StructField("event_id", StringType, nullable = true),
+          StructField("event_type", StringType, nullable = true),
+          StructField(
+            "users",
+            ArrayType(StructType(
+              Seq(StructField("id", LongType, nullable = true), StructField("name", StringType, nullable = true)))),
+            nullable = true),
+          StructField("tags", ArrayType(StringType), nullable = true)))
 
     // Create index with ONLY exploded field indexing (no regular indexes) and multiLine option
     val readOptions = Map("multiLine" -> "true")
@@ -590,47 +489,28 @@ class IndexTests extends SparkTests {
 
     // Verify only the exploded field index is registered
     assert(index.indexes.contains("user_id"), "user_id should be in indexes")
-    assert(
-      !index.indexes.contains("event_type"),
-      "event_type should NOT be in indexes for this test"
-    )
+    assert(!index.indexes.contains("event_type"), "event_type should NOT be in indexes for this test")
 
     // Test locating files by exploded field values - use correct storage column name
     val userIdFiles = index.locateFiles(Map("user_id" -> Array(100L, 101L)))
-    assert(
-      userIdFiles.nonEmpty,
-      "Should find files containing user IDs 100 or 101"
-    )
+    assert(userIdFiles.nonEmpty, "Should find files containing user IDs 100 or 101")
 
     // Test join with ONLY exploded field (no regular columns)
-    val userQueryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(
-        Seq(
-          Row(100L),
-          Row(101L)
-        )
-      ),
-      StructType(
-        Seq(
-          StructField("user_id", LongType, nullable = false)
-        )
-      )
-    )
+    val userQueryData =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(Seq(Row(100L), Row(101L))),
+        StructType(Seq(StructField("user_id", LongType, nullable = false))))
     val joinResult = userQueryData.join(index, Seq("user_id"))
-    assert(
-      joinResult.count() > 0,
-      "Should be able to join on user_id from JSON exploded field data"
-    )
+    assert(joinResult.count() > 0, "Should be able to join on user_id from JSON exploded field data")
   }
 
   test("JSON format support - computed indexes") {
     // Simple schema for JSON computed index test
-    val simpleJsonSchema = StructType(
-      Seq(
-        StructField("event_id", StringType, nullable = true),
-        StructField("event_type", StringType, nullable = true)
-      )
-    )
+    val simpleJsonSchema =
+      StructType(
+        Seq(
+          StructField("event_id", StringType, nullable = true),
+          StructField("event_type", StringType, nullable = true)))
 
     val readOptions = Map("multiLine" -> "true")
     val index = Index("json_computed", simpleJsonSchema, "json", readOptions)
@@ -646,34 +526,19 @@ class IndexTests extends SparkTests {
     index.printIndex(false)
 
     // Verify only computed index is available
-    assert(
-      index.indexes.contains("event_prefix"),
-      "computed index should be available"
-    )
-    assert(
-      !index.indexes.contains("event_type"),
-      "event_type should NOT be in indexes for this test"
-    )
+    assert(index.indexes.contains("event_prefix"), "computed index should be available")
+    assert(!index.indexes.contains("event_type"), "event_type should NOT be in indexes for this test")
 
     // Test join with ONLY computed index
-    val prefixQueryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(
-        Seq(
-          Row("e")
-        )
-      ),
-      StructType(
-        Seq(
-          StructField("event_prefix", StringType, nullable = false)
-        )
-      )
-    )
+    val prefixQueryData =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(Seq(Row("e"))),
+        StructType(Seq(StructField("event_prefix", StringType, nullable = false))))
     val computedJoinResult = prefixQueryData.join(index, Seq("event_prefix"))
+    // scalastyle:off println
     println(s"Computed join result count: ${computedJoinResult.count()}")
-    assert(
-      computedJoinResult.count() > 0,
-      "Should be able to join using computed index from JSON data"
-    )
+    // scalastyle:on println
+    assert(computedJoinResult.count() > 0, "Should be able to join using computed index from JSON data")
   }
 
   test("select restricts columns in join result") {
@@ -685,10 +550,11 @@ class IndexTests extends SparkTests {
     index.addIndex("Version")
     index.update
 
-    val table2 = spark.read
-      .schema(table2Schema)
-      .option("header", "true")
-      .csv(resourcePath("/data/table2_part0.csv"))
+    val table2 =
+      spark.read
+        .schema(table2Schema)
+        .option("header", "true")
+        .csv(resourcePath("/data/table2_part0.csv"))
 
     // Without select — result has all table1 columns
     val fullResult = index.join(table2, Seq("Id", "Version"), "left_semi")
@@ -707,11 +573,11 @@ class IndexTests extends SparkTests {
     val index = Index("select_validate_test", table1Schema, "csv")
 
     // Null/empty rejected
-    intercept[IllegalArgumentException] { index.select() }
-    intercept[IllegalArgumentException] { index.select("  ") }
+    intercept[IllegalArgumentException](index.select())
+    intercept[IllegalArgumentException](index.select("  "))
 
     // Non-existent column rejected
-    intercept[ColumnNotFoundException] { index.select("NonExistent") }
+    intercept[ColumnNotFoundException](index.select("NonExistent"))
 
     // Valid column works
     val result = index.select("Id")
@@ -719,28 +585,23 @@ class IndexTests extends SparkTests {
   }
 
   test("JSON format validation - requires same format") {
-    val jsonSchema = StructType(
-      Seq(
-        StructField("event_id", StringType, nullable = true)
-      )
-    )
+    val jsonSchema = StructType(Seq(StructField("event_id", StringType, nullable = true)))
 
-    val index = Index("json_format_test", jsonSchema, "json")
-    val index2 = Index("json_format_test", jsonSchema, "json")
+    Index("json_format_test", jsonSchema, "json")
+    Index("json_format_test", jsonSchema, "json")
 
     // Should throw exception when trying to change format
     assertThrows[FormatMismatchException] {
-      val index3 = Index("json_format_test", jsonSchema, "parquet")
+      Index("json_format_test", jsonSchema, "parquet")
     }
   }
 
   test("JSON format support - schema validation") {
-    val jsonSchema = StructType(
-      Seq(
-        StructField("event_id", StringType, nullable = true),
-        StructField("event_type", StringType, nullable = true)
-      )
-    )
+    val jsonSchema =
+      StructType(
+        Seq(
+          StructField("event_id", StringType, nullable = true),
+          StructField("event_type", StringType, nullable = true)))
 
     val index = Index("json_schema_test", jsonSchema, "json")
     assert(index.storedSchema === jsonSchema)

--- a/src/test/scala/dev/cjfravel/ariadne/MixedIndexIntersectionTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/MixedIndexIntersectionTests.scala
@@ -1,22 +1,20 @@
 package dev.cjfravel.ariadne
 
-import org.scalatest.matchers.should.Matchers
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.Row
+import org.scalatest.matchers.should.Matchers
 
-/** Tests for intersection of heterogeneous index types (regular and bloom
-  * filter), verifying AND semantics when locating files across mixed index
-  * columns.
-  */
+/**
+ * Tests for intersection of heterogeneous index types (regular and bloom filter), verifying AND semantics when locating
+ * files across mixed index columns.
+ */
 class MixedIndexIntersectionTests extends SparkTests with Matchers {
 
-  val testSchema = StructType(
-    Seq(
-      StructField("id", IntegerType, nullable = false),
-      StructField("category", StringType, nullable = false),
-      StructField("value", DoubleType, nullable = false)
-    )
-  )
+  val testSchema =
+    StructType(
+      Seq(
+        StructField("id", IntegerType, nullable = false),
+        StructField("category", StringType, nullable = false),
+        StructField("value", DoubleType, nullable = false)))
 
   test("should intersect regular and bloom indexes correctly (AND semantics)") {
     val indexName = "mixed_index_intersect"
@@ -49,7 +47,8 @@ class MixedIndexIntersectionTests extends SparkTests with Matchers {
     // Expected: Empty set
     // Bug: If bloom filter returns empty set (no match), it might be ignored, and regular index (id=1) returns path1.
 
-    // We need to use locateFilesFromDataFrame logic, which is used by join() or can be called directly if we expose it or use locateFiles
+    // We need to use locateFilesFromDataFrame logic, which is used by join() or can be called
+    // directly if we expose it or use locateFiles
     // locateFiles maps to locateFilesFromDataFrame internally? No, locateFiles maps to locateFilesRegular usually.
     // Let's check Index.scala locateFiles.
 

--- a/src/test/scala/dev/cjfravel/ariadne/MultiColumnIntersectTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/MultiColumnIntersectTests.scala
@@ -1,22 +1,21 @@
 package dev.cjfravel.ariadne
 
-import org.scalatest.matchers.should.Matchers
-import org.apache.spark.sql.types._
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.types._
+import org.scalatest.matchers.should.Matchers
 
-/** Tests for multi-column index intersection logic, verifying that
-  * `locateFiles` correctly computes the set intersection of matching files
-  * across multiple indexed columns.
-  */
+/**
+ * Tests for multi-column index intersection logic, verifying that `locateFiles` correctly computes the set intersection
+ * of matching files across multiple indexed columns.
+ */
 class MultiColumnIntersectTests extends SparkTests with Matchers {
 
-  val testSchema = StructType(
-    Seq(
-      StructField("Id", IntegerType, nullable = false),
-      StructField("Version", IntegerType, nullable = false),
-      StructField("Value", DoubleType, nullable = false)
-    )
-  )
+  val testSchema =
+    StructType(
+      Seq(
+        StructField("Id", IntegerType, nullable = false),
+        StructField("Version", IntegerType, nullable = false),
+        StructField("Value", DoubleType, nullable = false)))
 
   test("should intersect files when querying multiple columns") {
     val index =
@@ -81,15 +80,11 @@ class MultiColumnIntersectTests extends SparkTests with Matchers {
     index.update
 
     // Query for Id=4, Version=2 — both only in part1
-    val queryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(Seq(Row(4, 2))),
-      StructType(
-        Seq(
-          StructField("Id", IntegerType, nullable = false),
-          StructField("Version", IntegerType, nullable = false)
-        )
-      )
-    )
+    val queryData =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(Seq(Row(4, 2))),
+        StructType(
+          Seq(StructField("Id", IntegerType, nullable = false), StructField("Version", IntegerType, nullable = false))))
 
     val result = index.join(queryData, Seq("Id", "Version"), "inner")
     val resultRows = result.collect()
@@ -131,12 +126,7 @@ class MultiColumnIntersectTests extends SparkTests with Matchers {
 
     // Version=1 exists in both files, but Id=999 exists in neither.
     // With correct AND semantics across index types, the result must be empty.
-    val files = index.locateFiles(
-      Map(
-        "Id" -> Array(999),
-        "Version" -> Array(1)
-      )
-    )
+    val files = index.locateFiles(Map("Id" -> Array(999), "Version" -> Array(1)))
 
     files shouldBe empty
   }
@@ -155,12 +145,7 @@ class MultiColumnIntersectTests extends SparkTests with Matchers {
 
     // Id=1 is in both files. Version=3 is only in part1.
     // AND across both bloom columns should yield only part1.
-    val files = index.locateFiles(
-      Map(
-        "Id" -> Array(1),
-        "Version" -> Array(3)
-      )
-    )
+    val files = index.locateFiles(Map("Id" -> Array(1), "Version" -> Array(3)))
 
     files should have size 1
     files.head should include("table1_part1")

--- a/src/test/scala/dev/cjfravel/ariadne/RangeIndexTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/RangeIndexTests.scala
@@ -1,29 +1,26 @@
 package dev.cjfravel.ariadne
 
 import dev.cjfravel.ariadne.exceptions.ColumnNotFoundException
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
-import org.apache.spark.sql.types._
-import org.apache.spark.sql.functions._
 import org.apache.spark.sql.Row
-import dev.cjfravel.ariadne.Index.DataFrameOps
+import org.apache.spark.sql.types._
+import org.scalatest.matchers.should.Matchers
 
-/** Tests for range index support covering index creation, idempotency, min/max
-  * value tracking per file, and range-based file location queries.
-  */
+/**
+ * Tests for range index support covering index creation, idempotency, min/max value tracking per file, and range-based
+ * file location queries.
+ */
 class RangeIndexTests extends SparkTests with Matchers {
 
   // table1_part0.csv: Id=[1,2,3,1], Version=[1,1,1,2], Value=[5.0,3.0,4.0,4.5]
   //   -> Id range [1,3], Version range [1,2], Value range [3.0,5.0]
   // table1_part1.csv: Id=[4,4,3,1], Version=[1,2,2,3], Value=[2.0,9.0,4.0,5.0]
   //   -> Id range [1,4], Version range [1,3], Value range [2.0,9.0]
-  val testSchema: StructType = StructType(
-    Seq(
-      StructField("Id", IntegerType, nullable = false),
-      StructField("Version", IntegerType, nullable = false),
-      StructField("Value", DoubleType, nullable = false)
-    )
-  )
+  val testSchema: StructType =
+    StructType(
+      Seq(
+        StructField("Id", IntegerType, nullable = false),
+        StructField("Version", IntegerType, nullable = false),
+        StructField("Value", DoubleType, nullable = false)))
 
   test("should add range index") {
     val index =
@@ -116,10 +113,10 @@ class RangeIndexTests extends SparkTests with Matchers {
     index.update
 
     // Create a DataFrame with Id=4 which only appears in part1
-    val queryDf = spark.createDataFrame(
-      spark.sparkContext.parallelize(Seq(Row(4))),
-      StructType(Seq(StructField("Id", IntegerType, nullable = false)))
-    )
+    val queryDf =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(Seq(Row(4))),
+        StructType(Seq(StructField("Id", IntegerType, nullable = false))))
 
     val result = index.join(queryDf, Seq("Id"))
     result.count() should be > 0L

--- a/src/test/scala/dev/cjfravel/ariadne/SchemaHelperTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/SchemaHelperTests.scala
@@ -1,29 +1,21 @@
 package dev.cjfravel.ariadne
 
 import org.apache.spark.sql.types._
-
 import org.scalatest.funsuite.AnyFunSuite
 
-/** Tests for [[SchemaHelper]] verifying field lookup in flat and nested
-  * schemas.
-  */
+/**
+ * Tests for [[SchemaHelper]] verifying field lookup in flat and nested schemas.
+ */
 class SchemaHelperTests extends AnyFunSuite {
-  val schema = StructType(
-    Seq(
-      StructField("id", IntegerType, true),
-      StructField("name", StringType, true),
-      StructField(
-        "address",
-        StructType(
-          Seq(
-            StructField("street", StringType, true),
-            StructField("city", StringType, true)
-          )
-        ),
-        true
-      )
-    )
-  )
+  val schema =
+    StructType(
+      Seq(
+        StructField("id", IntegerType, true),
+        StructField("name", StringType, true),
+        StructField(
+          "address",
+          StructType(Seq(StructField("street", StringType, true), StructField("city", StringType, true))),
+          true)))
 
   test("schema contains") {
     assert(SchemaHelper.fieldExists(schema, "id") === true)

--- a/src/test/scala/dev/cjfravel/ariadne/SparkTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/SparkTests.scala
@@ -1,22 +1,20 @@
 package dev.cjfravel.ariadne
 
-import org.apache.spark.sql.SparkSession
-import org.apache.spark.SparkContext
+import java.nio.file.{Files, Path}
 
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.SparkSession
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 
-import java.nio.file.{Files, Path}
-
-/** Base test infrastructure trait for all Ariadne Spark tests.
-  *
-  * Creates a local-mode `SparkSession` with Delta Lake extensions and a
-  * temporary directory as `spark.ariadne.storagePath`. The session is torn down
-  * after each suite.
-  *
-  * Provides `resourcePath(fileName)` to resolve test data files from
-  * `src/test/resources/`.
-  */
+/**
+ * Base test infrastructure trait for all Ariadne Spark tests.
+ *
+ * Creates a local-mode `SparkSession` with Delta Lake extensions and a temporary directory as
+ * `spark.ariadne.storagePath`. The session is torn down after each suite.
+ *
+ * Provides `resourcePath(fileName)` to resolve test data files from `src/test/resources/`.
+ */
 trait SparkTests extends AnyFunSuite with BeforeAndAfterAll {
   implicit var spark: SparkSession = _
   var sc: SparkContext = _
@@ -26,16 +24,14 @@ trait SparkTests extends AnyFunSuite with BeforeAndAfterAll {
     tempDir = Files.createTempDirectory("ariadne-test-output-")
     sc = new SparkContext("local[*]", "TestAriadne")
 
-    spark = SparkSession
-      .builder()
-      .config(sc.getConf)
-      .config("spark.ariadne.storagePath", tempDir.toString)
-      .config("spark.ariadne.largeIndexLimit", "500000")
-      .config(
-        "spark.sql.catalog.spark_catalog",
-        "org.apache.spark.sql.delta.catalog.DeltaCatalog"
-      )
-      .getOrCreate()
+    spark =
+      SparkSession
+        .builder()
+        .config(sc.getConf)
+        .config("spark.ariadne.storagePath", tempDir.toString)
+        .config("spark.ariadne.largeIndexLimit", "500000")
+        .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+        .getOrCreate()
   }
 
   override def afterAll(): Unit = {
@@ -47,16 +43,6 @@ trait SparkTests extends AnyFunSuite with BeforeAndAfterAll {
     }
   }
 
-  private def deleteDirectory(path: Path): Unit = {
-    if (Files.isDirectory(path)) {
-      Files
-        .walk(path)
-        .sorted(java.util.Comparator.reverseOrder())
-        .forEach(Files.delete)
-    }
-  }
-
-  def resourcePath(fileName: String): String = {
+  def resourcePath(fileName: String): String =
     "file://" + getClass.getResource(fileName).getPath
-  }
 }

--- a/src/test/scala/dev/cjfravel/ariadne/TemporalIndexTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/TemporalIndexTests.scala
@@ -1,36 +1,31 @@
 package dev.cjfravel.ariadne
 
-import dev.cjfravel.ariadne.exceptions.ColumnNotFoundException
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
-import org.apache.spark.sql.types._
-import org.apache.spark.sql.functions._
-import org.apache.spark.sql.Row
 import dev.cjfravel.ariadne.Index.DataFrameOps
+import dev.cjfravel.ariadne.exceptions.ColumnNotFoundException
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types._
+import org.scalatest.matchers.should.Matchers
 
-/** Tests for temporal index support covering index creation, idempotency,
-  * validation of key/value columns, and temporal deduplication during joins.
-  */
+/**
+ * Tests for temporal index support covering index creation, idempotency, validation of key/value columns, and temporal
+ * deduplication during joins.
+ */
 class TemporalIndexTests extends SparkTests with Matchers {
 
   // Schema with Id, Value, and UpdatedAt timestamp
   // temporal_part0.csv: Id=1,2,3,4 with timestamps at 2024-01-15
   // temporal_part1.csv: Id=1,2,5 with timestamps at 2024-06 (1), 2024-03 (2), 2024-06 (5)
   // So latest for Id=1 is in part1 (2024-06), Id=2 in part1 (2024-03), Id=3 in part0, Id=4 in part0, Id=5 in part1
-  val temporalSchema = StructType(
-    Seq(
-      StructField("Id", IntegerType, nullable = false),
-      StructField("Value", DoubleType, nullable = false),
-      StructField("UpdatedAt", TimestampType, nullable = true)
-    )
-  )
+  val temporalSchema =
+    StructType(
+      Seq(
+        StructField("Id", IntegerType, nullable = false),
+        StructField("Value", DoubleType, nullable = false),
+        StructField("UpdatedAt", TimestampType, nullable = true)))
 
-  val simpleSchema = StructType(
-    Seq(
-      StructField("Id", IntegerType, nullable = false),
-      StructField("Value", DoubleType, nullable = false)
-    )
-  )
+  val simpleSchema =
+    StructType(
+      Seq(StructField("Id", IntegerType, nullable = false), StructField("Value", DoubleType, nullable = false)))
 
   test("addTemporalIndex should add a temporal index configuration") {
     val index =
@@ -42,12 +37,7 @@ class TemporalIndexTests extends SparkTests with Matchers {
   }
 
   test("addTemporalIndex should be idempotent") {
-    val index = Index(
-      "temporal_idempotent_test",
-      temporalSchema,
-      "csv",
-      Map("header" -> "true")
-    )
+    val index = Index("temporal_idempotent_test", temporalSchema, "csv", Map("header" -> "true"))
 
     index.addTemporalIndex("Id", "UpdatedAt")
     index.addTemporalIndex("Id", "UpdatedAt") // Should not throw
@@ -56,12 +46,7 @@ class TemporalIndexTests extends SparkTests with Matchers {
   }
 
   test("addTemporalIndex should reject non-existent value column") {
-    val index = Index(
-      "temporal_bad_col_test",
-      temporalSchema,
-      "csv",
-      Map("header" -> "true")
-    )
+    val index = Index("temporal_bad_col_test", temporalSchema, "csv", Map("header" -> "true"))
 
     a[ColumnNotFoundException] should be thrownBy {
       index.addTemporalIndex("NonExistent", "UpdatedAt")
@@ -69,12 +54,7 @@ class TemporalIndexTests extends SparkTests with Matchers {
   }
 
   test("addTemporalIndex should reject non-existent timestamp column") {
-    val index = Index(
-      "temporal_bad_ts_test",
-      temporalSchema,
-      "csv",
-      Map("header" -> "true")
-    )
+    val index = Index("temporal_bad_ts_test", temporalSchema, "csv", Map("header" -> "true"))
 
     a[ColumnNotFoundException] should be thrownBy {
       index.addTemporalIndex("Id", "NonExistent")
@@ -82,23 +62,13 @@ class TemporalIndexTests extends SparkTests with Matchers {
   }
 
   test("addTemporalIndex and addIndex should be mutually exclusive") {
-    val index1 = Index(
-      "temporal_excl_regular1",
-      temporalSchema,
-      "csv",
-      Map("header" -> "true")
-    )
+    val index1 = Index("temporal_excl_regular1", temporalSchema, "csv", Map("header" -> "true"))
     index1.addIndex("Id")
     an[IllegalArgumentException] should be thrownBy {
       index1.addTemporalIndex("Id", "UpdatedAt")
     }
 
-    val index2 = Index(
-      "temporal_excl_regular2",
-      temporalSchema,
-      "csv",
-      Map("header" -> "true")
-    )
+    val index2 = Index("temporal_excl_regular2", temporalSchema, "csv", Map("header" -> "true"))
     index2.addTemporalIndex("Id", "UpdatedAt")
     an[IllegalArgumentException] should be thrownBy {
       index2.addIndex("Id")
@@ -106,23 +76,13 @@ class TemporalIndexTests extends SparkTests with Matchers {
   }
 
   test("addTemporalIndex and addBloomIndex should be mutually exclusive") {
-    val index1 = Index(
-      "temporal_excl_bloom1",
-      temporalSchema,
-      "csv",
-      Map("header" -> "true")
-    )
+    val index1 = Index("temporal_excl_bloom1", temporalSchema, "csv", Map("header" -> "true"))
     index1.addBloomIndex("Id")
     an[IllegalArgumentException] should be thrownBy {
       index1.addTemporalIndex("Id", "UpdatedAt")
     }
 
-    val index2 = Index(
-      "temporal_excl_bloom2",
-      temporalSchema,
-      "csv",
-      Map("header" -> "true")
-    )
+    val index2 = Index("temporal_excl_bloom2", temporalSchema, "csv", Map("header" -> "true"))
     index2.addTemporalIndex("Id", "UpdatedAt")
     an[IllegalArgumentException] should be thrownBy {
       index2.addBloomIndex("Id")
@@ -130,12 +90,7 @@ class TemporalIndexTests extends SparkTests with Matchers {
   }
 
   test("metadata should persist temporal index configuration") {
-    val index1 = Index(
-      "temporal_persist_test",
-      temporalSchema,
-      "csv",
-      Map("header" -> "true")
-    )
+    val index1 = Index("temporal_persist_test", temporalSchema, "csv", Map("header" -> "true"))
     index1.addTemporalIndex("Id", "UpdatedAt")
 
     // Reload the index
@@ -144,12 +99,7 @@ class TemporalIndexTests extends SparkTests with Matchers {
   }
 
   test("should build temporal index during update") {
-    val index = Index(
-      "temporal_build_test",
-      temporalSchema,
-      "csv",
-      Map("header" -> "true")
-    )
+    val index = Index("temporal_build_test", temporalSchema, "csv", Map("header" -> "true"))
 
     val csvPath = resourcePath("/data/temporal_part0.csv")
     index.addFile(csvPath)
@@ -161,12 +111,7 @@ class TemporalIndexTests extends SparkTests with Matchers {
   }
 
   test("should locate files using temporal index with file pruning") {
-    val index = Index(
-      "temporal_locate_test",
-      temporalSchema,
-      "csv",
-      Map("header" -> "true")
-    )
+    val index = Index("temporal_locate_test", temporalSchema, "csv", Map("header" -> "true"))
 
     val csvPath0 = resourcePath("/data/temporal_part0.csv")
     val csvPath1 = resourcePath("/data/temporal_part1.csv")
@@ -191,12 +136,7 @@ class TemporalIndexTests extends SparkTests with Matchers {
   }
 
   test("temporal join should return only the latest version of each entity") {
-    val index = Index(
-      "temporal_dedup_test",
-      temporalSchema,
-      "csv",
-      Map("header" -> "true")
-    )
+    val index = Index("temporal_dedup_test", temporalSchema, "csv", Map("header" -> "true"))
 
     val csvPath0 = resourcePath("/data/temporal_part0.csv")
     val csvPath1 = resourcePath("/data/temporal_part1.csv")
@@ -207,25 +147,18 @@ class TemporalIndexTests extends SparkTests with Matchers {
     // Query for Id=1 which appears in both files
     // part0: Id=1, Value=100.0, UpdatedAt=2024-01-15
     // part1: Id=1, Value=150.0, UpdatedAt=2024-06-15 (LATEST)
-    val queryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(Seq(Row(1))),
-      StructType(Seq(StructField("Id", IntegerType, nullable = false)))
-    )
+    val queryData =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(Seq(Row(1))),
+        StructType(Seq(StructField("Id", IntegerType, nullable = false))))
 
     val result = index.join(queryData, Seq("Id"), "inner")
     result.count() should be(1) // Only one row for Id=1
-    result.select("Value").collect().head.getDouble(0) should be(
-      150.0
-    ) // Latest value
+    result.select("Value").collect().head.getDouble(0) should be(150.0) // Latest value
   }
 
   test("temporal join should deduplicate across multiple entities") {
-    val index = Index(
-      "temporal_multi_dedup_test",
-      temporalSchema,
-      "csv",
-      Map("header" -> "true")
-    )
+    val index = Index("temporal_multi_dedup_test", temporalSchema, "csv", Map("header" -> "true"))
 
     val csvPath0 = resourcePath("/data/temporal_part0.csv")
     val csvPath1 = resourcePath("/data/temporal_part1.csv")
@@ -236,30 +169,26 @@ class TemporalIndexTests extends SparkTests with Matchers {
     // Query for Id=1 and Id=2, both in both files
     // Id=1: latest in part1 (Value=150.0)
     // Id=2: latest in part1 (Value=250.0)
-    val queryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(Seq(Row(1), Row(2))),
-      StructType(Seq(StructField("Id", IntegerType, nullable = false)))
-    )
+    val queryData =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(Seq(Row(1), Row(2))),
+        StructType(Seq(StructField("Id", IntegerType, nullable = false))))
 
     val result = index.join(queryData, Seq("Id"), "inner")
     result.count() should be(2) // One per Id
 
-    val resultMap = result
-      .select("Id", "Value")
-      .collect()
-      .map(r => r.getInt(0) -> r.getDouble(1))
-      .toMap
+    val resultMap =
+      result
+        .select("Id", "Value")
+        .collect()
+        .map(r => r.getInt(0) -> r.getDouble(1))
+        .toMap
     resultMap(1) should be(150.0) // Latest for Id=1
     resultMap(2) should be(250.0) // Latest for Id=2
   }
 
   test("temporal join should handle entities only in one file") {
-    val index = Index(
-      "temporal_single_file_test",
-      temporalSchema,
-      "csv",
-      Map("header" -> "true")
-    )
+    val index = Index("temporal_single_file_test", temporalSchema, "csv", Map("header" -> "true"))
 
     val csvPath0 = resourcePath("/data/temporal_part0.csv")
     val csvPath1 = resourcePath("/data/temporal_part1.csv")
@@ -268,30 +197,26 @@ class TemporalIndexTests extends SparkTests with Matchers {
     index.update
 
     // Query for Id=3 (only in part0) and Id=5 (only in part1)
-    val queryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(Seq(Row(3), Row(5))),
-      StructType(Seq(StructField("Id", IntegerType, nullable = false)))
-    )
+    val queryData =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(Seq(Row(3), Row(5))),
+        StructType(Seq(StructField("Id", IntegerType, nullable = false))))
 
     val result = index.join(queryData, Seq("Id"), "inner")
     result.count() should be(2)
 
-    val resultMap = result
-      .select("Id", "Value")
-      .collect()
-      .map(r => r.getInt(0) -> r.getDouble(1))
-      .toMap
+    val resultMap =
+      result
+        .select("Id", "Value")
+        .collect()
+        .map(r => r.getInt(0) -> r.getDouble(1))
+        .toMap
     resultMap(3) should be(300.0) // Only version
     resultMap(5) should be(500.0) // Only version
   }
 
   test("temporal join with DataFrame.join implicit should work") {
-    val index = Index(
-      "temporal_implicit_join_test",
-      temporalSchema,
-      "csv",
-      Map("header" -> "true")
-    )
+    val index = Index("temporal_implicit_join_test", temporalSchema, "csv", Map("header" -> "true"))
 
     val csvPath0 = resourcePath("/data/temporal_part0.csv")
     val csvPath1 = resourcePath("/data/temporal_part1.csv")
@@ -299,44 +224,39 @@ class TemporalIndexTests extends SparkTests with Matchers {
     index.addTemporalIndex("Id", "UpdatedAt")
     index.update
 
-    val queryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(Seq(Row(1), Row(2))),
-      StructType(Seq(StructField("Id", IntegerType, nullable = false)))
-    )
+    val queryData =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(Seq(Row(1), Row(2))),
+        StructType(Seq(StructField("Id", IntegerType, nullable = false))))
 
     val result = queryData.join(index, Seq("Id"), "inner")
     result.count() should be(2)
   }
 
   test("should support mixed temporal and regular indexes") {
-    val mixedSchema = StructType(
-      Seq(
-        StructField("Id", IntegerType, nullable = false),
-        StructField("Category", StringType, nullable = false),
-        StructField("Value", DoubleType, nullable = false),
-        StructField("UpdatedAt", TimestampType, nullable = true)
-      )
-    )
+    val mixedSchema =
+      StructType(
+        Seq(
+          StructField("Id", IntegerType, nullable = false),
+          StructField("Category", StringType, nullable = false),
+          StructField("Value", DoubleType, nullable = false),
+          StructField("UpdatedAt", TimestampType, nullable = true)))
 
     // Create test data with categories and timestamps
-    val testData1 = spark.createDataFrame(
-      spark.sparkContext.parallelize(
-        Seq(
-          Row(1, "A", 100.0, java.sql.Timestamp.valueOf("2024-01-15 10:00:00")),
-          Row(2, "B", 200.0, java.sql.Timestamp.valueOf("2024-01-15 10:00:00"))
-        )
-      ),
-      mixedSchema
-    )
-    val testData2 = spark.createDataFrame(
-      spark.sparkContext.parallelize(
-        Seq(
-          Row(1, "A", 150.0, java.sql.Timestamp.valueOf("2024-06-15 12:00:00")),
-          Row(3, "C", 300.0, java.sql.Timestamp.valueOf("2024-06-15 12:00:00"))
-        )
-      ),
-      mixedSchema
-    )
+    val testData1 =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(
+          Seq(
+            Row(1, "A", 100.0, java.sql.Timestamp.valueOf("2024-01-15 10:00:00")),
+            Row(2, "B", 200.0, java.sql.Timestamp.valueOf("2024-01-15 10:00:00")))),
+        mixedSchema)
+    val testData2 =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(
+          Seq(
+            Row(1, "A", 150.0, java.sql.Timestamp.valueOf("2024-06-15 12:00:00")),
+            Row(3, "C", 300.0, java.sql.Timestamp.valueOf("2024-06-15 12:00:00")))),
+        mixedSchema)
 
     val tempPath1 =
       s"${System.getProperty("java.io.tmpdir")}/temporal_mixed_1_${System.currentTimeMillis()}"
@@ -356,48 +276,41 @@ class TemporalIndexTests extends SparkTests with Matchers {
       index.indexes should contain("Category")
 
       // Join on temporal column should dedup
-      val queryData = spark.createDataFrame(
-        spark.sparkContext.parallelize(Seq(Row(1))),
-        StructType(Seq(StructField("Id", IntegerType, nullable = false)))
-      )
+      val queryData =
+        spark.createDataFrame(
+          spark.sparkContext.parallelize(Seq(Row(1))),
+          StructType(Seq(StructField("Id", IntegerType, nullable = false))))
       val result = index.join(queryData, Seq("Id"), "inner")
       result.count() should be(1)
-      result.select("Value").collect().head.getDouble(0) should be(
-        150.0
-      ) // Latest
+      result.select("Value").collect().head.getDouble(0) should be(150.0) // Latest
     } finally {
-      val fs = org.apache.hadoop.fs.FileSystem
-        .get(spark.sparkContext.hadoopConfiguration)
+      val fs =
+        org.apache.hadoop.fs.FileSystem
+          .get(spark.sparkContext.hadoopConfiguration)
       fs.delete(new org.apache.hadoop.fs.Path(tempPath1), true)
       fs.delete(new org.apache.hadoop.fs.Path(tempPath2), true)
     }
   }
 
   test("temporal join should handle null timestamps (nulls ranked last)") {
-    val nullTsSchema = StructType(
-      Seq(
-        StructField("Id", IntegerType, nullable = false),
-        StructField("Value", DoubleType, nullable = false),
-        StructField("UpdatedAt", TimestampType, nullable = true)
-      )
-    )
+    val nullTsSchema =
+      StructType(
+        Seq(
+          StructField("Id", IntegerType, nullable = false),
+          StructField("Value", DoubleType, nullable = false),
+          StructField("UpdatedAt", TimestampType, nullable = true)))
 
-    val testData1 = spark.createDataFrame(
-      spark.sparkContext.parallelize(
-        Seq(
-          Row(1, 100.0, null) // null timestamp
-        )
-      ),
-      nullTsSchema
-    )
-    val testData2 = spark.createDataFrame(
-      spark.sparkContext.parallelize(
-        Seq(
-          Row(1, 150.0, java.sql.Timestamp.valueOf("2024-06-15 12:00:00"))
-        )
-      ),
-      nullTsSchema
-    )
+    val testData1 =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(
+          Seq(
+            Row(1, 100.0, null) // null timestamp
+          )),
+        nullTsSchema)
+    val testData2 =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(Seq(Row(1, 150.0, java.sql.Timestamp.valueOf("2024-06-15 12:00:00")))),
+        nullTsSchema)
 
     val tempPath1 =
       s"${System.getProperty("java.io.tmpdir")}/temporal_null_1_${System.currentTimeMillis()}"
@@ -412,18 +325,17 @@ class TemporalIndexTests extends SparkTests with Matchers {
       index.addTemporalIndex("Id", "UpdatedAt")
       index.update
 
-      val queryData = spark.createDataFrame(
-        spark.sparkContext.parallelize(Seq(Row(1))),
-        StructType(Seq(StructField("Id", IntegerType, nullable = false)))
-      )
+      val queryData =
+        spark.createDataFrame(
+          spark.sparkContext.parallelize(Seq(Row(1))),
+          StructType(Seq(StructField("Id", IntegerType, nullable = false))))
       val result = index.join(queryData, Seq("Id"), "inner")
       result.count() should be(1)
-      result.select("Value").collect().head.getDouble(0) should be(
-        150.0
-      ) // Non-null ts wins
+      result.select("Value").collect().head.getDouble(0) should be(150.0) // Non-null ts wins
     } finally {
-      val fs = org.apache.hadoop.fs.FileSystem
-        .get(spark.sparkContext.hadoopConfiguration)
+      val fs =
+        org.apache.hadoop.fs.FileSystem
+          .get(spark.sparkContext.hadoopConfiguration)
       fs.delete(new org.apache.hadoop.fs.Path(tempPath1), true)
       fs.delete(new org.apache.hadoop.fs.Path(tempPath2), true)
     }

--- a/src/test/scala/dev/cjfravel/ariadne/catalog/AriadneCatalogTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/catalog/AriadneCatalogTests.scala
@@ -1,77 +1,65 @@
 package dev.cjfravel.ariadne.catalog
 
+import java.nio.file.Files
+
 import dev.cjfravel.ariadne.{Index, IndexCatalog, SparkTests}
-import dev.cjfravel.ariadne.Index.DataFrameOps
-import org.apache.spark.{SparkConf, SparkContext}
-import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.functions
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.{SparkConf, SparkContext}
 import org.scalatest.matchers.should.Matchers
 
-import java.nio.file.{Files, Path}
-
-/** Tests for the Ariadne Spark SQL catalog integration.
-  *
-  * Verifies that Ariadne indexes are discoverable and queryable through Spark
-  * SQL when the [[AriadneCatalog]] is configured. Tests cover:
-  *   - `SHOW TABLES` discovering all indexes
-  *   - `DESCRIBE TABLE` returning the correct source schema
-  *   - `SELECT *` reading source data files
-  *   - `WHERE` filter pushdown using `locateFiles()`
-  *   - `JOIN` optimization via the [[AriadneJoinRule]]
-  *
-  * Uses a separate SparkSession with the Ariadne catalog and extension
-  * registered, distinct from the base [[SparkTests]] session.
-  */
+/**
+ * Tests for the Ariadne Spark SQL catalog integration.
+ *
+ * Verifies that Ariadne indexes are discoverable and queryable through Spark SQL when the [[AriadneCatalog]] is
+ * configured. Tests cover:
+ *   - `SHOW TABLES` discovering all indexes
+ *   - `DESCRIBE TABLE` returning the correct source schema
+ *   - `SELECT *` reading source data files
+ *   - `WHERE` filter pushdown using `locateFiles()`
+ *   - `JOIN` optimization via the [[AriadneJoinRule]]
+ *
+ * Uses a separate SparkSession with the Ariadne catalog and extension registered, distinct from the base [[SparkTests]]
+ * session.
+ */
 class AriadneCatalogTests extends SparkTests with Matchers {
 
-  val indexSchema: StructType = StructType(
-    Seq(
-      StructField("Id", IntegerType, nullable = false),
-      StructField("Version", IntegerType, nullable = false),
-      StructField("Value", DoubleType, nullable = false)
-    )
-  )
+  val indexSchema: StructType =
+    StructType(
+      Seq(
+        StructField("Id", IntegerType, nullable = false),
+        StructField("Version", IntegerType, nullable = false),
+        StructField("Value", DoubleType, nullable = false)))
 
-  val querySchema: StructType = StructType(
-    Seq(
-      StructField("Id", IntegerType, nullable = false),
-      StructField("Version", IntegerType, nullable = false)
-    )
-  )
+  val querySchema: StructType =
+    StructType(
+      Seq(StructField("Id", IntegerType, nullable = false), StructField("Version", IntegerType, nullable = false)))
 
-  /** Override to add Ariadne catalog + extension configuration.
-    * spark.sql.extensions is a static config that must be on SparkConf BEFORE
-    * SparkContext creation — setting it on the builder is too late.
-    */
+  /**
+   * Override to add Ariadne catalog + extension configuration. spark.sql.extensions is a static config that must be on
+   * SparkConf BEFORE SparkContext creation — setting it on the builder is too late.
+   */
   override def beforeAll(): Unit = {
     tempDir = Files.createTempDirectory("ariadne-catalog-test-")
 
-    val conf = new SparkConf()
-      .setMaster("local[*]")
-      .setAppName("TestAriadneCatalog")
-      .set(
-        "spark.sql.extensions",
-        "dev.cjfravel.ariadne.catalog.AriadneSparkExtension"
-      )
+    val conf =
+      new SparkConf()
+        .setMaster("local[*]")
+        .setAppName("TestAriadneCatalog")
+        .set("spark.sql.extensions", "dev.cjfravel.ariadne.catalog.AriadneSparkExtension")
     sc = new SparkContext(conf)
 
-    spark = SparkSession
-      .builder()
-      .config(sc.getConf)
-      .config("spark.ariadne.storagePath", tempDir.toString)
-      .config("spark.ariadne.largeIndexLimit", "500000")
-      .config(
-        "spark.sql.catalog.spark_catalog",
-        "org.apache.spark.sql.delta.catalog.DeltaCatalog"
-      )
-      .config(
-        "spark.sql.catalog.ariadne",
-        "dev.cjfravel.ariadne.catalog.AriadneCatalog"
-      )
-      .getOrCreate()
+    spark =
+      SparkSession
+        .builder()
+        .config(sc.getConf)
+        .config("spark.ariadne.storagePath", tempDir.toString)
+        .config("spark.ariadne.largeIndexLimit", "500000")
+        .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+        .config("spark.sql.catalog.ariadne", "dev.cjfravel.ariadne.catalog.AriadneCatalog")
+        .getOrCreate()
   }
 
   private def createTestIndex(name: String): Index = {
@@ -128,24 +116,15 @@ class AriadneCatalogTests extends SparkTests with Matchers {
   }
 
   test("DESCRIBE TABLE handles complex types") {
-    val complexSchema = StructType(
-      Seq(
-        StructField("event_id", StringType),
-        StructField("event_type", StringType),
-        StructField(
-          "tags",
-          ArrayType(
-            StructType(
-              Seq(
-                StructField("name", StringType),
-                StructField("category", StringType)
-              )
-            )
-          )
-        ),
-        StructField("user_ids", ArrayType(LongType))
-      )
-    )
+    val complexSchema =
+      StructType(
+        Seq(
+          StructField("event_id", StringType),
+          StructField("event_type", StringType),
+          StructField(
+            "tags",
+            ArrayType(StructType(Seq(StructField("name", StringType), StructField("category", StringType))))),
+          StructField("user_ids", ArrayType(LongType))))
 
     val index = Index("catalog_complex_describe", complexSchema, "json")
     index.addFile(resourcePath("/data/events.json"))
@@ -153,9 +132,10 @@ class AriadneCatalogTests extends SparkTests with Matchers {
     index.update
 
     val desc = spark.sql("DESCRIBE ariadne.catalog_complex_describe").collect()
-    val colMap = desc
-      .map(r => r.getAs[String]("col_name") -> r.getAs[String]("data_type"))
-      .toMap
+    val colMap =
+      desc
+        .map(r => r.getAs[String]("col_name") -> r.getAs[String]("data_type"))
+        .toMap
 
     colMap should contain key "event_id"
     colMap should contain key "tags"
@@ -208,16 +188,12 @@ class AriadneCatalogTests extends SparkTests with Matchers {
   test("SELECT with WHERE IN on indexed column") {
     createTestIndex("catalog_where_in_test")
 
-    val result = spark.sql(
-      "SELECT * FROM ariadne.catalog_where_in_test WHERE Id IN (1, 2)"
-    )
+    val result = spark.sql("SELECT * FROM ariadne.catalog_where_in_test WHERE Id IN (1, 2)")
     val rows = result.collect()
 
     // Id=1: 3 rows, Id=2: 1 row = 4 total
     rows.length should be(4)
-    rows.foreach { row =>
-      Set(1, 2) should contain(row.getAs[Int]("Id"))
-    }
+    rows.foreach(row => Set(1, 2) should contain(row.getAs[Int]("Id")))
   }
 
   // --- JOIN optimization ---
@@ -226,18 +202,12 @@ class AriadneCatalogTests extends SparkTests with Matchers {
     createTestIndex("catalog_join_test")
 
     // Create a temp table for the "other side"
-    val queryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(
-        Seq(Row(1, 1), Row(2, 1))
-      ),
-      querySchema
-    )
+    val queryData = spark.createDataFrame(spark.sparkContext.parallelize(Seq(Row(1, 1), Row(2, 1))), querySchema)
     queryData.createOrReplaceTempView("join_query")
 
-    val result = spark.sql(
-      """SELECT c.* FROM ariadne.catalog_join_test c
-        |JOIN join_query q ON c.Id = q.Id AND c.Version = q.Version""".stripMargin
-    )
+    val result =
+      spark.sql("""SELECT c.* FROM ariadne.catalog_join_test c
+        |JOIN join_query q ON c.Id = q.Id AND c.Version = q.Version""".stripMargin)
     val rows = result.collect()
 
     // Id=1,Version=1 -> (1,1,5.0); Id=2,Version=1 -> (2,1,3.0)
@@ -247,28 +217,23 @@ class AriadneCatalogTests extends SparkTests with Matchers {
   test("SQL JOIN matches programmatic index.join results") {
     val index = createTestIndex("catalog_join_match_test")
 
-    val queryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(
-        Seq(Row(1, 1), Row(3, 2))
-      ),
-      querySchema
-    )
+    val queryData = spark.createDataFrame(spark.sparkContext.parallelize(Seq(Row(1, 1), Row(3, 2))), querySchema)
     queryData.createOrReplaceTempView("match_query")
 
     // Programmatic join
-    val programmaticResult = index
-      .join(queryData, Seq("Id", "Version"), "inner")
-      .orderBy("Id", "Version")
-      .collect()
+    val programmaticResult =
+      index
+        .join(queryData, Seq("Id", "Version"), "inner")
+        .orderBy("Id", "Version")
+        .collect()
 
     // SQL join
-    val sqlResult = spark
-      .sql(
-        """SELECT c.Id, c.Version, c.Value FROM ariadne.catalog_join_match_test c
+    val sqlResult =
+      spark
+        .sql("""SELECT c.Id, c.Version, c.Value FROM ariadne.catalog_join_match_test c
           |JOIN match_query q ON c.Id = q.Id AND c.Version = q.Version
-          |ORDER BY c.Id, c.Version""".stripMargin
-      )
-      .collect()
+          |ORDER BY c.Id, c.Version""".stripMargin)
+        .collect()
 
     programmaticResult.length should be(sqlResult.length)
     programmaticResult.zip(sqlResult).foreach { case (prog, sql) =>
@@ -279,44 +244,32 @@ class AriadneCatalogTests extends SparkTests with Matchers {
   }
 
   test("SQL JOIN with reverse direction") {
-    val index = createTestIndex("catalog_join_reverse_test")
+    createTestIndex("catalog_join_reverse_test")
 
-    val queryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(
-        Seq(Row(1, 1), Row(4, 2))
-      ),
-      querySchema
-    )
+    val queryData = spark.createDataFrame(spark.sparkContext.parallelize(Seq(Row(1, 1), Row(4, 2))), querySchema)
     queryData.createOrReplaceTempView("reverse_query")
 
     // SQL join with Ariadne on the right
-    val result = spark.sql(
-      """SELECT * FROM reverse_query q
+    val result =
+      spark.sql("""SELECT * FROM reverse_query q
         |JOIN ariadne.catalog_join_reverse_test c
-        |ON q.Id = c.Id AND q.Version = c.Version""".stripMargin
-    )
+        |ON q.Id = c.Id AND q.Version = c.Version""".stripMargin)
     val rows = result.collect()
     rows.length should be(2)
   }
 
   test("SQL JOIN with non-indexed columns falls back gracefully") {
-    val index = createTestIndex("catalog_join_fallback_test")
+    createTestIndex("catalog_join_fallback_test")
 
-    val valueSchema = StructType(
-      Seq(StructField("Value", DoubleType, nullable = false))
-    )
-    val queryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(Seq(Row(5.0))),
-      valueSchema
-    )
+    val valueSchema = StructType(Seq(StructField("Value", DoubleType, nullable = false)))
+    val queryData = spark.createDataFrame(spark.sparkContext.parallelize(Seq(Row(5.0))), valueSchema)
     queryData.createOrReplaceTempView("fallback_query")
 
     // Value is not indexed, so the join rule should not rewrite
     // This should still work via the V1Scan fallback (full table scan + standard join)
-    val result = spark.sql(
-      """SELECT * FROM ariadne.catalog_join_fallback_test c
-        |JOIN fallback_query q ON c.Value = q.Value""".stripMargin
-    )
+    val result =
+      spark.sql("""SELECT * FROM ariadne.catalog_join_fallback_test c
+        |JOIN fallback_query q ON c.Value = q.Value""".stripMargin)
     val rows = result.collect()
     // Value=5.0 appears in (1,1,5.0) and (1,3,5.0)
     rows.length should be(2)
@@ -328,11 +281,12 @@ class AriadneCatalogTests extends SparkTests with Matchers {
     createTestIndex("catalog_list_match_test")
 
     val catalogNames = IndexCatalog.list().toSet
-    val sqlNames = spark
-      .sql("SHOW TABLES IN ariadne")
-      .collect()
-      .map(_.getAs[String]("tableName"))
-      .toSet
+    val sqlNames =
+      spark
+        .sql("SHOW TABLES IN ariadne")
+        .collect()
+        .map(_.getAs[String]("tableName"))
+        .toSet
 
     // SQL should show at least all indexes that IndexCatalog.list shows
     catalogNames.foreach(name => sqlNames should contain(name))
@@ -343,22 +297,15 @@ class AriadneCatalogTests extends SparkTests with Matchers {
   test("JOIN with non-equi condition preserves all predicates") {
     createTestIndex("catalog_nonequi_test")
 
-    val nonEquiSchema = StructType(
-      Seq(
-        StructField("Id", IntegerType, nullable = false),
-        StructField("MinValue", DoubleType, nullable = false)
-      )
-    )
-    val queryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(Seq(Row(1, 4.9))),
-      nonEquiSchema
-    )
+    val nonEquiSchema =
+      StructType(
+        Seq(StructField("Id", IntegerType, nullable = false), StructField("MinValue", DoubleType, nullable = false)))
+    val queryData = spark.createDataFrame(spark.sparkContext.parallelize(Seq(Row(1, 4.9))), nonEquiSchema)
     queryData.createOrReplaceTempView("nonequi_query")
 
-    val result = spark.sql(
-      """SELECT c.* FROM ariadne.catalog_nonequi_test c
-        |JOIN nonequi_query q ON c.Id = q.Id AND c.Value > q.MinValue""".stripMargin
-    )
+    val result =
+      spark.sql("""SELECT c.* FROM ariadne.catalog_nonequi_test c
+        |JOIN nonequi_query q ON c.Id = q.Id AND c.Value > q.MinValue""".stripMargin)
     val rows = result.collect()
 
     // Id=1 rows: (1,1,5.0), (1,2,4.5), (1,3,5.0)
@@ -378,16 +325,12 @@ class AriadneCatalogTests extends SparkTests with Matchers {
     index.addIndex("Id") // Only Id indexed, not Version
     index.update
 
-    val queryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(Seq(Row(1, 1), Row(1, 2))),
-      querySchema
-    )
+    val queryData = spark.createDataFrame(spark.sparkContext.parallelize(Seq(Row(1, 1), Row(1, 2))), querySchema)
     queryData.createOrReplaceTempView("partial_query")
 
-    val result = spark.sql(
-      """SELECT c.* FROM ariadne.catalog_partial_idx_test c
-        |JOIN partial_query q ON c.Id = q.Id AND c.Version = q.Version""".stripMargin
-    )
+    val result =
+      spark.sql("""SELECT c.* FROM ariadne.catalog_partial_idx_test c
+        |JOIN partial_query q ON c.Id = q.Id AND c.Version = q.Version""".stripMargin)
     val rows = result.collect()
 
     // Should match: (1,1,5.0) and (1,2,4.5) = 2 rows
@@ -400,23 +343,16 @@ class AriadneCatalogTests extends SparkTests with Matchers {
   test("JOIN with different column names produces correct results") {
     createTestIndex("catalog_diffname_test")
 
-    val diffNameSchema = StructType(
-      Seq(
-        StructField("CustomerId", IntegerType, nullable = false),
-        StructField("Id", IntegerType, nullable = false)
-      )
-    )
-    val queryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(Seq(Row(1, 999))),
-      diffNameSchema
-    )
+    val diffNameSchema =
+      StructType(
+        Seq(StructField("CustomerId", IntegerType, nullable = false), StructField("Id", IntegerType, nullable = false)))
+    val queryData = spark.createDataFrame(spark.sparkContext.parallelize(Seq(Row(1, 999))), diffNameSchema)
     queryData.createOrReplaceTempView("diffname_query")
 
     // Intent: join c.Id = q.CustomerId (=1), NOT c.Id = q.Id (=999)
-    val result = spark.sql(
-      """SELECT c.* FROM ariadne.catalog_diffname_test c
-        |JOIN diffname_query q ON c.Id = q.CustomerId""".stripMargin
-    )
+    val result =
+      spark.sql("""SELECT c.* FROM ariadne.catalog_diffname_test c
+        |JOIN diffname_query q ON c.Id = q.CustomerId""".stripMargin)
     val rows = result.collect()
 
     // c.Id should match q.CustomerId=1: (1,1,5.0), (1,2,4.5), (1,3,5.0) = 3 rows
@@ -426,22 +362,17 @@ class AriadneCatalogTests extends SparkTests with Matchers {
   test("JOIN with different column names on multiple columns") {
     createTestIndex("catalog_diffname_multi_test")
 
-    val diffNameSchema = StructType(
-      Seq(
-        StructField("CustId", IntegerType, nullable = false),
-        StructField("CustVersion", IntegerType, nullable = false)
-      )
-    )
-    val queryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(Seq(Row(1, 1), Row(3, 2))),
-      diffNameSchema
-    )
+    val diffNameSchema =
+      StructType(
+        Seq(
+          StructField("CustId", IntegerType, nullable = false),
+          StructField("CustVersion", IntegerType, nullable = false)))
+    val queryData = spark.createDataFrame(spark.sparkContext.parallelize(Seq(Row(1, 1), Row(3, 2))), diffNameSchema)
     queryData.createOrReplaceTempView("diffname_multi_query")
 
-    val result = spark.sql(
-      """SELECT c.* FROM ariadne.catalog_diffname_multi_test c
-        |JOIN diffname_multi_query q ON c.Id = q.CustId AND c.Version = q.CustVersion""".stripMargin
-    )
+    val result =
+      spark.sql("""SELECT c.* FROM ariadne.catalog_diffname_multi_test c
+        |JOIN diffname_multi_query q ON c.Id = q.CustId AND c.Version = q.CustVersion""".stripMargin)
     val rows = result.collect()
 
     // (1,1,5.0) and (3,2,4.0) = 2 rows
@@ -453,18 +384,14 @@ class AriadneCatalogTests extends SparkTests with Matchers {
   test("LEFT OUTER JOIN returns unmatched rows with nulls") {
     createTestIndex("catalog_left_join_test")
 
-    val queryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(Seq(Row(1, 1), Row(999, 1))),
-      querySchema
-    )
+    val queryData = spark.createDataFrame(spark.sparkContext.parallelize(Seq(Row(1, 1), Row(999, 1))), querySchema)
     queryData.createOrReplaceTempView("left_join_query")
 
-    val result = spark.sql(
-      """SELECT q.Id as qId, q.Version as qVersion, c.Value
+    val result =
+      spark.sql("""SELECT q.Id as qId, q.Version as qVersion, c.Value
         |FROM left_join_query q
         |LEFT JOIN ariadne.catalog_left_join_test c
-        |ON q.Id = c.Id AND q.Version = c.Version""".stripMargin
-    )
+        |ON q.Id = c.Id AND q.Version = c.Version""".stripMargin)
     val rows = result.collect()
 
     // 2 rows: (1,1,5.0) matched; (999,1,null) unmatched
@@ -482,19 +409,14 @@ class AriadneCatalogTests extends SparkTests with Matchers {
   test("JOIN preserves WHERE filter on Ariadne side") {
     createTestIndex("catalog_filter_join_test")
 
-    val queryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(
-        Seq(Row(1, 1), Row(1, 2), Row(1, 3))
-      ),
-      querySchema
-    )
+    val queryData =
+      spark.createDataFrame(spark.sparkContext.parallelize(Seq(Row(1, 1), Row(1, 2), Row(1, 3))), querySchema)
     queryData.createOrReplaceTempView("filter_join_query")
 
-    val result = spark.sql(
-      """SELECT c.* FROM ariadne.catalog_filter_join_test c
+    val result =
+      spark.sql("""SELECT c.* FROM ariadne.catalog_filter_join_test c
         |JOIN filter_join_query q ON c.Id = q.Id AND c.Version = q.Version
-        |WHERE c.Value > 4.9""".stripMargin
-    )
+        |WHERE c.Value > 4.9""".stripMargin)
     val rows = result.collect()
 
     // Id=1 matching rows: (1,1,5.0), (1,2,4.5), (1,3,5.0)
@@ -539,16 +461,13 @@ class AriadneCatalogTests extends SparkTests with Matchers {
 
   // --- Round 2 edge case: Temporal dedup missing in join rule ---
 
-  test(
-    "SQL JOIN on temporal index applies deduplication like programmatic API"
-  ) {
-    val temporalSchema = StructType(
-      Seq(
-        StructField("Id", IntegerType, nullable = false),
-        StructField("Value", DoubleType, nullable = false),
-        StructField("UpdatedAt", TimestampType, nullable = false)
-      )
-    )
+  test("SQL JOIN on temporal index applies deduplication like programmatic API") {
+    val temporalSchema =
+      StructType(
+        Seq(
+          StructField("Id", IntegerType, nullable = false),
+          StructField("Value", DoubleType, nullable = false),
+          StructField("UpdatedAt", TimestampType, nullable = false)))
     val csvOptions = Map("header" -> "true")
     val index =
       Index("catalog_temporal_join_test", temporalSchema, "csv", csvOptions)
@@ -559,10 +478,7 @@ class AriadneCatalogTests extends SparkTests with Matchers {
 
     val queryIdSchema =
       StructType(Seq(StructField("Id", IntegerType, nullable = false)))
-    val queryData = spark.createDataFrame(
-      spark.sparkContext.parallelize(Seq(Row(1))),
-      queryIdSchema
-    )
+    val queryData = spark.createDataFrame(spark.sparkContext.parallelize(Seq(Row(1))), queryIdSchema)
     queryData.createOrReplaceTempView("temporal_join_query")
 
     // Programmatic join applies temporal dedup — returns only latest version
@@ -572,10 +488,9 @@ class AriadneCatalogTests extends SparkTests with Matchers {
     programmaticRows.head.getAs[Double]("Value") should be(150.0)
 
     // SQL join should match programmatic behavior
-    val sqlResult = spark.sql(
-      """SELECT c.Id, c.Value FROM ariadne.catalog_temporal_join_test c
-        |JOIN temporal_join_query q ON c.Id = q.Id""".stripMargin
-    )
+    val sqlResult =
+      spark.sql("""SELECT c.Id, c.Value FROM ariadne.catalog_temporal_join_test c
+        |JOIN temporal_join_query q ON c.Id = q.Id""".stripMargin)
     val sqlRows = sqlResult.collect()
     sqlRows.length should be(1)
     sqlRows.head.getAs[Double]("Value") should be(150.0)
@@ -584,13 +499,12 @@ class AriadneCatalogTests extends SparkTests with Matchers {
   // --- Round 2 edge case: Temporal pushdown changes scan semantics ---
 
   test("SELECT WHERE on temporal column returns only latest version") {
-    val temporalSchema = StructType(
-      Seq(
-        StructField("Id", IntegerType, nullable = false),
-        StructField("Value", DoubleType, nullable = false),
-        StructField("UpdatedAt", TimestampType, nullable = false)
-      )
-    )
+    val temporalSchema =
+      StructType(
+        Seq(
+          StructField("Id", IntegerType, nullable = false),
+          StructField("Value", DoubleType, nullable = false),
+          StructField("UpdatedAt", TimestampType, nullable = false)))
     val csvOptions = Map("header" -> "true")
     val index =
       Index("catalog_temporal_where_test", temporalSchema, "csv", csvOptions)
@@ -601,9 +515,7 @@ class AriadneCatalogTests extends SparkTests with Matchers {
 
     // Temporal indexes mean "only the latest version" — SELECT should
     // return only the latest version, same as JOIN behavior
-    val result = spark.sql(
-      "SELECT * FROM ariadne.catalog_temporal_where_test WHERE Id = 1"
-    )
+    val result = spark.sql("SELECT * FROM ariadne.catalog_temporal_where_test WHERE Id = 1")
     val rows = result.collect()
 
     // Id=1 appears in both files but temporal dedup keeps only the latest
@@ -612,13 +524,12 @@ class AriadneCatalogTests extends SparkTests with Matchers {
   }
 
   test("SELECT * on temporal index applies dedup even without WHERE") {
-    val temporalSchema = StructType(
-      Seq(
-        StructField("Id", IntegerType, nullable = false),
-        StructField("Value", DoubleType, nullable = false),
-        StructField("UpdatedAt", TimestampType, nullable = false)
-      )
-    )
+    val temporalSchema =
+      StructType(
+        Seq(
+          StructField("Id", IntegerType, nullable = false),
+          StructField("Value", DoubleType, nullable = false),
+          StructField("UpdatedAt", TimestampType, nullable = false)))
     val csvOptions = Map("header" -> "true")
     val index =
       Index("catalog_temporal_select_test", temporalSchema, "csv", csvOptions)
@@ -661,10 +572,7 @@ class AriadneCatalogTests extends SparkTests with Matchers {
     createTestIndex("catalog_exists_test")
 
     val catalog = new AriadneCatalog()
-    catalog.initialize(
-      "ariadne",
-      new CaseInsensitiveStringMap(new java.util.HashMap[String, String]())
-    )
+    catalog.initialize("ariadne", new CaseInsensitiveStringMap(new java.util.HashMap[String, String]()))
 
     val existsIdent =
       Identifier.of(Array.empty[String], "catalog_exists_test")


### PR DESCRIPTION
Adopts the same enforced Scala code-quality tooling as the sibling **nomos** project, wired into this single-module Spark build.

## Tooling

- **scalafmt** (`.scalafmt.conf`) — opinionated formatting, checked at `validate`.
- **scalafix** (`.scalafix.conf`: `RemoveUnused` + `OrganizeImports`) — at `verify`; SemanticDB wired into `scala-maven-plugin`.
- **scalastyle** (`scalastyle-config.xml`, adapted from Apache Spark, license-header rule removed) — static checks at `verify`, on **main + test** sources.

All three run in the build and CI, so a violation fails the build. `LICENSE.md` gains a "Third-party components" note recording the config's Apache-2.0 provenance.

## Rules reconciled (each commented in the config)

Spark-internal rules that don't fit an **external** Spark library are disabled:

| Rule | Why |
|------|-----|
| `funsuite` (must extend `SparkFunSuite`) | `org.apache.spark.SparkFunSuite` is Spark-internal, not published; tests use ScalaTest's `AnyFunSuite` |
| `hadoopconfiguration` | `sparkContext.hadoopConfiguration` is the supported public API; the suggested `spark.sessionState.newHadoopConf()` is Spark-internal |

Plus the same tooling/domain rules reconciled in nomos: `IfBrace` + `ImportOrder` (owned by scalafmt/scalafix), `NonASCII`, `extractOpt`, `JavaConverters`. Line length is 120. Deliberate `println`/`Class.forName` uses stay guarded via local `// scalastyle:off`.

## Code changes

All 62 sources reformatted; resulting violations fixed: long lines wrapped, imports organized/deduplicated (scalafix), `toLowerCase(Locale.ROOT)`, a relative `collection` import made absolute, and debug `println`s wrapped with `scalastyle:off println`.

## Scala version

**Kept pinned at 2.12.17.** SemanticDB is pinned to **4.14.2** (the newest build published for 2.12.17) so scalafix works without touching the pinned Scala/Spark versions.

## Verification

`mvn clean verify` green locally on Java 11: scalafmt (0/62 unformatted) → **278 tests pass** → scalafix CHECK → scalastyle (62 files, 0 errors).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>