### PR TITLE
Propagate non-contention lock I/O failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project are documented here. The format is based on
   stale rows from being promoted by an earlier temporal deduplication pass.
 - Index updates now migrate legacy exploded-field column names in both main and staging tables under the update lock
   before file-size backfill or consolidation can reintroduce an old column.
+- Lock acquisition now retries only true file-exists contention; other filesystem `IOException`s propagate immediately
+  instead of being converted into misleading lock-contention failures.
 
 ## [0.1.4-beta]
 

--- a/src/main/scala/dev/cjfravel/ariadne/IndexLock.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexLock.scala
@@ -125,7 +125,7 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit val spark: Spar
       writeLockFile(LockInfo(correlationId, now, now, getOwner), overwrite = false)
       logger.warn(s"Lock acquired for index '$indexName' (correlationId='$correlationId')")
     } catch {
-      case _: org.apache.hadoop.fs.FileAlreadyExistsException | _: java.io.IOException =>
+      case _: org.apache.hadoop.fs.FileAlreadyExistsException =>
         handleExistingLock(correlationId, startTime, 0, depth)
     }
   }
@@ -226,7 +226,7 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit val spark: Spar
             logger.warn(s"Lock acquired for index '$indexName' (correlationId='$correlationId')")
             acquired = true
           } catch {
-            case _: org.apache.hadoop.fs.FileAlreadyExistsException | _: java.io.IOException =>
+            case _: org.apache.hadoop.fs.FileAlreadyExistsException =>
               currentLock = readLock().getOrElse(currentLock)
           }
         case Some(lock) =>
@@ -238,7 +238,7 @@ case class IndexLock(lockPath: Path, indexName: String)(implicit val spark: Spar
             logger.warn(s"Lock acquired for index '$indexName' (correlationId='$correlationId')")
             acquired = true
           } catch {
-            case _: org.apache.hadoop.fs.FileAlreadyExistsException | _: java.io.IOException =>
+            case _: org.apache.hadoop.fs.FileAlreadyExistsException =>
               currentLock = readLock().getOrElse(currentLock)
           }
       }

--- a/src/test/scala/dev/cjfravel/ariadne/IndexLockTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexLockTests.scala
@@ -1,5 +1,7 @@
 package dev.cjfravel.ariadne
 
+import java.io.IOException
+import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.time.Instant
 
@@ -7,7 +9,29 @@ import scala.io.Source
 
 import com.google.gson.Gson
 import dev.cjfravel.ariadne.exceptions.IndexLockException
-import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.hadoop.fs._
+import org.apache.hadoop.fs.permission.FsPermission
+import org.apache.hadoop.util.Progressable
+
+/**
+ * Test-only filesystem that injects a non-contention failure when creating a lock file.
+ */
+class FailingLockCreateFileSystem extends RawLocalFileSystem {
+  override def getUri: URI = URI.create("faulty-lock:///")
+
+  override def create(path: Path, overwrite: Boolean): FSDataOutputStream =
+    throw new IOException("injected lock create failure")
+
+  override def create(
+      path: Path,
+      permission: FsPermission,
+      overwrite: Boolean,
+      bufferSize: Int,
+      replication: Short,
+      blockSize: Long,
+      progress: Progressable): FSDataOutputStream =
+    throw new IOException("injected lock create failure")
+}
 
 /**
  * Tests for [[IndexLock]] covering lock acquisition, release, refresh, stale lock auto-healing, and contention
@@ -187,6 +211,30 @@ class IndexLockTests extends SparkTests {
       }
     } finally {
       cleanup(path)
+    }
+  }
+
+  test("non-contention create IOException is propagated") {
+    val storageKey = "spark.ariadne.storagePath"
+    val originalStoragePath = spark.conf.get(storageKey)
+    val hadoopConf = spark.sparkContext.hadoopConfiguration
+    hadoopConf.set("fs.faulty-lock.impl", classOf[FailingLockCreateFileSystem].getName)
+    hadoopConf.setBoolean("fs.faulty-lock.impl.disable.cache", true)
+    val faultyStoragePath = s"faulty-lock://${tempDir.toAbsolutePath}"
+    spark.conf.set(storageKey, faultyStoragePath)
+
+    try {
+      val lock = IndexLock(new Path(s"$faultyStoragePath/non-contention.lock"), "test-index")
+      val error =
+        intercept[IOException] {
+          lock.acquire("io-failure")
+        }
+      assert(error.getMessage.contains("injected lock create failure"))
+    } finally {
+      spark.conf.set(storageKey, originalStoragePath)
+      hadoopConf.unset("fs.faulty-lock.impl")
+      hadoopConf.unset("fs.faulty-lock.impl.disable.cache")
+      FileSystem.closeAll()
     }
   }
 }


### PR DESCRIPTION
## Summary
- retry lock acquisition only for Hadoop `FileAlreadyExistsException`
- propagate other filesystem `IOException`s immediately
- add a deterministic test-only Hadoop filesystem failure
- document the behavior change in the changelog

## TDD
- RED: an injected create `IOException` was converted to `IndexLockException` after retries
- GREEN: the focused lock suite and full Spark 3.5 verification pass (281 tests)