### PR TITLE
Speed up Spark test execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build & Test (Spark 3.5)
+    env:
+      MAVEN_OPTS: -Xmx8g -XX:+UseG1GC
 
     steps:
       - name: Checkout
@@ -30,7 +32,9 @@ jobs:
         run: mvn -B validate -Dgpg.skip=true
 
       - name: Build and test with coverage
-        run: mvn verify scoverage:report -Dgpg.skip=true -B -q
+        run: |
+          mvn -B -q scoverage:report -Dgpg.skip=true
+          mvn -B -q verify -DskipTests -Dgpg.skip=true
 
       - name: Upload coverage report
         if: always()
@@ -66,6 +70,8 @@ jobs:
   build-spark41:
     runs-on: ubuntu-latest
     name: Build & Test (Spark 4.1)
+    env:
+      MAVEN_OPTS: -Xmx8g -XX:+UseG1GC
 
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,10 @@ All notable changes to this project are documented here. The format is based on
 ### Changed
 
 - Release version checks now cover the changelog and include a shell regression test in the Maven test phase.
-- Spark tests now cap local execution and shuffle parallelism at the four cores available on public GitHub-hosted Linux
-  runners. Spark 3.5 coverage CI runs one instrumented lifecycle followed by `verify -DskipTests`, eliminating a
-  duplicate 24-minute suite execution while retaining formatting, lint, style, coverage, and packaging gates.
+- Spark tests now use the four cores available on public GitHub-hosted Linux runners while reducing tiny fixture
+  shuffles and Delta snapshot reconstruction to one partition. Spark 3.5 coverage CI runs one instrumented lifecycle
+  followed by `verify -DskipTests`, eliminating a duplicate 24-minute suite execution while retaining formatting,
+  lint, style, coverage, and packaging gates.
 
 ## [0.1.4-beta]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ All notable changes to this project are documented here. The format is based on
 ### Changed
 
 - Release version checks now cover the changelog and include a shell regression test in the Maven test phase.
+- Spark tests now cap local execution and shuffle parallelism at the four cores available on public GitHub-hosted Linux
+  runners. Spark 3.5 coverage CI runs one instrumented lifecycle followed by `verify -DskipTests`, eliminating a
+  duplicate 24-minute suite execution while retaining formatting, lint, style, coverage, and packaging gates.
 
 ## [0.1.4-beta]
 

--- a/dev/scripts/ci-runtime-tests.sh
+++ b/dev/scripts/ci-runtime-tests.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 WORKFLOW=".github/workflows/ci.yml"
+POM="pom.xml"
 
 if [[ ! -f "$WORKFLOW" ]]; then
     echo "CI workflow not found: $WORKFLOW"
@@ -26,3 +27,8 @@ fi
 assert_contains 'mvn -B -q scoverage:report -Dgpg.skip=true' "single coverage lifecycle"
 assert_contains 'mvn -B -q verify -DskipTests -Dgpg.skip=true' "post-coverage verify command"
 assert_contains 'MAVEN_OPTS: -Xmx8g -XX:+UseG1GC' "bounded Maven heap"
+
+if ! grep -Fq '<skip>${skipTests}</skip>' "$POM"; then
+    echo "Maven exec scripts must honor -DskipTests during the post-coverage verify lifecycle"
+    exit 1
+fi

--- a/dev/scripts/ci-runtime-tests.sh
+++ b/dev/scripts/ci-runtime-tests.sh
@@ -4,11 +4,25 @@ set -euo pipefail
 
 WORKFLOW=".github/workflows/ci.yml"
 
+if [[ ! -f "$WORKFLOW" ]]; then
+    echo "CI workflow not found: $WORKFLOW"
+    exit 1
+fi
+
+assert_contains() {
+    local expected="$1"
+    local description="$2"
+    if ! grep -Fq "$expected" "$WORKFLOW"; then
+        echo "CI workflow is missing $description: $expected"
+        exit 1
+    fi
+}
+
 if grep -Eq 'mvn .*verify.*scoverage:report|mvn .*scoverage:report.*verify' "$WORKFLOW"; then
     echo "CI must not combine verify and scoverage:report in one invocation because it runs tests twice"
     exit 1
 fi
 
-grep -Fq 'mvn -B -q scoverage:report -Dgpg.skip=true' "$WORKFLOW"
-grep -Fq 'mvn -B -q verify -DskipTests -Dgpg.skip=true' "$WORKFLOW"
-grep -Fq 'MAVEN_OPTS: -Xmx8g -XX:+UseG1GC' "$WORKFLOW"
+assert_contains 'mvn -B -q scoverage:report -Dgpg.skip=true' "single coverage lifecycle"
+assert_contains 'mvn -B -q verify -DskipTests -Dgpg.skip=true' "post-coverage verify command"
+assert_contains 'MAVEN_OPTS: -Xmx8g -XX:+UseG1GC' "bounded Maven heap"

