### PR TITLE
Harden legacy exploded-column updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project are documented here. The format is based on
 
 - Multi-column temporal joins now calculate every temporal rank against the original rows before filtering, preventing
   stale rows from being promoted by an earlier temporal deduplication pass.
+- Index updates now migrate legacy exploded-field column names in both main and staging tables under the update lock
+  before file-size backfill or consolidation can reintroduce an old column.
 
 ## [0.1.4-beta]
 

--- a/src/main/scala/dev/cjfravel/ariadne/Index.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/Index.scala
@@ -743,6 +743,9 @@ case class Index private (name: String, schema: Option[StructType])(implicit val
     val correlationId = UUID.randomUUID().toString
     lock.acquire(correlationId)
     try {
+      // Normalize every persisted table before file-size backfill or staging consolidation.
+      migrateExplodedFieldColumns(force = true)
+
       // Ensure legacy indexes have the file_size column before backfilling.
       // Indexes created before ariadne introduced file_size (alpha-45) have no
       // file_size column in their Delta schema at all. Delta MERGE schema

--- a/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
@@ -101,57 +101,63 @@ trait IndexBuildOperations extends BloomFilterOperations {
    * Migrates pre-0.1.1 indexes that stored exploded field columns under `array_column` names to the current `as_column`
    * naming convention.
    *
-   * Detection: reads the main index Delta table schema and checks whether any `ExplodedFieldMapping.array_column`
-   * appears as a column while the corresponding `as_column` does not. When this pattern is found, the table is
-   * rewritten with renamed columns, and any large-index directories named by `array_column` are similarly migrated.
+   * Detection: reads the main and staging Delta table schemas and checks whether any
+   * `ExplodedFieldMapping.array_column` appears as a column while the corresponding `as_column` does not. When this
+   * pattern is found, each table is rewritten with renamed columns, and any large-index directories named by
+   * `array_column` are similarly migrated.
    *
    * This method is idempotent and fast when no migration is needed (single schema check). It is called automatically on
-   * the first index read.
+   * the first index read and forced at the start of update while the update lock is held.
+   *
+   * @param force
+   *   when true, checks persisted schemas even if this instance previously completed a migration check
    */
-  protected def migrateExplodedFieldColumns(): Unit = {
-    if (_explodedMigrationChecked) return
-    _explodedMigrationChecked = true
-
-    val mappings = metadata.exploded_field_indexes.asScala.toSeq
-    if (mappings.isEmpty) return
-
-    delta(indexFilePath) match {
-      case None => // No index table yet, nothing to migrate
-      case Some(dt) =>
-        val schema = dt.toDF.schema.fieldNames.toSet
-        val columnsToRename = mappings.filter(m => schema.contains(m.array_column) && !schema.contains(m.as_column))
-        if (columnsToRename.isEmpty) return
-
-        logger.warn(
-          s"Migrating exploded field columns for index '$name': " +
-            columnsToRename
-              .map(m => s"${m.array_column} -> ${m.as_column}")
-              .mkString(", "))
+  protected def migrateExplodedFieldColumns(force: Boolean = false): Unit =
+    if (force || !_explodedMigrationChecked) {
+      val mappings = metadata.exploded_field_indexes.asScala.toSeq
+      if (mappings.nonEmpty) {
         val startTime = System.currentTimeMillis()
 
-        // Rewrite main index with renamed columns
-        var df = dt.toDF
-        columnsToRename.foreach { m => df = df.withColumnRenamed(m.array_column, m.as_column) }
-        df.write
-          .format("delta")
-          .option("overwriteSchema", "true")
-          .mode("overwrite")
-          .save(indexFilePath.toString)
+        def migrateTable(path: Path, tableName: String): Unit =
+          delta(path).foreach { dt =>
+            val schema = dt.toDF.schema.fieldNames.toSet
+            val columnsToRename =
+              mappings.filter(m => schema.contains(m.array_column) && !schema.contains(m.as_column))
+            if (columnsToRename.nonEmpty) {
+              logger.warn(
+                s"Migrating exploded field columns in $tableName for index '$name': " +
+                  columnsToRename
+                    .map(m => s"${m.array_column} -> ${m.as_column}")
+                    .mkString(", "))
+              var df = dt.toDF
+              columnsToRename.foreach { m => df = df.withColumnRenamed(m.array_column, m.as_column) }
+              df.write
+                .format("delta")
+                .option("overwriteSchema", "true")
+                .mode("overwrite")
+                .save(path.toString)
+            }
+          }
 
-        // Migrate large index directories
-        columnsToRename.foreach { m =>
-          val oldPath = new Path(largeIndexesFilePath, m.array_column)
-          val newPath = new Path(largeIndexesFilePath, m.as_column)
+        migrateTable(indexFilePath, "main table")
+        migrateTable(stagingFilePath, "staging table")
+
+        mappings.foreach { mapping =>
+          val oldPath = new Path(largeIndexesFilePath, mapping.array_column)
+          val newPath = new Path(largeIndexesFilePath, mapping.as_column)
           if (exists(oldPath) && !exists(newPath)) {
-            logger.warn(s"Renaming large index directory: ${m.array_column} -> ${m.as_column}")
-            fs.rename(oldPath, newPath)
+            logger.warn(s"Renaming large index directory: ${mapping.array_column} -> ${mapping.as_column}")
+            if (!fs.rename(oldPath, newPath)) {
+              throw new java.io.IOException(s"Failed to rename legacy large index directory $oldPath to $newPath")
+            }
           }
         }
 
         logger.warn(
           s"Exploded field migration completed for index '$name' in ${System.currentTimeMillis() - startTime}ms")
+      }
+      _explodedMigrationChecked = true
     }
-  }
 
   /**
    * Returns the set of all storage column names across regular, computed, exploded-field, and temporal index types.

--- a/src/test/scala/dev/cjfravel/ariadne/BugFixTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/BugFixTests.scala
@@ -232,4 +232,49 @@ class BugFixTests extends SparkTests {
     assert(afterSchema.contains("user_id"), "Post-migration: should have 'user_id' column")
     assert(!afterSchema.contains("users"), "Post-migration: should NOT have 'users' column")
   }
+
+  test("Migration - update normalizes old exploded columns in main and staging tables") {
+    val arrayTestSchema =
+      StructType(
+        Seq(
+          StructField("event_id", StringType, nullable = false),
+          StructField(
+            "users",
+            ArrayType(StructType(Seq(StructField("id", IntegerType, nullable = false)))),
+            nullable = false)))
+    val testData =
+      spark.createDataFrame(
+        spark.sparkContext.parallelize(Seq(Row("e1", Array(Row(100))), Row("e2", Array(Row(101))))),
+        arrayTestSchema)
+    val tempPath =
+      s"${System.getProperty("java.io.tmpdir")}/migration_update_test_${System.currentTimeMillis()}"
+    testData.write.mode("overwrite").parquet(tempPath)
+
+    val index = Index("migration_update_test", arrayTestSchema, "parquet")
+    index.addFile(tempPath)
+    index.addExplodedFieldIndex("users", "id", "user_id")
+
+    val oldStyleIndex =
+      spark.read
+        .parquet(tempPath)
+        .withColumn("filename", input_file_name())
+        .select("filename", "users")
+        .withColumn("temp", explode(col("users.id")))
+        .groupBy("filename")
+        .agg(collect_set(col("temp")).alias("users"))
+
+    val indexRoot = new Path(IndexPathUtils.storagePath, "migration_update_test")
+    val indexPath = new Path(indexRoot, "index")
+    val stagingPath = new Path(indexRoot, "staging")
+    oldStyleIndex.write.format("delta").mode("overwrite").save(indexPath.toString)
+    oldStyleIndex.write.format("delta").mode("overwrite").save(stagingPath.toString)
+
+    Index("migration_update_test").update
+
+    val migrated = spark.read.format("delta").load(indexPath.toString)
+    assert(migrated.columns.contains("user_id"), "Post-migration: main table should have 'user_id'")
+    assert(!migrated.columns.contains("users"), "Post-migration: main table should not retain legacy 'users'")
+    assert(migrated.columns.contains("file_size"), "Post-migration: main table should have 'file_size'")
+    assert(migrated.where(col("file_size").isNull).count() === 0L, "Post-migration: file_size should be populated")
+  }
 }


### PR DESCRIPTION
## Summary
- force exploded-column migration at the start of update while the update lock is held
- normalize both main and stale staging Delta tables
- mark migration checks complete only after success
- surface failed legacy large-index directory renames
- add a regression for stale staging reintroducing an old exploded column

## TDD
- RED: update left both `user_id` and legacy `users` in the main table
- GREEN: focused migration tests and full Spark 3.5 verification pass