### PR TITLE
Verify example image inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ All notable changes to this project are documented here. The format is based on
 
 ### Changed
 
-- The examples image pins both base images by digest and verifies Spark SHA-512 plus Delta JAR SHA-1 checksums before
+- The examples image pins both base images by digest and verifies Spark SHA-512 plus Delta JAR SHA-256 checksums before
   extraction or use.
 - Release version checks now cover the changelog and include a shell regression test in the Maven test phase.
 - CI now uses current Node 24-based GitHub action majors, scopes pull-request write permission to the coverage job, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ All notable changes to this project are documented here. The format is based on
 
 ### Changed
 
+- The examples image pins both base images by digest and verifies Spark SHA-512 plus Delta JAR SHA-1 checksums before
+  extraction or use.
 - Release version checks now cover the changelog and include a shell regression test in the Maven test phase.
 - CI now uses current Node 24-based GitHub action majors, scopes pull-request write permission to the coverage job, and
   skips coverage publishing steps for fork pull requests with read-only tokens.

--- a/dev/scripts/example-dockerfile-tests.sh
+++ b/dev/scripts/example-dockerfile-tests.sh
@@ -12,7 +12,7 @@ fi
 assert_contains() {
     local expected="$1"
     if ! grep -Fq "$expected" "$DOCKERFILE"; then
-        echo "examples/Dockerfile is missing integrity contract: $expected"
+        echo "$DOCKERFILE is missing integrity contract: $expected"
         exit 1
     fi
 }

--- a/dev/scripts/example-dockerfile-tests.sh
+++ b/dev/scripts/example-dockerfile-tests.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 
 DOCKERFILE="examples/Dockerfile"
 