--- a/dev/scripts/ci-runtime-tests.sh
+++ b/dev/scripts/ci-runtime-tests.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+WORKFLOW=".github/workflows/ci.yml"
+
+if grep -Eq 'mvn .*verify.*scoverage:report|mvn .*scoverage:report.*verify' "$WORKFLOW"; then
+    echo "CI must not combine verify and scoverage:report in one invocation because it runs tests twice"
+    exit 1
+fi
+
+grep -Fq 'mvn -B -q scoverage:report -Dgpg.skip=true' "$WORKFLOW"
+grep -Fq 'mvn -B -q verify -DskipTests -Dgpg.skip=true' "$WORKFLOW"
+grep -Fq 'MAVEN_OPTS: -Xmx8g -XX:+UseG1GC' "$WORKFLOW"

--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>3.5.0</version>
+                <configuration>
+                    <skip>${skipTests}</skip>
+                </configuration>
                 <executions>
                     <execution>
                         <id>run-custom-script</id>

--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,19 @@
                             </arguments>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>test-ci-runtime-script</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>bash</executable>
+                            <arguments>
+                                <argument>dev/scripts/ci-runtime-tests.sh</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 

--- a/src/test/scala/dev/cjfravel/ariadne/AriadneContextTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/AriadneContextTests.scala
@@ -14,7 +14,8 @@ class AriadneContextTests extends SparkTests {
   }
 
   test("Spark test session uses bounded parallelism for tiny fixtures") {
-    assert(spark.conf.get("spark.sql.shuffle.partitions") === "4")
+    assert(spark.conf.get("spark.sql.shuffle.partitions") === "1")
+    assert(spark.conf.get("spark.databricks.delta.snapshotPartitions") === "1")
     assert(spark.sparkContext.defaultParallelism === 4)
     assert(!spark.sparkContext.getConf.getBoolean("spark.ui.enabled", true))
   }

--- a/src/test/scala/dev/cjfravel/ariadne/AriadneContextTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/AriadneContextTests.scala
@@ -12,4 +12,10 @@ class AriadneContextTests extends SparkTests {
       }
     assert(contextUser.storagePath.toString === tempDir.toString)
   }
+
+  test("Spark test session uses bounded parallelism for tiny fixtures") {
+    assert(spark.conf.get("spark.sql.shuffle.partitions") === "4")
+    assert(spark.sparkContext.defaultParallelism === 4)
+    assert(!spark.sparkContext.getConf.getBoolean("spark.ui.enabled", true))
+  }
 }

