### PR TITLE
Harden CI permissions and action runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,21 +8,23 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
     name: Build & Test (Spark 3.5)
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       MAVEN_OPTS: -Xmx8g -XX:+UseG1GC
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Java 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 11
@@ -38,13 +40,13 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-spark35
           path: target/cobertura.xml
 
       - name: Post coverage to PR
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: irongut/CodeCoverageSummary@v1.3.0
         with:
           filename: target/cobertura.xml
@@ -56,13 +58,13 @@ jobs:
           thresholds: "60 80"
 
       - name: Prepend header to coverage report
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           sed -i '1s/^/## Code Coverage — Spark 3.5\n\n/' code-coverage-results.md
 
       - name: Add coverage comment to PR
-        if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: coverage-spark35
           path: code-coverage-results.md
@@ -75,10 +77,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ All notable changes to this project are documented here. The format is based on
 ### Changed
 
 - Release version checks now cover the changelog and include a shell regression test in the Maven test phase.
+- CI now uses current Node 24-based GitHub action majors, scopes pull-request write permission to the coverage job, and
+  skips coverage publishing steps for fork pull requests with read-only tokens.
 - Spark tests now use the four cores available on public GitHub-hosted Linux runners while reducing tiny fixture
   shuffles and Delta snapshot reconstruction to one partition. Spark 3.5 coverage CI runs one instrumented lifecycle
   followed by `verify -DskipTests`, eliminating a duplicate 24-minute suite execution while retaining formatting,

--- a/dev/scripts/ci-runtime-tests.sh
+++ b/dev/scripts/ci-runtime-tests.sh
@@ -27,6 +27,21 @@ fi
 assert_contains 'mvn -B -q scoverage:report -Dgpg.skip=true' "single coverage lifecycle"
 assert_contains 'mvn -B -q verify -DskipTests -Dgpg.skip=true' "post-coverage verify command"
 assert_contains 'MAVEN_OPTS: -Xmx8g -XX:+UseG1GC' "bounded Maven heap"
+assert_contains 'uses: actions/checkout@v7' "current checkout action"
+assert_contains 'uses: actions/setup-java@v5' "current Java setup action"
+assert_contains 'uses: actions/upload-artifact@v7' "current artifact upload action"
+assert_contains 'uses: marocchino/sticky-pull-request-comment@v3' "current coverage comment action"
+
+if sed -n '1,/^jobs:/p' "$WORKFLOW" | grep -Fq 'pull-requests: write'; then
+    echo "Workflow-wide pull-request write permission must be scoped to the coverage job"
+    exit 1
+fi
+
+fork_guard="github.event.pull_request.head.repo.full_name == github.repository"
+if [[ $(grep -Fc "$fork_guard" "$WORKFLOW") -lt 3 ]]; then
+    echo "All three coverage reporting steps must skip fork pull requests"
+    exit 1
+fi
 
 if ! grep -Fq '<skip>${skipTests}</skip>' "$POM"; then
     echo "Maven exec scripts must honor -DskipTests during the post-coverage verify lifecycle"


### PR DESCRIPTION
## Summary
- scope `pull-requests: write` to the Spark 3.5 coverage job
- skip all coverage rendering/comment steps for fork PRs
- upgrade checkout to v7, setup-java to v5, upload-artifact to v7, and sticky-comment to v3
- extend Maven workflow contracts to prevent permission/runtime regressions

## TDD
- RED: workflow contract rejected old action majors and workflow-wide PR write permission
- GREEN: contract, YAML parsing, and targeted Maven lifecycle pass