### PR TITLE
Keep existing index metadata read-only on open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project are documented here. The format is based on
   before file-size backfill or consolidation can reintroduce an old column.
 - Lock acquisition now retries only true file-exists contention; other filesystem `IOException`s propagate immediately
   instead of being converted into misleading lock-contention failures.
+- Opening an existing index no longer rewrites `metadata.json`, preserving unknown fields for forward compatibility;
+  metadata is written only when creation or explicit schema/read-option changes require it.
 
 ### Changed
 

--- a/src/main/scala/dev/cjfravel/ariadne/Index.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/Index.scala
@@ -1297,6 +1297,7 @@ object Index {
 
     val metadataExists = index.metadataExists
     logger.warn(s"Index '$name': ${if (metadataExists) "reconnecting" else "creating new"}")
+    var metadataChanged = !metadataExists
     val metadata =
       if (metadataExists) {
         index.metadata
@@ -1355,8 +1356,9 @@ object Index {
                 // cannot validate the expression references without executing it
               }
               logger.warn(s"Index '$name': schema evolved (allowSchemaMismatch=true)")
+              metadata.schema = s.json
+              metadataChanged = true
             }
-            metadata.schema = s.json
           } else if (metadata.schema != s.json) {
             throw new SchemaMismatchException(name)
           }
@@ -1389,7 +1391,10 @@ object Index {
         if (metadataExists) {
           // Merge with existing options, with new options taking precedence
           options.foreach { case (key, value) =>
-            metadata.read_options.put(key, value)
+            if (metadata.read_options.get(key) != value) {
+              metadata.read_options.put(key, value)
+              metadataChanged = true
+            }
           }
         } else {
           // Set initial options
@@ -1400,7 +1405,9 @@ object Index {
       case None => // Keep existing options
     }
 
-    index.writeMetadata(metadata)
+    if (metadataChanged) {
+      index.writeMetadata(metadata)
+    }
     index
   }
 

--- a/src/test/scala/dev/cjfravel/ariadne/IndexMetadataOperationsTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexMetadataOperationsTests.scala
@@ -1,5 +1,8 @@
 package dev.cjfravel.ariadne
+import java.nio.charset.StandardCharsets
+
 import dev.cjfravel.ariadne.exceptions._
+import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.types._
 import org.scalatest.matchers.should.Matchers
 
@@ -104,6 +107,41 @@ class IndexMetadataOperationsTests extends SparkTests with Matchers {
     index2.storedSchema should be(testSchema)
     index2.indexes should contain("Id")
     index2.indexes should contain("test_computed")
+  }
+
+  test("opening an existing index should not rewrite metadata") {
+    val indexName = "read_only_open_test"
+    val created = Index(indexName, testSchema, "csv")
+    created.addIndex("Id")
+    val metadataPath = new Path(created.storagePath, "metadata.json")
+    val filesystem = metadataPath.getFileSystem(spark.sparkContext.hadoopConfiguration)
+
+    val input = filesystem.open(metadataPath)
+    val originalJson =
+      try {
+        new String(input.readAllBytes(), StandardCharsets.UTF_8)
+      } finally {
+        input.close()
+      }
+    val metadataWithFutureField =
+      originalJson.trim.stripSuffix("}") + ""","future_field":{"enabled":true}}"""
+    val output = filesystem.create(metadataPath, true)
+    try {
+      output.write(metadataWithFutureField.getBytes(StandardCharsets.UTF_8))
+    } finally {
+      output.close()
+    }
+
+    Index(indexName)
+
+    val reopenedInput = filesystem.open(metadataPath)
+    val reopenedJson =
+      try {
+        new String(reopenedInput.readAllBytes(), StandardCharsets.UTF_8)
+      } finally {
+        reopenedInput.close()
+      }
+    reopenedJson shouldBe metadataWithFutureField
   }
 
   test("metadata format validation should work") {


### PR DESCRIPTION
## Summary
- avoid rewriting metadata when reconnecting without changes
- preserve unknown future JSON fields byte-for-byte
- continue persisting explicit schema evolution and read-option changes
- document the behavior in the changelog

## TDD
- RED: reopening erased an injected future metadata field
- GREEN: focused metadata tests and full Spark 3.5 verification pass (282 tests)