### PR TITLE
Fix multi-column temporal deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed
+
+- Multi-column temporal joins now calculate every temporal rank against the original rows before filtering, preventing
+  stale rows from being promoted by an earlier temporal deduplication pass.
+
 ## [0.1.4-beta]
 
 ### Added

--- a/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexJoinOperations.scala
@@ -262,8 +262,9 @@ trait IndexJoinOperations extends IndexBuildOperations {
    * Applies temporal deduplication to keep only the latest version of each value for temporal index columns being used
    * in the current join.
    *
-   * Uses row_number() window function partitioned by the value column and ordered by the timestamp column descending,
-   * keeping only rank 1.
+   * Uses a row_number() window for each applicable temporal index, partitioned by its value column and ordered by its
+   * timestamp column descending. All ranks are computed against the original rows before filtering to rows ranked first
+   * for every applicable temporal index.
    *
    * @param df
    *   The DataFrame read from data files
@@ -281,17 +282,28 @@ trait IndexJoinOperations extends IndexBuildOperations {
       df
     } else {
       logger.warn(s"Applying temporal deduplication for columns: ${applicableConfigs.map(_.column).mkString(", ")}")
-      val result =
-        applicableConfigs.foldLeft(df) { (accumDf, config) =>
-          val w =
-            Window
-              .partitionBy(config.column)
-              .orderBy(col(config.timestamp_column).desc_nulls_last)
-          accumDf
-            .withColumn("_ariadne_temporal_rank", row_number().over(w))
-            .filter(col("_ariadne_temporal_rank") === 1)
-            .drop("_ariadne_temporal_rank")
+      def unusedRankColumn(base: String, usedColumns: Set[String]): String =
+        Iterator
+          .from(0)
+          .map(index => if (index == 0) base else s"${base}_$index")
+          .find(name => !usedColumns.contains(name))
+          .fold(throw new IllegalStateException("Unable to allocate a temporary temporal rank column"))(identity)
+
+      val (rankedDf, _, rankColumns) =
+        applicableConfigs.zipWithIndex.foldLeft((df, df.columns.toSet, Vector.empty[String])) {
+          case ((accumDf, usedColumns, accumulatedRankColumns), (config, index)) =>
+            val rankColumn = unusedRankColumn(s"_ariadne_temporal_rank_$index", usedColumns)
+            val w =
+              Window
+                .partitionBy(config.column)
+                .orderBy(col(config.timestamp_column).desc_nulls_last)
+            (
+              accumDf.withColumn(rankColumn, row_number().over(w)),
+              usedColumns + rankColumn,
+              accumulatedRankColumns :+ rankColumn)
         }
+      val allLatest = rankColumns.map(rankColumn => col(rankColumn) === 1).reduce(_ && _)
+      val result = rankedDf.filter(allLatest).drop(rankColumns: _*)
       logger.debug(s"Temporal deduplication applied for ${applicableConfigs.size} column(s)")
       result
     }

--- a/src/test/scala/dev/cjfravel/ariadne/TemporalIndexTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/TemporalIndexTests.scala
@@ -340,4 +340,45 @@ class TemporalIndexTests extends SparkTests with Matchers {
       fs.delete(new org.apache.hadoop.fs.Path(tempPath2), true)
     }
   }
+
+  test("multiple temporal indexes should rank each column against the original rows") {
+    val multiTemporalSchema =
+      StructType(
+        Seq(
+          StructField("EntityA", IntegerType, nullable = false),
+          StructField("UpdatedA", TimestampType, nullable = false),
+          StructField("EntityB", StringType, nullable = false),
+          StructField("UpdatedB", TimestampType, nullable = false),
+          StructField("Payload", StringType, nullable = false)))
+
+    val index = Index("multi_temporal_independent_ranks", multiTemporalSchema, "parquet")
+    index.addTemporalIndex("EntityA", "UpdatedA")
+    index.addTemporalIndex("EntityB", "UpdatedB")
+
+    val rows =
+      Seq(
+        Row(
+          1,
+          java.sql.Timestamp.valueOf("2024-03-01 00:00:00"),
+          "x",
+          java.sql.Timestamp.valueOf("2024-01-01 00:00:00"),
+          "stale-for-b"),
+        Row(
+          2,
+          java.sql.Timestamp.valueOf("2024-01-01 00:00:00"),
+          "x",
+          java.sql.Timestamp.valueOf("2024-03-01 00:00:00"),
+          "stale-for-a"),
+        Row(
+          2,
+          java.sql.Timestamp.valueOf("2024-02-01 00:00:00"),
+          "y",
+          java.sql.Timestamp.valueOf("2024-02-01 00:00:00"),
+          "latest-for-both"))
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(rows), multiTemporalSchema)
+
+    val result = index.applyTemporalDeduplication(df, Seq("EntityA", "EntityB"))
+
+    result.select("Payload").collect().map(_.getString(0)).toSeq shouldBe Seq("latest-for-both")
+  }
 }


### PR DESCRIPTION
## Summary
- compute every applicable temporal rank against the original rows
- filter only after all temporal rank columns are available
- add a regression test for stale-row promotion across two temporal indexes
- document the fix in the changelog

## TDD
- RED: the new regression returned `stale-for-b` alongside `latest-for-both`
- GREEN: the temporal suite and full Spark 3.5 verification pass (279 tests)