### PR TITLE
Test release version references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this project are documented here. The format is based on
 - Lock acquisition now retries only true file-exists contention; other filesystem `IOException`s propagate immediately
   instead of being converted into misleading lock-contention failures.
 
+### Changed
+
+- Release version checks now cover the changelog and include a shell regression test in the Maven test phase.
+
 ## [0.1.4-beta]
 
 ### Added

--- a/dev/scripts/readme-has-version-tests.sh
+++ b/dev/scripts/readme-has-version-tests.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+mkdir -p "$TEST_ROOT/dev/scripts" "$TEST_ROOT/docs/users"
+cp "$REPO_ROOT/dev/scripts/readme-has-version.sh" "$TEST_ROOT/dev/scripts/"
+
+cat >"$TEST_ROOT/pom.xml" <<'EOF'
+<project>
+  <version>1.2.3</version>
+</project>
+EOF
+echo "Install version 1.2.3" >"$TEST_ROOT/README.md"
+echo "Install version 1.2.3" >"$TEST_ROOT/docs/users/getting-started.html"
+echo "## [1.2.2]" >"$TEST_ROOT/CHANGELOG.md"
+
+if (cd "$TEST_ROOT" && bash dev/scripts/readme-has-version.sh >/dev/null); then
+  echo "Version check accepted a changelog that omitted the current version"
+  exit 1
+fi
+
+echo "## [1.2.3]" >"$TEST_ROOT/CHANGELOG.md"
+(cd "$TEST_ROOT" && bash dev/scripts/readme-has-version.sh >/dev/null)

--- a/dev/scripts/readme-has-version.sh
+++ b/dev/scripts/readme-has-version.sh
@@ -11,6 +11,7 @@ fi
 # Files that must reference the current version
 FILES=(
     "README.md"
+    "CHANGELOG.md"
     "docs/users/getting-started.html"
 )
 

--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,19 @@
                             </arguments>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>test-version-references-script</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>bash</executable>
+                            <arguments>
+                                <argument>dev/scripts/readme-has-version-tests.sh</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 


### PR DESCRIPTION
## Summary
- require the current project version in `CHANGELOG.md` alongside README and getting-started
- add a shell regression test for stale release references
- run the script test during Maven `test`

## TDD
- RED: the checker accepted a changelog that omitted the current version
- GREEN: shell regression and full Spark 3.5 verification pass