--- a/src/test/scala/dev/cjfravel/ariadne/SparkTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/SparkTests.scala
@@ -8,6 +8,35 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 
 /**
+ * Shared Spark configuration for Ariadne test suites.
+ *
+ * Keeps the base and catalog-specific sessions aligned with the four-core GitHub-hosted runner while minimizing tiny
+ * fixture shuffle and Delta snapshot overhead.
+ */
+private[ariadne] object SparkTests {
+
+  /**
+   * Creates the common SparkConf used by test suites.
+   *
+   * @param appName
+   *   Spark application name for the suite
+   * @param extensions
+   *   Spark SQL extension class configured before SparkContext creation
+   * @return
+   *   bounded local Spark configuration for tiny test fixtures
+   */
+  def sparkConf(appName: String, extensions: String): SparkConf =
+    new SparkConf()
+      .setMaster("local[4]")
+      .setAppName(appName)
+      .set("spark.sql.extensions", extensions)
+      .set("spark.sql.shuffle.partitions", "1")
+      .set("spark.default.parallelism", "4")
+      .set("spark.databricks.delta.snapshotPartitions", "1")
+      .set("spark.ui.enabled", "false")
+}
+
+/**
  * Base test infrastructure trait for all Ariadne Spark tests.
  *
  * Creates a local-mode `SparkSession` with Delta Lake extensions and a temporary directory as
@@ -24,15 +53,7 @@ trait SparkTests extends AnyFunSuite with BeforeAndAfterAll {
     tempDir = Files.createTempDirectory("ariadne-test-output-")
     // spark.sql.extensions must be set on the SparkConf before the SparkContext is created so the
     // Delta session extension is installed; Delta path-based commands (e.g. VACUUM) rely on it.
-    val conf =
-      new SparkConf()
-        .setMaster("local[4]")
-        .setAppName("TestAriadne")
-        .set("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
-        .set("spark.sql.shuffle.partitions", "1")
-        .set("spark.default.parallelism", "4")
-        .set("spark.databricks.delta.snapshotPartitions", "1")
-        .set("spark.ui.enabled", "false")
+    val conf = SparkTests.sparkConf("TestAriadne", "io.delta.sql.DeltaSparkSessionExtension")
     sc = new SparkContext(conf)
 
     spark =

--- a/src/test/scala/dev/cjfravel/ariadne/SparkTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/SparkTests.scala
@@ -29,8 +29,9 @@ trait SparkTests extends AnyFunSuite with BeforeAndAfterAll {
         .setMaster("local[4]")
         .setAppName("TestAriadne")
         .set("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
-        .set("spark.sql.shuffle.partitions", "4")
+        .set("spark.sql.shuffle.partitions", "1")
         .set("spark.default.parallelism", "4")
+        .set("spark.databricks.delta.snapshotPartitions", "1")
         .set("spark.ui.enabled", "false")
     sc = new SparkContext(conf)
 

--- a/src/test/scala/dev/cjfravel/ariadne/SparkTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/SparkTests.scala
@@ -26,9 +26,12 @@ trait SparkTests extends AnyFunSuite with BeforeAndAfterAll {
     // Delta session extension is installed; Delta path-based commands (e.g. VACUUM) rely on it.
     val conf =
       new SparkConf()
-        .setMaster("local[*]")
+        .setMaster("local[4]")
         .setAppName("TestAriadne")
         .set("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+        .set("spark.sql.shuffle.partitions", "4")
+        .set("spark.default.parallelism", "4")
+        .set("spark.ui.enabled", "false")
     sc = new SparkContext(conf)
 
     spark =

--- a/src/test/scala/dev/cjfravel/ariadne/catalog/AriadneCatalogTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/catalog/AriadneCatalogTests.scala
@@ -3,11 +3,11 @@ package dev.cjfravel.ariadne.catalog
 import java.nio.file.Files
 
 import dev.cjfravel.ariadne.{Index, IndexCatalog, SparkTests}
+import org.apache.spark.SparkContext
 import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.sql.{Row, SparkSession}
-import org.apache.spark.SparkContext
 import org.scalatest.matchers.should.Matchers
 
 /**

--- a/src/test/scala/dev/cjfravel/ariadne/catalog/AriadneCatalogTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/catalog/AriadneCatalogTests.scala
@@ -49,8 +49,9 @@ class AriadneCatalogTests extends SparkTests with Matchers {
         .setMaster("local[4]")
         .setAppName("TestAriadneCatalog")
         .set("spark.sql.extensions", "dev.cjfravel.ariadne.catalog.AriadneSparkExtension")
-        .set("spark.sql.shuffle.partitions", "4")
+        .set("spark.sql.shuffle.partitions", "1")
         .set("spark.default.parallelism", "4")
+        .set("spark.databricks.delta.snapshotPartitions", "1")
         .set("spark.ui.enabled", "false")
     sc = new SparkContext(conf)
 

--- a/src/test/scala/dev/cjfravel/ariadne/catalog/AriadneCatalogTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/catalog/AriadneCatalogTests.scala
@@ -46,9 +46,12 @@ class AriadneCatalogTests extends SparkTests with Matchers {
 
     val conf =
       new SparkConf()
-        .setMaster("local[*]")
+        .setMaster("local[4]")
         .setAppName("TestAriadneCatalog")
         .set("spark.sql.extensions", "dev.cjfravel.ariadne.catalog.AriadneSparkExtension")
+        .set("spark.sql.shuffle.partitions", "4")
+        .set("spark.default.parallelism", "4")
+        .set("spark.ui.enabled", "false")
     sc = new SparkContext(conf)
 
     spark =

--- a/src/test/scala/dev/cjfravel/ariadne/catalog/AriadneCatalogTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/catalog/AriadneCatalogTests.scala
@@ -7,7 +7,7 @@ import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.sql.{Row, SparkSession}
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.SparkContext
 import org.scalatest.matchers.should.Matchers
 
 /**
@@ -45,14 +45,7 @@ class AriadneCatalogTests extends SparkTests with Matchers {
     tempDir = Files.createTempDirectory("ariadne-catalog-test-")
 
     val conf =
-      new SparkConf()
-        .setMaster("local[4]")
-        .setAppName("TestAriadneCatalog")
-        .set("spark.sql.extensions", "dev.cjfravel.ariadne.catalog.AriadneSparkExtension")
-        .set("spark.sql.shuffle.partitions", "1")
-        .set("spark.default.parallelism", "4")
-        .set("spark.databricks.delta.snapshotPartitions", "1")
-        .set("spark.ui.enabled", "false")
+      SparkTests.sparkConf("TestAriadneCatalog", "dev.cjfravel.ariadne.catalog.AriadneSparkExtension")
     sc = new SparkContext(conf)
 
     spark =


### PR DESCRIPTION
## Summary
- align test-only Spark execution with the public Actions runner: `local[4]` and four default input partitions
- reduce tiny test shuffles and Delta snapshot reconstruction to one partition
- disable the unused Spark UI in tests
- replace `mvn verify scoverage:report` (two full suites) with one `scoverage:report` lifecycle plus `verify -DskipTests`
- give the Maven/Spark driver an 8 GB heap on 16 GB runners
- add diagnostic CI workflow and Spark configuration contract tests

## Measured baseline and result
- old Actions Spark 3.5: ~54 minutes, including 24m50s + 24m22s duplicate suites
- first optimized Actions run: ~26 minutes, one suite (52% wall-clock reduction)
- local catalog suite: 1m41s baseline → 1m11s with bounded snapshot/shuffle partitions
- final Actions timing is running on the latest commit

## TDD
- RED: Spark reported 200 shuffle partitions; workflow contract detected combined `verify scoverage:report`; one-input-partition experiment correctly exposed multi-file fixture assumptions
- GREEN: four input partitions preserve affected query/build/index suites, while one shuffle/snapshot partition passes targeted suites

## Review feedback
- addressed and resolved explicit diagnostic feedback for missing workflow assertions in a69f3aa