+if [[ ! -f "$DOCKERFILE" ]]; then
+    echo "Example Dockerfile not found: $DOCKERFILE"
+    exit 1
+fi
+
 assert_contains() {
     local expected="$1"
     if ! grep -Fq "$expected" "$DOCKERFILE"; then
@@ -15,7 +20,7 @@ assert_contains() {
 assert_contains 'maven:3.9-eclipse-temurin-11@sha256:1fee93ca227db7e8b8c7c72752ada0f03da6ebab40addd6fe48ac6293424186c'
 assert_contains 'eclipse-temurin:11-jdk-jammy@sha256:78d5c3a04afb5ae9750e58a755fc6ce6f4bd843587e40edaa3b7467c5184015e'
 assert_contains 'ec5ff678136b1ff981e396d1f7b5dfbf399439c5cb853917e8c954723194857607494a89b7e205fce988ec48b1590b5caeae3b18e1b5db1370c0522b256ff376'
-assert_contains 'ce09ca3d701f55357199bf5167b3c7daa729a07c'
-assert_contains '9d9d56fcae37f1b3d48d80f8b7eefabd3477569d'
+assert_contains '088e187da689a347a6a8556dcb22318e3dfcfb995d807f5e2c19b4d0a7ee9499'
+assert_contains '4dcc179fc4076bda5060a4038f979c53e1f5916cf04971e28f9441db390763c7'
 assert_contains 'sha512sum -c -'
-assert_contains 'sha1sum -c -'
+assert_contains 'sha256sum -c -'

--- a/dev/scripts/example-dockerfile-tests.sh
+++ b/dev/scripts/example-dockerfile-tests.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DOCKERFILE="examples/Dockerfile"
+
+assert_contains() {
+    local expected="$1"
+    if ! grep -Fq "$expected" "$DOCKERFILE"; then
+        echo "examples/Dockerfile is missing integrity contract: $expected"
+        exit 1
+    fi
+}
+
+assert_contains 'maven:3.9-eclipse-temurin-11@sha256:1fee93ca227db7e8b8c7c72752ada0f03da6ebab40addd6fe48ac6293424186c'
+assert_contains 'eclipse-temurin:11-jdk-jammy@sha256:78d5c3a04afb5ae9750e58a755fc6ce6f4bd843587e40edaa3b7467c5184015e'
+assert_contains 'ec5ff678136b1ff981e396d1f7b5dfbf399439c5cb853917e8c954723194857607494a89b7e205fce988ec48b1590b5caeae3b18e1b5db1370c0522b256ff376'
+assert_contains 'ce09ca3d701f55357199bf5167b3c7daa729a07c'
+assert_contains '9d9d56fcae37f1b3d48d80f8b7eefabd3477569d'
+assert_contains 'sha512sum -c -'
+assert_contains 'sha1sum -c -'

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9-eclipse-temurin-11 AS builder
+FROM maven:3.9-eclipse-temurin-11@sha256:1fee93ca227db7e8b8c7c72752ada0f03da6ebab40addd6fe48ac6293424186c AS builder
 
 COPY pom.xml /build/pom.xml
 COPY src /build/src
@@ -7,14 +7,16 @@ COPY README.md /build/README.md
 WORKDIR /build
 RUN mvn package -DskipTests -q
 
-FROM eclipse-temurin:11-jdk-jammy
+FROM eclipse-temurin:11-jdk-jammy@sha256:78d5c3a04afb5ae9750e58a755fc6ce6f4bd843587e40edaa3b7467c5184015e
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends python3 python3-pip wget && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Spark 3.5.5
+ARG SPARK_SHA512=ec5ff678136b1ff981e396d1f7b5dfbf399439c5cb853917e8c954723194857607494a89b7e205fce988ec48b1590b5caeae3b18e1b5db1370c0522b256ff376
 RUN wget -q https://archive.apache.org/dist/spark/spark-3.5.5/spark-3.5.5-bin-hadoop3.tgz && \
+    echo "$SPARK_SHA512  spark-3.5.5-bin-hadoop3.tgz" | sha512sum -c - && \
     tar xzf spark-3.5.5-bin-hadoop3.tgz -C /opt && \
     mv /opt/spark-3.5.5-bin-hadoop3 /opt/spark && \
     rm spark-3.5.5-bin-hadoop3.tgz
@@ -24,10 +26,14 @@ ENV PATH=$SPARK_HOME/bin:$PATH
 ENV PYSPARK_PYTHON=python3
 
 # Install Delta Lake JARs
+ARG DELTA_SPARK_SHA1=ce09ca3d701f55357199bf5167b3c7daa729a07c
+ARG DELTA_STORAGE_SHA1=9d9d56fcae37f1b3d48d80f8b7eefabd3477569d
 RUN wget -q https://repo1.maven.org/maven2/io/delta/delta-spark_2.12/3.2.1/delta-spark_2.12-3.2.1.jar \
       -O $SPARK_HOME/jars/delta-spark_2.12-3.2.1.jar && \
     wget -q https://repo1.maven.org/maven2/io/delta/delta-storage/3.2.1/delta-storage-3.2.1.jar \
-      -O $SPARK_HOME/jars/delta-storage-3.2.1.jar
+      -O $SPARK_HOME/jars/delta-storage-3.2.1.jar && \
+    echo "$DELTA_SPARK_SHA1  $SPARK_HOME/jars/delta-spark_2.12-3.2.1.jar" | sha1sum -c - && \
+    echo "$DELTA_STORAGE_SHA1  $SPARK_HOME/jars/delta-storage-3.2.1.jar" | sha1sum -c -
 
 # Install Jupyter + Scala kernel
 RUN pip3 install --no-cache-dir jupyter spylon-kernel && \

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -26,14 +26,14 @@ ENV PATH=$SPARK_HOME/bin:$PATH
 ENV PYSPARK_PYTHON=python3
 
 # Install Delta Lake JARs
-ARG DELTA_SPARK_SHA1=ce09ca3d701f55357199bf5167b3c7daa729a07c
-ARG DELTA_STORAGE_SHA1=9d9d56fcae37f1b3d48d80f8b7eefabd3477569d
+ARG DELTA_SPARK_SHA256=088e187da689a347a6a8556dcb22318e3dfcfb995d807f5e2c19b4d0a7ee9499
+ARG DELTA_STORAGE_SHA256=4dcc179fc4076bda5060a4038f979c53e1f5916cf04971e28f9441db390763c7
 RUN wget -q https://repo1.maven.org/maven2/io/delta/delta-spark_2.12/3.2.1/delta-spark_2.12-3.2.1.jar \
       -O $SPARK_HOME/jars/delta-spark_2.12-3.2.1.jar && \
     wget -q https://repo1.maven.org/maven2/io/delta/delta-storage/3.2.1/delta-storage-3.2.1.jar \
       -O $SPARK_HOME/jars/delta-storage-3.2.1.jar && \
-    echo "$DELTA_SPARK_SHA1  $SPARK_HOME/jars/delta-spark_2.12-3.2.1.jar" | sha1sum -c - && \
-    echo "$DELTA_STORAGE_SHA1  $SPARK_HOME/jars/delta-storage-3.2.1.jar" | sha1sum -c -
+    echo "$DELTA_SPARK_SHA256  $SPARK_HOME/jars/delta-spark_2.12-3.2.1.jar" | sha256sum -c - && \
+    echo "$DELTA_STORAGE_SHA256  $SPARK_HOME/jars/delta-storage-3.2.1.jar" | sha256sum -c -
 
 # Install Jupyter + Scala kernel
 RUN pip3 install --no-cache-dir jupyter spylon-kernel && \

--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,19 @@
                             </arguments>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>test-example-dockerfile-script</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>bash</executable>
+                            <arguments>
+                                <argument>dev/scripts/example-dockerfile-tests.sh</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 


### PR DESCRIPTION
## Summary
- pin Maven and Temurin base images by manifest digest
- verify Spark 3.5.5 SHA-512 before extraction
- verify Delta Spark and Storage 3.2.1 JAR SHA-256 values before use
- enforce all pins/checks through the Maven test lifecycle

## TDD
- RED: Docker integrity contract failed on the unpinned builder image
- GREEN: contract, targeted Maven lifecycle, and Docker BuildKit validation pass

## Verification sources
- Spark SHA-512 independently matched published packaging references to the Apache archive sidecar
- Delta SHA-256 values computed directly from Maven Central HTTPS artifacts
- base digests resolved through Docker Buildx manifests