### PR TITLE
Align catalog lifecycle semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to this project are documented here. The format is based on
   completeness/hash fallback.
 - Intelligent batching now keeps files together when their aggregate distinct count equals `largeIndexLimit`, avoiding
   unnecessary staging writes and consolidation cycles.
+- Catalog `list`, `exists`, `get`, and `describe` now consistently expose only metadata-backed indexes, while `remove`
+  still cleans directory-only and FileList-only recovery artifacts.
 - Multi-column temporal joins now calculate every temporal rank against the original rows before filtering, preventing
   stale rows from being promoted by an earlier temporal deduplication pass.
 - Index updates now migrate legacy exploded-field column names in both main and staging tables under the update lock

--- a/docs/api/dev/cjfravel/ariadne/IndexCatalog$.html
+++ b/docs/api/dev/cjfravel/ariadne/IndexCatalog$.html
@@ -514,8 +514,8 @@ summaries.foreach(s <span class="kw">=&gt;</span> println(s.name))</pre></li></o
         <span class="name">exists</span><span class="params">(<span name="name">name: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="params">(<span class="implicit">implicit </span><span name="spark">spark: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
 
-      <p class="shortcomment cmt">Checks whether an index with the given name exists.</p><div class="fullcomment"><div class="comment cmt"><p>Checks whether an index with the given name exists.</p><p>An index is considered to exist if its <code>metadata.json</code> file is present in the indexes storage directory, or if its
-file list entry exists.
+      <p class="shortcomment cmt">Checks whether an index with the given name exists.</p><div class="fullcomment"><div class="comment cmt"><p>Checks whether an index with the given name exists.</p><p>An index is considered a valid catalog entry only when its <code>metadata.json</code> file is present. Partial storage
+directories and orphaned FileLists remain removable recovery artifacts but are not exposed through catalog APIs.
 </p></div><dl class="paramcmts block"><dt class="param">name</dt><dd class="cmt"><p>
   the index name to check</p></dd><dt class="param">spark</dt><dd class="cmt"><p>
   implicit SparkSession</p></dd><dt>returns</dt><dd class="cmt"><p>

--- a/src/main/scala/dev/cjfravel/ariadne/IndexCatalog.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexCatalog.scala
@@ -128,8 +128,8 @@ object IndexCatalog {
   /**
    * Checks whether an index with the given name exists.
    *
-   * An index is considered to exist if its `metadata.json` file is present in the indexes storage directory, or if its
-   * file list entry exists.
+   * An index is considered a valid catalog entry only when its `metadata.json` file is present. Partial storage
+   * directories and orphaned FileLists remain removable recovery artifacts but are not exposed through catalog APIs.
    *
    * @example
    *   {{{if (IndexCatalog.exists("orders")) println("Index found")}}}
@@ -152,7 +152,7 @@ object IndexCatalog {
       }
     val metadataPath =
       new Path(new Path(IndexPathUtils.storagePath, name), "metadata.json")
-    contextUser.fs.exists(metadataPath) || IndexPathUtils.exists(name)
+    contextUser.fs.exists(metadataPath)
   }
 
   /**
@@ -382,7 +382,7 @@ object IndexCatalog {
    */
   def remove(name: String)(implicit spark: SparkSession): Boolean = {
     require(name != null && name.trim.nonEmpty, "name must not be null or blank")
-    if (!exists(name)) {
+    if (!IndexPathUtils.exists(name)) {
       throw new IndexNotFoundException(name)
     }
     val sparkSession = spark

--- a/src/test/scala/dev/cjfravel/ariadne/IndexCatalogTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/IndexCatalogTests.scala
@@ -1,6 +1,7 @@
 package dev.cjfravel.ariadne
 
 import dev.cjfravel.ariadne.exceptions.IndexNotFoundException
+import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.types._
 
 /**
@@ -77,6 +78,34 @@ class IndexCatalogTests extends SparkTests {
   test("exists returns true for existing index") {
     Index("catalog_exists", schema1, "parquet")
     assert(IndexCatalog.exists("catalog_exists"))
+  }
+
+  test("partial index directory is removable but not a catalog entry") {
+    val name = "catalog_partial_directory"
+    val path = new Path(IndexPathUtils.storagePath, name)
+    path.getFileSystem(spark.sparkContext.hadoopConfiguration).mkdirs(path)
+
+    assert(!IndexCatalog.list().contains(name))
+    assert(!IndexCatalog.exists(name))
+    assertThrows[IndexNotFoundException] {
+      IndexCatalog.describe(name)
+    }
+    assert(IndexCatalog.remove(name))
+    assert(!path.getFileSystem(spark.sparkContext.hadoopConfiguration).exists(path))
+  }
+
+  test("file-list-only state is removable but not a catalog entry") {
+    val name = "catalog_partial_filelist"
+    val fileListName = IndexPathUtils.fileListName(name)
+    FileList(fileListName).addFile("/tmp/catalog-partial-file.parquet")
+
+    assert(!IndexCatalog.list().contains(name))
+    assert(!IndexCatalog.exists(name))
+    assertThrows[IndexNotFoundException] {
+      IndexCatalog.describe(name)
+    }
+    assert(IndexCatalog.remove(name))
+    assert(!FileList.exists(fileListName))
   }
 
   // --- describe ---


### PR DESCRIPTION
## Summary
- define valid catalog entries as metadata-backed indexes
- align `list`, `exists`, `get`, and `describe` behavior
- keep directory-only and FileList-only states hidden from reads
- preserve `remove` as a recovery operation for partial artifacts
- add RED→GREEN tests for both partial states
- regenerate API documentation

## TDD
- RED: catalog `exists` returned true while `list` omitted directory-only and FileList-only states
- GREEN: partial states are not catalog entries but remain removable; all 307 tests pass in 7m11s