### PR TITLE
Enforce repository readiness contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project are documented here. The format is based on
 
 - Contributor Covenant 2.1 governance, citation metadata, structured issue forms with private security routing, and a
   PR contract requiring RED/GREEN and persisted-compatibility evidence.
+- Repository-readiness contracts now enforce exact coordinated release metadata, canonical generated Scaladoc, and
+  shaded JAR contents for both supported Spark artifacts without invoking publication.
 - Explicit `metadata_version` and `storage_format_version` markers with lock-safe, ordered, idempotent migration
   preflight for the alpha37 compatibility floor. Queries, catalog scans, metadata mutations, updates, deletes,
   compaction, and vacuum migrate `file_size` and exploded-field storage before use; future versions fail explicitly.

--- a/dev/scripts/api-docs-drift-tests.sh
+++ b/dev/scripts/api-docs-drift-tests.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SPARK_COMPAT=${1:-spark3}
+
+if [[ "$SPARK_COMPAT" != "spark3" ]]; then
+    echo "API documentation drift is checked against the canonical Spark 3.5 build."
+    exit 0
+fi
+
+if [[ ! -d target/site/scaladocs ]]; then
+    echo "Generated API documentation is missing: target/site/scaladocs"
+    exit 1
+fi
+
+if ! diff -qr docs/api target/site/scaladocs; then
+    echo "docs/api does not match the generated Spark 3.5 Scaladoc."
+    echo "Run dev/scripts/build-api-docs.sh and commit the result."
+    exit 1
+fi

--- a/dev/scripts/build-api-docs.sh
+++ b/dev/scripts/build-api-docs.sh
@@ -12,8 +12,9 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
-echo "==> Generating Scaladoc via scala-maven-plugin..."
-mvn -q scala:doc
+echo "==> Generating Scaladoc from the complete Spark 3.5 source set..."
+bash dev/scripts/clean-api-docs-output.sh
+mvn -q package -DskipTests -Dgpg.skip=true
 
 if [[ ! -d target/site/scaladocs ]]; then
   echo "ERROR: target/site/scaladocs not produced" >&2

--- a/dev/scripts/build-api-docs.sh
+++ b/dev/scripts/build-api-docs.sh
@@ -14,7 +14,7 @@ cd "$(git rev-parse --show-toplevel)"
 
 echo "==> Generating Scaladoc from the complete Spark 3.5 source set..."
 bash dev/scripts/clean-api-docs-output.sh
-mvn -q package -DskipTests -Dgpg.skip=true
+mvn -q package -Pspark35 -DskipTests -Dgpg.skip=true
 
 if [[ ! -d target/site/scaladocs ]]; then
   echo "ERROR: target/site/scaladocs not produced" >&2

--- a/dev/scripts/clean-api-docs-output.sh
+++ b/dev/scripts/clean-api-docs-output.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+rm -rf "$REPO_ROOT/target/site/scaladocs"

--- a/dev/scripts/package-contents-tests.sh
+++ b/dev/scripts/package-contents-tests.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+JAR_PATH=${1:-}
+
+if [[ -z "$JAR_PATH" || ! -f "$JAR_PATH" ]]; then
+    echo "Packaged Ariadne JAR is missing: $JAR_PATH"
+    exit 1
+fi
+
+CONTENTS=$(mktemp)
+trap 'rm -f "$CONTENTS"' EXIT
+jar tf "$JAR_PATH" >"$CONTENTS"
+
+require_entry() {
+    if ! grep -q "^$1" "$CONTENTS"; then
+        echo "$JAR_PATH is missing required packaged namespace: $1"
+        exit 1
+    fi
+}
+
+reject_entry() {
+    if grep -q "^$1" "$CONTENTS"; then
+        echo "$JAR_PATH contains forbidden packaged namespace: $1"
+        exit 1
+    fi
+}
+
+require_entry 'dev/cjfravel/ariadne/shaded/gson/'
+require_entry 'dev/cjfravel/ariadne/shaded/guava/'
+
+reject_entry 'com/google/common/'
+reject_entry 'com/google/gson/'
+reject_entry 'com/fasterxml/jackson/'
+reject_entry 'io/delta/'
+
+if grep '^org/apache/spark/' "$CONTENTS" |
+    grep -Ev '^org/apache/spark/$|^org/apache/spark/sql/$|^org/apache/spark/sql/AriadneInternalHelper(\$)?\.class$'; then
+    echo "$JAR_PATH contains Spark classes outside Ariadne's internal compatibility helper."
+    exit 1
+fi

--- a/dev/scripts/readme-has-version-tests.sh
+++ b/dev/scripts/readme-has-version-tests.sh
@@ -74,3 +74,19 @@ if (cd "$TEST_ROOT" && bash dev/scripts/readme-has-version.sh >/dev/null); then
   echo "Version check accepted an artifact paired with a stale version"
   exit 1
 fi
+
+cp "$TEST_ROOT/pom.xml" "$TEST_ROOT/pom.valid.xml"
+sed -i '/<version>1.2.3<\/version>/d' "$TEST_ROOT/pom.xml"
+OUTPUT=$(cd "$TEST_ROOT" && bash dev/scripts/readme-has-version.sh 2>&1 || true)
+if ! grep -Fq "Version not found in pom.xml" <<<"$OUTPUT"; then
+  echo "Version check did not report a controlled missing-version error"
+  exit 1
+fi
+
+cp "$TEST_ROOT/pom.valid.xml" "$TEST_ROOT/pom.xml"
+sed -i '/<spark.suffix>35<\/spark.suffix>/d' "$TEST_ROOT/pom.xml"
+OUTPUT=$(cd "$TEST_ROOT" && bash dev/scripts/readme-has-version.sh 2>&1 || true)
+if ! grep -Fq "Unable to determine artifact coordinates for spark35" <<<"$OUTPUT"; then
+  echo "Version check did not report a controlled malformed-profile error"
+  exit 1
+fi

--- a/dev/scripts/readme-has-version-tests.sh
+++ b/dev/scripts/readme-has-version-tests.sh
@@ -11,12 +11,40 @@ cp "$REPO_ROOT/dev/scripts/readme-has-version.sh" "$TEST_ROOT/dev/scripts/"
 
 cat >"$TEST_ROOT/pom.xml" <<'EOF'
 <project>
+  <artifactId>ariadne-spark${spark.suffix}_${scala.binary.version}</artifactId>
   <version>1.2.3</version>
+  <profiles>
+    <profile>
+      <id>spark35</id>
+      <properties>
+        <scala.binary.version>2.12</scala.binary.version>
+        <spark.suffix>35</spark.suffix>
+      </properties>
+    </profile>
+    <profile>
+      <id>spark41</id>
+      <properties>
+        <scala.binary.version>2.13</scala.binary.version>
+        <spark.suffix>41</spark.suffix>
+      </properties>
+    </profile>
+  </profiles>
 </project>
 EOF
-echo "Install version 1.2.3" >"$TEST_ROOT/README.md"
-echo "Install version 1.2.3" >"$TEST_ROOT/docs/users/getting-started.html"
+cat >"$TEST_ROOT/README.md" <<'EOF'
+<artifactId>ariadne-spark35_2.12</artifactId>
+<version>1.2.3</version>
+<artifactId>ariadne-spark41_2.13</artifactId>
+<version>1.2.3</version>
+EOF
+cat >"$TEST_ROOT/docs/users/getting-started.html" <<'EOF'
+&lt;artifactId&gt;ariadne-spark35_2.12&lt;/artifactId&gt;
+&lt;version&gt;1.2.3&lt;/version&gt;
+&lt;artifactId&gt;ariadne-spark41_2.13&lt;/artifactId&gt;
+&lt;version&gt;1.2.3&lt;/version&gt;
+EOF
 echo "## [1.2.2]" >"$TEST_ROOT/CHANGELOG.md"
+echo "version: 1.2.3" >"$TEST_ROOT/CITATION.cff"
 
 if (cd "$TEST_ROOT" && bash dev/scripts/readme-has-version.sh >/dev/null); then
   echo "Version check accepted a changelog that omitted the current version"
@@ -25,3 +53,24 @@ fi
 
 echo "## [1.2.3]" >"$TEST_ROOT/CHANGELOG.md"
 (cd "$TEST_ROOT" && bash dev/scripts/readme-has-version.sh >/dev/null)
+
+echo "## [11.2.30]" >"$TEST_ROOT/CHANGELOG.md"
+if (cd "$TEST_ROOT" && bash dev/scripts/readme-has-version.sh >/dev/null); then
+  echo "Version check accepted the current version as a substring"
+  exit 1
+fi
+
+echo "## [1.2.3]" >"$TEST_ROOT/CHANGELOG.md"
+sed -i 's/ariadne-spark41_2.13/ariadne-spark40_2.13/g' "$TEST_ROOT/README.md"
+if (cd "$TEST_ROOT" && bash dev/scripts/readme-has-version.sh >/dev/null); then
+  echo "Version check accepted documentation with the wrong Spark 4 artifact"
+  exit 1
+fi
+
+sed -i 's/ariadne-spark40_2.13/ariadne-spark41_2.13/g' "$TEST_ROOT/README.md"
+sed -i '0,/1.2.3/s//1.2.2/' "$TEST_ROOT/README.md"
+echo "Current release: 1.2.3" >>"$TEST_ROOT/README.md"
+if (cd "$TEST_ROOT" && bash dev/scripts/readme-has-version.sh >/dev/null); then
+  echo "Version check accepted an artifact paired with a stale version"
+  exit 1
+fi

--- a/dev/scripts/readme-has-version.sh
+++ b/dev/scripts/readme-has-version.sh
@@ -1,6 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Extract version from pom.xml
+set -euo pipefail
+
 VERSION=$(grep -oPm1 "(?<=<version>)[^<]+" pom.xml)
 
 if [[ -z "$VERSION" ]]; then
@@ -8,26 +9,48 @@ if [[ -z "$VERSION" ]]; then
     exit 1
 fi
 
-# Files that must reference the current version
-FILES=(
-    "README.md"
-    "CHANGELOG.md"
-    "docs/users/getting-started.html"
-)
-
 STATUS=0
-for f in "${FILES[@]}"; do
-    if [[ ! -f "$f" ]]; then
-        echo "Version-check file missing: $f"
-        STATUS=1
-        continue
-    fi
-    if grep -q "$VERSION" "$f"; then
-        echo "Version $VERSION is present in $f."
-    else
-        echo "Version $VERSION is NOT present in $f."
+
+require_fixed_line() {
+    local file="$1"
+    local expected="$2"
+    if ! grep -Fqx "$expected" "$file"; then
+        echo "$file is missing exact release metadata: $expected"
         STATUS=1
     fi
+}
+
+require_compact_sequence() {
+    local file="$1"
+    local expected="$2"
+    local compact
+    compact=$(tr -d '[:space:]' <"$file")
+    if ! grep -Fq "$expected" <<<"$compact"; then
+        echo "$file is missing coordinated release metadata: $expected"
+        STATUS=1
+    fi
+}
+
+for file in README.md CHANGELOG.md CITATION.cff docs/users/getting-started.html; do
+    if [[ ! -f "$file" ]]; then
+        echo "Version-check file missing: $file"
+        exit 1
+    fi
+done
+
+require_fixed_line CHANGELOG.md "## [$VERSION]"
+require_fixed_line CITATION.cff "version: $VERSION"
+
+for profile in spark35 spark41; do
+    profile_xml=$(awk "/<id>$profile<\\/id>/,/<\\/profile>/" pom.xml)
+    spark_suffix=$(grep -oPm1 "(?<=<spark.suffix>)[^<]+" <<<"$profile_xml")
+    scala_binary_version=$(grep -oPm1 "(?<=<scala.binary.version>)[^<]+" <<<"$profile_xml")
+    artifact_id="ariadne-spark${spark_suffix}_${scala_binary_version}"
+
+    require_compact_sequence README.md \
+        "<artifactId>$artifact_id</artifactId><version>$VERSION</version>"
+    require_compact_sequence docs/users/getting-started.html \
+        "&lt;artifactId&gt;$artifact_id&lt;/artifactId&gt;&lt;version&gt;$VERSION&lt;/version&gt;"
 done
 
 exit $STATUS

--- a/dev/scripts/readme-has-version.sh
+++ b/dev/scripts/readme-has-version.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-VERSION=$(grep -oPm1 "(?<=<version>)[^<]+" pom.xml)
+VERSION=$(grep -oPm1 "(?<=<version>)[^<]+" pom.xml || true)
 
 if [[ -z "$VERSION" ]]; then
     echo "Version not found in pom.xml"
@@ -43,8 +43,13 @@ require_fixed_line CITATION.cff "version: $VERSION"
 
 for profile in spark35 spark41; do
     profile_xml=$(awk "/<id>$profile<\\/id>/,/<\\/profile>/" pom.xml)
-    spark_suffix=$(grep -oPm1 "(?<=<spark.suffix>)[^<]+" <<<"$profile_xml")
-    scala_binary_version=$(grep -oPm1 "(?<=<scala.binary.version>)[^<]+" <<<"$profile_xml")
+    spark_suffix=$(grep -oPm1 "(?<=<spark.suffix>)[^<]+" <<<"$profile_xml" || true)
+    scala_binary_version=$(grep -oPm1 "(?<=<scala.binary.version>)[^<]+" <<<"$profile_xml" || true)
+    if [[ -z "$spark_suffix" || -z "$scala_binary_version" ]]; then
+        echo "Unable to determine artifact coordinates for $profile"
+        STATUS=1
+        continue
+    fi
     artifact_id="ariadne-spark${spark_suffix}_${scala_binary_version}"
 
     require_compact_sequence README.md \

--- a/dev/scripts/repository-readiness-tests.sh
+++ b/dev/scripts/repository-readiness-tests.sh
@@ -24,6 +24,9 @@ for file in \
     pom.xml \
     CODE_OF_CONDUCT.md \
     CITATION.cff \
+    dev/scripts/api-docs-drift-tests.sh \
+    dev/scripts/clean-api-docs-output.sh \
+    dev/scripts/package-contents-tests.sh \
     .github/ISSUE_TEMPLATE/bug.yml \
     .github/ISSUE_TEMPLATE/feature.yml \
     .github/ISSUE_TEMPLATE/config.yml \
@@ -42,5 +45,12 @@ assert_contains .github/ISSUE_TEMPLATE/config.yml 'security/advisories/new'
 assert_contains README.md 'CODE_OF_CONDUCT.md'
 assert_contains README.md 'CITATION.cff'
 assert_contains CONTRIBUTING.md 'CODE_OF_CONDUCT.md'
+assert_contains dev/scripts/api-docs-drift-tests.sh 'target/site/scaladocs'
+assert_contains dev/scripts/build-api-docs.sh 'clean-api-docs-output.sh'
+assert_contains pom.xml 'clean-api-docs-output'
+assert_contains dev/scripts/package-contents-tests.sh 'dev/cjfravel/ariadne/shaded'
+assert_contains dev/scripts/package-contents-tests.sh 'com/fasterxml/jackson'
+assert_contains README.md 'ariadne-spark35_2.12'
+assert_contains README.md 'ariadne-spark41_2.13'
 VERSION=$(grep -oPm1 "(?<=<version>)[^<]+" pom.xml)
 assert_contains CITATION.cff "version: $VERSION"

--- a/dev/scripts/repository-readiness-tests.sh
+++ b/dev/scripts/repository-readiness-tests.sh
@@ -25,6 +25,7 @@ for file in \
     CODE_OF_CONDUCT.md \
     CITATION.cff \
     dev/scripts/api-docs-drift-tests.sh \
+    dev/scripts/build-api-docs.sh \
     dev/scripts/clean-api-docs-output.sh \
     dev/scripts/package-contents-tests.sh \
     .github/ISSUE_TEMPLATE/bug.yml \

--- a/dev/scripts/repository-readiness-tests.sh
+++ b/dev/scripts/repository-readiness-tests.sh
@@ -12,7 +12,7 @@ assert_file() {
 assert_contains() {
     local file="$1"
     local expected="$2"
-    if ! grep -Fiq "$expected" "$file"; then
+    if ! grep -Fiq -- "$expected" "$file"; then
         echo "$file is missing required content: $expected"
         exit 1
     fi
@@ -48,6 +48,7 @@ assert_contains README.md 'CITATION.cff'
 assert_contains CONTRIBUTING.md 'CODE_OF_CONDUCT.md'
 assert_contains dev/scripts/api-docs-drift-tests.sh 'target/site/scaladocs'
 assert_contains dev/scripts/build-api-docs.sh 'clean-api-docs-output.sh'
+assert_contains dev/scripts/build-api-docs.sh '-Pspark35'
 assert_contains pom.xml 'clean-api-docs-output'
 assert_contains dev/scripts/package-contents-tests.sh 'dev/cjfravel/ariadne/shaded'
 assert_contains dev/scripts/package-contents-tests.sh 'com/fasterxml/jackson'

--- a/docs/api/dev/cjfravel/ariadne/AriadneContextUser.html
+++ b/docs/api/dev/cjfravel/ariadne/AriadneContextUser.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.AriadneContextUser" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.AriadneContextUser" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="catalog/index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -147,7 +147,7 @@
       <span class="symbol">
         <a title="" href="exceptions/index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented3">
                         <span class="separator"></span>
@@ -256,7 +256,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Provides Spark session context, HDFS access, and configuration for Ariadne operations.</p><p>Mix this trait into any class that needs access to Ariadne infrastructure. All configuration is read lazily from
 <code>SparkConf</code> properties prefixed with <code>spark.ariadne.*</code> and logged at <code>warn</code> level on first access.</p><p><b>Spark configuration keys:</b></p><pre>spark.ariadne.storagePath                 (required) Base HDFS/filesystem path <span class="kw">for</span> index storage
 spark.ariadne.largeIndexLimit             (default: <span class="num">500000</span>) Max values before a column is <span class="lit">"large"</span>
@@ -283,7 +283,7 @@ concurrency model.
             </span>
             <div class="subClasses hiddenContent"><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a>, <a href="FileList.html" class="extype" name="dev.cjfravel.ariadne.FileList">FileList</a>, <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a>, <a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a>, <a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a>, <a href="IndexJoinOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexJoinOperations">IndexJoinOperations</a>, <a href="IndexLock.html" class="extype" name="dev.cjfravel.ariadne.IndexLock">IndexLock</a>, <a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a>, <a href="IndexQueryOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexQueryOperations">IndexQueryOperations</a></div>
           </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -298,7 +298,7 @@ concurrency model.
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -325,9 +325,9 @@ concurrency model.
 
       <div id="template">
         <div id="allMembers">
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Abstract Value Members</h3>
@@ -345,7 +345,7 @@ concurrency model.
       <span class="symbol">
         <span class="name">spark</span><span class="result">: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Implicit SparkSession that must be provided by the mixing class.</p>
     </li></ol>
             </div>
@@ -367,7 +367,7 @@ concurrency model.
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -383,7 +383,7 @@ concurrency model.
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -399,7 +399,7 @@ concurrency model.
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -415,7 +415,7 @@ concurrency model.
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#autoBloomFpr" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="autoBloomFpr:Double"></a>
@@ -431,7 +431,7 @@ concurrency model.
       <span class="symbol">
         <span class="name">autoBloomFpr</span><span class="result">: <span class="extype" name="scala.Double">Double</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">False positive rate for auto-bloom filters on large index columns.</p><div class="fullcomment"><div class="comment cmt"><p>False positive rate for auto-bloom filters on large index columns. When a column exceeds largeIndexLimit, an
 auto-bloom filter is built with this FPR to enable file pruning at query time. Reads from
 spark.ariadne.autoBloomFpr configuration (default: 0.01).
@@ -450,7 +450,7 @@ spark.ariadne.autoBloomFpr configuration (default: 0.01).
       <span class="symbol">
         <span class="name">autoCompactThreshold</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Int">Int</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Optional threshold for auto-compaction.</p><div class="fullcomment"><div class="comment cmt"><p>Optional threshold for auto-compaction. When set, the main index Delta table is compacted after an update if the
 number of Delta log JSON files meets or exceeds this value. Reads from spark.ariadne.autoCompactThreshold
 configuration (default: not set).
@@ -469,17 +469,17 @@ configuration (default: not set).
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#debugEnabled" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="debugEnabled:Boolean"></a>
@@ -495,7 +495,7 @@ configuration (default: not set).
       <span class="symbol">
         <span class="name">debugEnabled</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">When true, logs detailed diagnostics during join operations including partition counts, physical plans, and
 per-phase timing.</p><div class="fullcomment"><div class="comment cmt"><p>When true, logs detailed diagnostics during join operations including partition counts, physical plans, and
 per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
@@ -514,12 +514,12 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">delete</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Deletes a path recursively from the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Deletes a path recursively from the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to delete</p></dd><dt>returns</dt><dd class="cmt"><p>
-  true if the path was successfully deleted</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  true if the path was successfully deleted</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the filesystem operation fails</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#delta" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="delta(path:org.apache.hadoop.fs.Path):Option[io.delta.tables.DeltaTable]"></a><a id="delta(Path):Option[DeltaTable]"></a>
@@ -535,7 +535,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">delta</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="io.delta.tables.DeltaTable">DeltaTable</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns a <span class="extype" name="io.delta.tables.DeltaTable">io.delta.tables.DeltaTable</span> if the path exists and contains valid Delta metadata.</p><div class="fullcomment"><div class="comment cmt"><p>Returns a <span class="extype" name="io.delta.tables.DeltaTable">io.delta.tables.DeltaTable</span> if the path exists and contains valid Delta metadata.</p><p>If the path exists but is <i>not</i> a valid Delta table (e.g., leftover partial write), the directory is deleted and
 <code>None</code> is returned so it can be recreated cleanly on the next write.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
@@ -555,7 +555,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -571,7 +571,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#exists" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exists(path:org.apache.hadoop.fs.Path):Boolean"></a><a id="exists(Path):Boolean"></a>
@@ -587,12 +587,12 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">exists</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks if a path exists on the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Checks if a path exists on the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to check</p></dd><dt>returns</dt><dd class="cmt"><p>
-  true if the path exists</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  true if the path exists</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the filesystem operation fails</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#fs" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="fs:org.apache.hadoop.fs.FileSystem"></a><a id="fs:FileSystem"></a>
@@ -608,7 +608,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">fs</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.FileSystem">FileSystem</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop <code>FileSystem</code> instance resolved from the <a href="#storagePath:org.apache.hadoop.fs.Path" class="extmbr" name="dev.cjfravel.ariadne.AriadneContextUser#storagePath">storagePath</a> URI and the Spark Hadoop configuration.</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop <code>FileSystem</code> instance resolved from the <a href="#storagePath:org.apache.hadoop.fs.Path" class="extmbr" name="dev.cjfravel.ariadne.AriadneContextUser#storagePath">storagePath</a> URI and the Spark Hadoop configuration. Used for all
 filesystem operations (existence checks, reads, deletes, lock files).
 </p></div></div>
@@ -626,12 +626,12 @@ filesystem operations (existence checks, reads, deletes, lock files).
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -647,12 +647,12 @@ filesystem operations (existence checks, reads, deletes, lock files).
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#indexRepartitionCount" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="indexRepartitionCount:Option[Int]"></a>
@@ -668,7 +668,7 @@ filesystem operations (existence checks, reads, deletes, lock files).
       <span class="symbol">
         <span class="name">indexRepartitionCount</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Int">Int</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Optional number of partitions to use when repartitioning the index DataFrame during joins.</p><div class="fullcomment"><div class="comment cmt"><p>Optional number of partitions to use when repartitioning the index DataFrame during joins. When set, the index
 DataFrame is repartitioned before expensive operations like explode to reduce per-executor memory pressure and
 avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepartitionCount configuration
@@ -688,7 +688,7 @@ avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepa
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#largeIndexLimit" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="largeIndexLimit:Long"></a>
@@ -704,7 +704,7 @@ avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepa
       <span class="symbol">
         <span class="name">largeIndexLimit</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Maximum number of distinct values per file before an index column is promoted to a &quot;large index&quot; (stored in a
 separate exploded Delta table).</p><div class="fullcomment"><div class="comment cmt"><p>Maximum number of distinct values per file before an index column is promoted to a &quot;large index&quot; (stored in a
 separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</code> (default: 500000).</p><p>If the configured value is not a valid positive number, a warning is logged and the default of 500,000 is used.
@@ -723,7 +723,7 @@ separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</
       <span class="symbol">
         <span class="name">lockMaxWait</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Maximum total time in seconds to wait for lock acquisition before failing.</p><div class="fullcomment"><div class="comment cmt"><p>Maximum total time in seconds to wait for lock acquisition before failing. Reads from spark.ariadne.lockMaxWait
 configuration (default: 3600).
 </p></div><dl class="attributes block"> <dt>Note</dt><dd><span class="cmt"><p>
@@ -743,7 +743,7 @@ configuration (default: 3600).
       <span class="symbol">
         <span class="name">lockRefreshInterval</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Refresh the update lock every N batches during updateBatched.</p><div class="fullcomment"><div class="comment cmt"><p>Refresh the update lock every N batches during updateBatched. Reads from spark.ariadne.lockRefreshInterval
 configuration (default: 1).
 </p></div></div>
@@ -761,7 +761,7 @@ configuration (default: 1).
       <span class="symbol">
         <span class="name">lockRetryInterval</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Base interval in seconds between lock acquisition retries (exponential backoff applied).</p><div class="fullcomment"><div class="comment cmt"><p>Base interval in seconds between lock acquisition retries (exponential backoff applied). Reads from
 spark.ariadne.lockRetryInterval configuration (default: 60).
 </p></div></div>
@@ -779,7 +779,7 @@ spark.ariadne.lockRetryInterval configuration (default: 60).
       <span class="symbol">
         <span class="name">lockTimeout</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Seconds since <code>lastRefreshedAt</code> before a lock is considered stale and eligible for auto-heal (forcible acquisition
 by another process).</p><div class="fullcomment"><div class="comment cmt"><p>Seconds since <code>lastRefreshedAt</code> before a lock is considered stale and eligible for auto-heal (forcible acquisition
 by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default: 1800).
@@ -798,12 +798,12 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">logger</span><span class="result">: <span class="extype" name="org.apache.logging.log4j.Logger">Logger</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Log4j logger shared by all Ariadne components.</p><div class="fullcomment"><div class="comment cmt"><p>Log4j logger shared by all Ariadne components. Uses the &quot;ariadne&quot; logger name. Marked <code>@transient lazy</code> so that
 <code>Index</code> (a case class) remains serializable across Spark stages — Log4j loggers are not <code>Serializable</code>.
 </p></div><dl class="attributes block"> <dt>Annotations</dt><dd>
                 <span class="name">@transient</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -819,7 +819,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -835,12 +835,12 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -856,12 +856,12 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#open" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="open(path:org.apache.hadoop.fs.Path):org.apache.hadoop.fs.FSDataInputStream"></a><a id="open(Path):FSDataInputStream"></a>
@@ -877,12 +877,12 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">open</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.FSDataInputStream">FSDataInputStream</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Opens an input stream to read from a path on the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Opens an input stream to read from a path on the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to open for reading</p></dd><dt>returns</dt><dd class="cmt"><p>
-  An FSDataInputStream for reading the file contents</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  An FSDataInputStream for reading the file contents</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the file does not exist or cannot be opened</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#repartitionDataFiles" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="repartitionDataFiles:Boolean"></a>
@@ -898,7 +898,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">repartitionDataFiles</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">When true, applies indexRepartitionCount repartitioning to the data files read during joinDf.</p><div class="fullcomment"><div class="comment cmt"><p>When true, applies indexRepartitionCount repartitioning to the data files read during joinDf. When false, data
 files keep their natural parquet partitioning. Disable when column selection significantly reduces data volume,
 making the repartition shuffle more expensive than useful. Reads from spark.ariadne.repartitionDataFiles
@@ -918,7 +918,7 @@ configuration (default: false).
       <span class="symbol">
         <span class="name">safeDestroyBroadcast</span><span class="params">(<span name="broadcast">broadcast: <span class="extype" name="org.apache.spark.broadcast.Broadcast">Broadcast</span>[_]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Safely destroys a broadcast variable, logging but swallowing any exception.</p><div class="fullcomment"><div class="comment cmt"><p>Safely destroys a broadcast variable, logging but swallowing any exception.</p><p>Intended for use inside <code>finally</code> blocks where a cleanup failure must not mask the original exception propagating
 out of the <code>try</code> block. Tolerates a null broadcast.
 </p></div><dl class="paramcmts block"><dt class="param">broadcast</dt><dd class="cmt"><p>
@@ -937,7 +937,7 @@ out of the <code>try</code> block. Tolerates a null broadcast.
       <span class="symbol">
         <span class="name">stagingConsolidationThreshold</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Number of batches to process before consolidating staged data into the main index.</p><div class="fullcomment"><div class="comment cmt"><p>Number of batches to process before consolidating staged data into the main index. This provides fault tolerance
 for large index builds - if a job fails, work is preserved up to the last consolidation point. Reads from
 spark.ariadne.stagingConsolidationThreshold configuration (default: 50).
@@ -956,10 +956,10 @@ spark.ariadne.stagingConsolidationThreshold configuration (default: 50).
       <span class="symbol">
         <span class="name">storagePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Base path on the Hadoop-compatible filesystem where all Ariadne index data is stored.</p><div class="fullcomment"><div class="comment cmt"><p>Base path on the Hadoop-compatible filesystem where all Ariadne index data is stored. Each index creates a
 subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</code> (required — no default).
-</p></div><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+</p></div><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if the configuration key is not set</p></span></dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -975,7 +975,7 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -991,7 +991,7 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -1007,13 +1007,13 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -1029,15 +1029,15 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -1053,19 +1053,19 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -1083,15 +1083,15 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -1103,13 +1103,13 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/BloomFilterOperations.html
+++ b/docs/api/dev/cjfravel/ariadne/BloomFilterOperations.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.BloomFilterOperations" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.BloomFilterOperations" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="catalog/index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -147,7 +147,7 @@
       <span class="symbol">
         <a title="" href="exceptions/index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented3">
                         <span class="separator"></span>
@@ -256,7 +256,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Trait providing bloom filter operations for <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a> instances.</p><p>Bloom filters are probabilistic data structures used to test set membership. This trait handles the full lifecycle of
 bloom filter indexes:</p><p><b>Building</b>: During index updates, bloom filters are created per file per configured column via
 <a href="#buildBloomFilterIndexes(df:org.apache.spark.sql.DataFrame):org.apache.spark.sql.DataFrame" class="extmbr" name="dev.cjfravel.ariadne.BloomFilterOperations#buildBloomFilterIndexes">buildBloomFilterIndexes</a>. Values are hashed into a Guava <code>BloomFilter[CharSequence]</code> and serialized to
@@ -278,7 +278,7 @@ ensure serializability across the Spark closure boundary.
             </span>
             <div class="subClasses hiddenContent"><a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a>, <a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a>, <a href="IndexJoinOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexJoinOperations">IndexJoinOperations</a>, <a href="IndexQueryOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexQueryOperations">IndexQueryOperations</a></div>
           </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -293,7 +293,7 @@ ensure serializability across the Spark closure boundary.
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -320,9 +320,9 @@ ensure serializability across the Spark closure boundary.
 
       <div id="template">
         <div id="allMembers">
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Abstract Value Members</h3>
@@ -340,7 +340,7 @@ ensure serializability across the Spark closure boundary.
       <span class="symbol">
         <span class="name">spark</span><span class="result">: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Implicit SparkSession that must be provided by the mixing class.</p><div class="fullcomment"><div class="comment cmt"><p>Implicit SparkSession that must be provided by the mixing class.</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
     </li></ol>
             </div>
@@ -362,7 +362,7 @@ ensure serializability across the Spark closure boundary.
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -378,7 +378,7 @@ ensure serializability across the Spark closure boundary.
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -394,7 +394,7 @@ ensure serializability across the Spark closure boundary.
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexFileOperations#addFilenameColumn" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addFilenameColumn(df:org.apache.spark.sql.DataFrame,files:Set[String]):org.apache.spark.sql.DataFrame"></a><a id="addFilenameColumn(DataFrame,Set[String]):DataFrame"></a>
@@ -410,7 +410,7 @@ ensure serializability across the Spark closure boundary.
       <span class="symbol">
         <span class="name">addFilenameColumn</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="files">files: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Adds a stable filename column to the DataFrame.</p><div class="fullcomment"><div class="comment cmt"><p>Adds a stable filename column to the DataFrame.</p><p>Uses <code>input_file_name()</code> to capture the source file path. For single-file reads where Spark may report an empty
 filename, falls back to the known file path.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
@@ -431,7 +431,7 @@ filename, falls back to the known file path.
       <span class="symbol">
         <span class="name">applyColumnSelection</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Applies column selection if columns have been specified via select().</p><div class="fullcomment"><div class="comment cmt"><p>Applies column selection if columns have been specified via select(). Only reads the explicitly selected columns.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
   The DataFrame to apply column selection to</p></dd><dt>returns</dt><dd class="cmt"><p>
@@ -450,12 +450,12 @@ filename, falls back to the known file path.
       <span class="symbol">
         <span class="name">applyComputedIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Applies computed indexes to a DataFrame by adding computed columns.</p><div class="fullcomment"><div class="comment cmt"><p>Applies computed indexes to a DataFrame by adding computed columns.</p><p>Each computed index is a Spark SQL expression stored in metadata. The expression is evaluated via <code>expr()</code> and
 added as a new column. If no computed indexes are configured, the DataFrame is returned unchanged.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
   The base DataFrame</p></dd><dt>returns</dt><dd class="cmt"><p>
-  DataFrame with computed index columns added</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="org.apache.spark.sql.AnalysisException"><code>org.apache.spark.sql.AnalysisException</code></span>
+  DataFrame with computed index columns added</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="org.apache.spark.sql.AnalysisException"><code>org.apache.spark.sql.AnalysisException</code></span> 
   if a computed index expression is invalid or references non-existent columns</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexFileOperations#applyExplodedFields" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="applyExplodedFields(df:org.apache.spark.sql.DataFrame):org.apache.spark.sql.DataFrame"></a><a id="applyExplodedFields(DataFrame):DataFrame"></a>
@@ -471,7 +471,7 @@ added as a new column. If no computed indexes are configured, the DataFrame is r
       <span class="symbol">
         <span class="name">applyExplodedFields</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Applies exploded field transformations to a DataFrame.</p><div class="fullcomment"><div class="comment cmt"><p>Applies exploded field transformations to a DataFrame.</p><p>For each configured exploded field, extracts the nested field path from the array column and explodes it into a
 top-level column. This is used on the read/join path to prepare data for joining on exploded field values.</p><p>Note that <code>explode()</code> (not <code>explode_outer()</code>) is used intentionally — rows with null or empty arrays are dropped
 because they contain no matchable values for the join. This is consistent with the index build path which also
@@ -493,7 +493,7 @@ excludes null/empty arrays.
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#autoBloomFpr" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="autoBloomFpr:Double"></a>
@@ -509,7 +509,7 @@ excludes null/empty arrays.
       <span class="symbol">
         <span class="name">autoBloomFpr</span><span class="result">: <span class="extype" name="scala.Double">Double</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">False positive rate for auto-bloom filters on large index columns.</p><div class="fullcomment"><div class="comment cmt"><p>False positive rate for auto-bloom filters on large index columns. When a column exceeds largeIndexLimit, an
 auto-bloom filter is built with this FPR to enable file pruning at query time. Reads from
 spark.ariadne.autoBloomFpr configuration (default: 0.01).
@@ -528,7 +528,7 @@ spark.ariadne.autoBloomFpr configuration (default: 0.01).
       <span class="symbol">
         <span class="name">autoCompactThreshold</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Int">Int</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Optional threshold for auto-compaction.</p><div class="fullcomment"><div class="comment cmt"><p>Optional threshold for auto-compaction. When set, the main index Delta table is compacted after an update if the
 number of Delta log JSON files meets or exceeds this value. Reads from spark.ariadne.autoCompactThreshold
 configuration (default: not set).
@@ -547,7 +547,7 @@ configuration (default: not set).
       <span class="symbol">
         <span class="name">bloomColumnPrefix</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Column name prefix used when storing bloom filter binary data in the index Delta table.</p><div class="fullcomment"><div class="comment cmt"><p>Column name prefix used when storing bloom filter binary data in the index Delta table.
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.BloomFilterOperations#bloomColumns" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -564,7 +564,7 @@ configuration (default: not set).
       <span class="symbol">
         <span class="name">bloomColumns</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the set of source column names that have bloom indexes configured.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the set of source column names that have bloom indexes configured.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   set of column names (without the <code>bloom_</code> prefix)</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd></dl></div>
@@ -582,7 +582,7 @@ configuration (default: not set).
       <span class="symbol">
         <span class="name">bloomContainsUdf</span><span class="result">: <span class="extype" name="org.apache.spark.sql.expressions.UserDefinedFunction">UserDefinedFunction</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Creates a Spark UDF for checking bloom filter membership at query time.</p><div class="fullcomment"><div class="comment cmt"><p>Creates a Spark UDF for checking bloom filter membership at query time.</p><p>The returned UDF accepts a serialized bloom filter (<code>Array[Byte]</code>) and a candidate value (<code>String</code>), and returns
 <code>true</code> if the bloom filter indicates the value might be present.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
@@ -601,7 +601,7 @@ configuration (default: not set).
       <span class="symbol">
         <span class="name">bloomIndexConfigs</span><span class="result">: <span class="extype" name="scala.Seq">Seq</span>[<a href="BloomIndexConfig.html" class="extype" name="dev.cjfravel.ariadne.BloomIndexConfig">BloomIndexConfig</a>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the bloom index configurations from the current index metadata.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the bloom index configurations from the current index metadata.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   sequence of <a href="BloomIndexConfig.html" class="extype" name="dev.cjfravel.ariadne.BloomIndexConfig">BloomIndexConfig</a> objects, one per bloom-indexed column</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd></dl></div>
@@ -619,7 +619,7 @@ configuration (default: not set).
       <span class="symbol">
         <span class="name">bloomMightContain</span><span class="params">(<span name="bloomBytes">bloomBytes: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Byte">Byte</span>]</span>, <span name="value">value: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks if a value might be contained in a serialized bloom filter.</p><div class="fullcomment"><div class="comment cmt"><p>Checks if a value might be contained in a serialized bloom filter.</p><p>Deserializes the bloom filter and performs a <code>mightContain</code> check. Returns <code>false</code> if either argument is <code>null</code>.
 </p></div><dl class="paramcmts block"><dt class="param">bloomBytes</dt><dd class="cmt"><p>
   serialized bloom filter bytes</p></dd><dt class="param">value</dt><dd class="cmt"><p>
@@ -639,7 +639,7 @@ configuration (default: not set).
       <span class="symbol">
         <span class="name">bloomStorageColumns</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the set of storage column names used for bloom filter binary data.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the set of storage column names used for bloom filter binary data.</p><p>Each name is the source column name prefixed with <a href="#bloomColumnPrefix:String" class="extmbr" name="dev.cjfravel.ariadne.BloomFilterOperations#bloomColumnPrefix">bloomColumnPrefix</a>.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   set of prefixed column names (e.g., <code>bloom_user_id</code>)</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd></dl></div>
@@ -657,7 +657,7 @@ configuration (default: not set).
       <span class="symbol">
         <span class="name">buildBloomFilterIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds bloom filter indexes for all configured bloom columns.</p><div class="fullcomment"><div class="comment cmt"><p>Builds bloom filter indexes for all configured bloom columns.</p><p>For each <a href="BloomIndexConfig.html" class="extype" name="dev.cjfravel.ariadne.BloomIndexConfig">BloomIndexConfig</a>, this method:</p><ol class="decimal"><li>Groups the input data by filename 2. Collects distinct values per file into a set 3. Creates a bloom filter
      from the collected values using <a href="#createBloomFilterUdf(fprValue:Double):org.apache.spark.sql.expressions.UserDefinedFunction" class="extmbr" name="dev.cjfravel.ariadne.BloomFilterOperations#createBloomFilterUdf">createBloomFilterUdf</a> 4. Joins the resulting bloom column back onto the
      accumulating DataFrame</li></ol><p>If no bloom indexes are configured, returns a distinct filename-only DataFrame.
@@ -678,17 +678,17 @@ configuration (default: not set).
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexFileOperations#createBaseDataFrame" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="createBaseDataFrame(files:Set[String]):org.apache.spark.sql.DataFrame"></a><a id="createBaseDataFrame(Set[String]):DataFrame"></a>
@@ -704,12 +704,12 @@ configuration (default: not set).
       <span class="symbol">
         <span class="name">createBaseDataFrame</span><span class="params">(<span name="files">files: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Creates a base DataFrame from the provided files using the stored format and schema.</p><div class="fullcomment"><div class="comment cmt"><p>Creates a base DataFrame from the provided files using the stored format and schema. Applies any read options
 configured in the index metadata.</p><p>Returns an empty DataFrame (with the stored schema) if all file paths are blank after normalization.
 </p></div><dl class="paramcmts block"><dt class="param">files</dt><dd class="cmt"><p>
   Set of file paths to read</p></dd><dt>returns</dt><dd class="cmt"><p>
-  DataFrame with data from the specified files</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+  DataFrame with data from the specified files</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if the stored format is not csv, parquet, or json</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.BloomFilterOperations#createBloomFilterUdf" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="createBloomFilterUdf(fprValue:Double):org.apache.spark.sql.expressions.UserDefinedFunction"></a><a id="createBloomFilterUdf(Double):UserDefinedFunction"></a>
@@ -725,7 +725,7 @@ configured in the index metadata.</p><p>Returns an empty DataFrame (with the sto
       <span class="symbol">
         <span class="name">createBloomFilterUdf</span><span class="params">(<span name="fprValue">fprValue: <span class="extype" name="scala.Double">Double</span></span>)</span><span class="result">: <span class="extype" name="org.apache.spark.sql.expressions.UserDefinedFunction">UserDefinedFunction</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Creates a Spark UDF that converts a collected set of values into a serialized bloom filter.</p><div class="fullcomment"><div class="comment cmt"><p>Creates a Spark UDF that converts a collected set of values into a serialized bloom filter.</p><p>The UDF is designed for use inside <code>agg(bloomUdf(collect_set(...)))</code>. It:</p><ol class="decimal"><li>Filters out null values from the input sequence 2. Creates a Guava <code>BloomFilter</code> sized for the actual number
      of non-null elements 3. Inserts each value (converted to <code>String</code>) into the filter 4. Serializes the filter to
      <code>Array[Byte]</code> via <code>ByteArrayOutputStream</code></li></ol><p>The <code>fprValue</code> parameter is captured as a local <code>val</code> to ensure it is serializable when the UDF closure is shipped
@@ -733,7 +733,7 @@ to Spark executors.
 </p></div><dl class="paramcmts block"><dt class="param">fprValue</dt><dd class="cmt"><p>
   the desired false positive rate (e.g., 0.01 for 1%); must be strictly between 0 and 1 (exclusive)</p></dd><dt>returns</dt><dd class="cmt"><p>
   a UDF that accepts <code>Seq[Any]</code> (from <code>collect_set</code>) and returns <code>Array[Byte]</code>, or <code>null</code> if the input is null or
-  contains only nulls</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+  contains only nulls</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if <code>fprValue</code> is not in the range (0, 1)</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#debugEnabled" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="debugEnabled:Boolean"></a>
@@ -749,7 +749,7 @@ to Spark executors.
       <span class="symbol">
         <span class="name">debugEnabled</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">When true, logs detailed diagnostics during join operations including partition counts, physical plans, and
 per-phase timing.</p><div class="fullcomment"><div class="comment cmt"><p>When true, logs detailed diagnostics during join operations including partition counts, physical plans, and
 per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
@@ -768,12 +768,12 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">delete</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Deletes a path recursively from the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Deletes a path recursively from the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to delete</p></dd><dt>returns</dt><dd class="cmt"><p>
-  true if the path was successfully deleted</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  true if the path was successfully deleted</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the filesystem operation fails</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#delta" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="delta(path:org.apache.hadoop.fs.Path):Option[io.delta.tables.DeltaTable]"></a><a id="delta(Path):Option[DeltaTable]"></a>
@@ -789,7 +789,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">delta</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="io.delta.tables.DeltaTable">DeltaTable</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns a <span class="extype" name="io.delta.tables.DeltaTable">io.delta.tables.DeltaTable</span> if the path exists and contains valid Delta metadata.</p><div class="fullcomment"><div class="comment cmt"><p>Returns a <span class="extype" name="io.delta.tables.DeltaTable">io.delta.tables.DeltaTable</span> if the path exists and contains valid Delta metadata.</p><p>If the path exists but is <i>not</i> a valid Delta table (e.g., leftover partial write), the directory is deleted and
 <code>None</code> is returned so it can be recreated cleanly on the next write.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
@@ -809,12 +809,12 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">deserializeBloomFilter</span><span class="params">(<span name="bytes">bytes: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Byte">Byte</span>]</span>)</span><span class="result">: <span class="extype" name="com.google.common.hash.BloomFilter">BloomFilter</span>[<span class="extype" name="java.lang.CharSequence">CharSequence</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Deserializes a Guava bloom filter from its byte representation.</p><div class="fullcomment"><div class="comment cmt"><p>Deserializes a Guava bloom filter from its byte representation.</p><p>Uses <code>BloomFilter.readFrom</code> with a UTF-8 <code>StringFunnel</code>, which must match the funnel used during creation in
 <a href="#createBloomFilterUdf(fprValue:Double):org.apache.spark.sql.expressions.UserDefinedFunction" class="extmbr" name="dev.cjfravel.ariadne.BloomFilterOperations#createBloomFilterUdf">createBloomFilterUdf</a>.
 </p></div><dl class="paramcmts block"><dt class="param">bytes</dt><dd class="cmt"><p>
   serialized bloom filter bytes (produced by <code>BloomFilter.writeTo</code>)</p></dd><dt>returns</dt><dd class="cmt"><p>
-  a <code>BloomFilter[CharSequence]</code> instance ready for membership queries</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  a <code>BloomFilter[CharSequence]</code> instance ready for membership queries</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the byte array is malformed or corrupted</p></span></dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -830,7 +830,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -846,7 +846,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#exists" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exists(path:org.apache.hadoop.fs.Path):Boolean"></a><a id="exists(Path):Boolean"></a>
@@ -862,12 +862,12 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">exists</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks if a path exists on the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Checks if a path exists on the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to check</p></dd><dt>returns</dt><dd class="cmt"><p>
-  true if the path exists</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  true if the path exists</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the filesystem operation fails</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadataOperations#format" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="format:String"></a>
@@ -883,7 +883,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">format</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the file format of the indexed data (e.g., &quot;parquet&quot;, &quot;csv&quot;, &quot;json&quot;).</p><div class="fullcomment"><div class="comment cmt"><p>Returns the file format of the indexed data (e.g., &quot;parquet&quot;, &quot;csv&quot;, &quot;json&quot;).</p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   the format string from the stored metadata</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#fs" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -900,7 +900,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">fs</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.FileSystem">FileSystem</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop <code>FileSystem</code> instance resolved from the <a href="AriadneContextUser.html#storagePath:org.apache.hadoop.fs.Path" class="extmbr" name="dev.cjfravel.ariadne.AriadneContextUser#storagePath">storagePath</a> URI and the Spark Hadoop configuration.</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop <code>FileSystem</code> instance resolved from the <a href="AriadneContextUser.html#storagePath:org.apache.hadoop.fs.Path" class="extmbr" name="dev.cjfravel.ariadne.AriadneContextUser#storagePath">storagePath</a> URI and the Spark Hadoop configuration. Used for all
 filesystem operations (existence checks, reads, deletes, lock files).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -918,12 +918,12 @@ filesystem operations (existence checks, reads, deletes, lock files).
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -939,12 +939,12 @@ filesystem operations (existence checks, reads, deletes, lock files).
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#indexRepartitionCount" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="indexRepartitionCount:Option[Int]"></a>
@@ -960,7 +960,7 @@ filesystem operations (existence checks, reads, deletes, lock files).
       <span class="symbol">
         <span class="name">indexRepartitionCount</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Int">Int</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Optional number of partitions to use when repartitioning the index DataFrame during joins.</p><div class="fullcomment"><div class="comment cmt"><p>Optional number of partitions to use when repartitioning the index DataFrame during joins. When set, the index
 DataFrame is repartitioned before expensive operations like explode to reduce per-executor memory pressure and
 avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepartitionCount configuration
@@ -980,7 +980,7 @@ avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepa
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#largeIndexLimit" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="largeIndexLimit:Long"></a>
@@ -996,7 +996,7 @@ avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepa
       <span class="symbol">
         <span class="name">largeIndexLimit</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Maximum number of distinct values per file before an index column is promoted to a &quot;large index&quot; (stored in a
 separate exploded Delta table).</p><div class="fullcomment"><div class="comment cmt"><p>Maximum number of distinct values per file before an index column is promoted to a &quot;large index&quot; (stored in a
 separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</code> (default: 500000).</p><p>If the configured value is not a valid positive number, a warning is logged and the default of 500,000 is used.
@@ -1015,7 +1015,7 @@ separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</
       <span class="symbol">
         <span class="name">locateFilesWithBloom</span><span class="params">(<span name="column">column: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="values">values: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Any">Any</span>]</span>, <span name="indexDf">indexDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Locates files that might contain any of the given values using bloom filters.</p><div class="fullcomment"><div class="comment cmt"><p>Locates files that might contain any of the given values using bloom filters.</p><p>Collects all rows from the index, deserializes each file's bloom filter for the specified column, and tests every
 candidate value. A file is included in the result if any value passes the <code>mightContain</code> check.
 </p></div><dl class="paramcmts block"><dt class="param">column</dt><dd class="cmt"><p>
@@ -1041,7 +1041,7 @@ candidate value. A file is included in the result if any value passes the <code>
       <span class="symbol">
         <span class="name">locateFilesWithBloomFromDataFrame</span><span class="params">(<span name="column">column: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="valuesDf">valuesDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="indexDf">indexDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Locates files that might contain values from a DataFrame using bloom filters.</p><div class="fullcomment"><div class="comment cmt"><p>Locates files that might contain values from a DataFrame using bloom filters.</p><p>Collects distinct non-null values from the specified column of <code>valuesDf</code>, then delegates to
 <a href="#locateFilesWithBloom(column:String,values:Array[Any],indexDf:org.apache.spark.sql.DataFrame):Set[String]" class="extmbr" name="dev.cjfravel.ariadne.BloomFilterOperations#locateFilesWithBloom">locateFilesWithBloom</a> for the actual bloom filter check.
 </p></div><dl class="paramcmts block"><dt class="param">column</dt><dd class="cmt"><p>
@@ -1067,7 +1067,7 @@ candidate value. A file is included in the result if any value passes the <code>
       <span class="symbol">
         <span class="name">lockMaxWait</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Maximum total time in seconds to wait for lock acquisition before failing.</p><div class="fullcomment"><div class="comment cmt"><p>Maximum total time in seconds to wait for lock acquisition before failing. Reads from spark.ariadne.lockMaxWait
 configuration (default: 3600).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Note</dt><dd><span class="cmt"><p>
@@ -1087,7 +1087,7 @@ configuration (default: 3600).
       <span class="symbol">
         <span class="name">lockRefreshInterval</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Refresh the update lock every N batches during updateBatched.</p><div class="fullcomment"><div class="comment cmt"><p>Refresh the update lock every N batches during updateBatched. Reads from spark.ariadne.lockRefreshInterval
 configuration (default: 1).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -1105,7 +1105,7 @@ configuration (default: 1).
       <span class="symbol">
         <span class="name">lockRetryInterval</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Base interval in seconds between lock acquisition retries (exponential backoff applied).</p><div class="fullcomment"><div class="comment cmt"><p>Base interval in seconds between lock acquisition retries (exponential backoff applied). Reads from
 spark.ariadne.lockRetryInterval configuration (default: 60).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -1123,7 +1123,7 @@ spark.ariadne.lockRetryInterval configuration (default: 60).
       <span class="symbol">
         <span class="name">lockTimeout</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Seconds since <code>lastRefreshedAt</code> before a lock is considered stale and eligible for auto-heal (forcible acquisition
 by another process).</p><div class="fullcomment"><div class="comment cmt"><p>Seconds since <code>lastRefreshedAt</code> before a lock is considered stale and eligible for auto-heal (forcible acquisition
 by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default: 1800).
@@ -1142,7 +1142,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">logger</span><span class="result">: <span class="extype" name="org.apache.logging.log4j.Logger">Logger</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Log4j logger shared by all Ariadne components.</p><div class="fullcomment"><div class="comment cmt"><p>Log4j logger shared by all Ariadne components. Uses the &quot;ariadne&quot; logger name. Marked <code>@transient lazy</code> so that
 <code>Index</code> (a case class) remains serializable across Spark stages — Log4j loggers are not <code>Serializable</code>.
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a> → <a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -1160,7 +1160,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">metadataExists</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks if metadata exists in the storage location.</p><div class="fullcomment"><div class="comment cmt"><p>Checks if metadata exists in the storage location.</p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   True if metadata exists, otherwise false.</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadataOperations#metadataFilePath" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -1177,7 +1177,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">metadataFilePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop path for the metadata file.</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop path for the metadata file.</p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   the path to <code>metadata.json</code> under the index storage directory</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -1194,7 +1194,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -1210,12 +1210,12 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -1231,12 +1231,12 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#open" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="open(path:org.apache.hadoop.fs.Path):org.apache.hadoop.fs.FSDataInputStream"></a><a id="open(Path):FSDataInputStream"></a>
@@ -1252,12 +1252,12 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">open</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.FSDataInputStream">FSDataInputStream</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Opens an input stream to read from a path on the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Opens an input stream to read from a path on the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to open for reading</p></dd><dt>returns</dt><dd class="cmt"><p>
-  An FSDataInputStream for reading the file contents</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  An FSDataInputStream for reading the file contents</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the file does not exist or cannot be opened</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadataOperations#refreshMetadata" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="refreshMetadata():Unit"></a>
@@ -1273,10 +1273,10 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">refreshMetadata</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Forces a reload of metadata from the <code>metadata.json</code> file on disk.</p><div class="fullcomment"><div class="comment cmt"><p>Forces a reload of metadata from the <code>metadata.json</code> file on disk.</p><p>Replaces the in-memory cached metadata with a freshly deserialized copy. This is called automatically by
 <span class="extype" name="metadata">metadata</span> on first access; callers may invoke it explicitly to pick up external changes.
-</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="MetadataMissingOrCorruptException"><code>MetadataMissingOrCorruptException</code></span>
+</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="MetadataMissingOrCorruptException"><code>MetadataMissingOrCorruptException</code></span> 
   if the metadata file does not exist, cannot be read, or contains invalid JSON</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#repartitionDataFiles" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="repartitionDataFiles:Boolean"></a>
@@ -1292,7 +1292,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">repartitionDataFiles</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">When true, applies indexRepartitionCount repartitioning to the data files read during joinDf.</p><div class="fullcomment"><div class="comment cmt"><p>When true, applies indexRepartitionCount repartitioning to the data files read during joinDf. When false, data
 files keep their natural parquet partitioning. Disable when column selection significantly reduces data volume,
 making the repartition shuffle more expensive than useful. Reads from spark.ariadne.repartitionDataFiles
@@ -1312,7 +1312,7 @@ configuration (default: false).
       <span class="symbol">
         <span class="name">safeDestroyBroadcast</span><span class="params">(<span name="broadcast">broadcast: <span class="extype" name="org.apache.spark.broadcast.Broadcast">Broadcast</span>[_]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Safely destroys a broadcast variable, logging but swallowing any exception.</p><div class="fullcomment"><div class="comment cmt"><p>Safely destroys a broadcast variable, logging but swallowing any exception.</p><p>Intended for use inside <code>finally</code> blocks where a cleanup failure must not mask the original exception propagating
 out of the <code>try</code> block. Tolerates a null broadcast.
 </p></div><dl class="paramcmts block"><dt class="param">broadcast</dt><dd class="cmt"><p>
@@ -1331,7 +1331,7 @@ out of the <code>try</code> block. Tolerates a null broadcast.
       <span class="symbol">
         <span class="name">stagingConsolidationThreshold</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Number of batches to process before consolidating staged data into the main index.</p><div class="fullcomment"><div class="comment cmt"><p>Number of batches to process before consolidating staged data into the main index. This provides fault tolerance
 for large index builds - if a job fails, work is preserved up to the last consolidation point. Reads from
 spark.ariadne.stagingConsolidationThreshold configuration (default: 50).
@@ -1350,10 +1350,10 @@ spark.ariadne.stagingConsolidationThreshold configuration (default: 50).
       <span class="symbol">
         <span class="name">storagePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Base path on the Hadoop-compatible filesystem where all Ariadne index data is stored.</p><div class="fullcomment"><div class="comment cmt"><p>Base path on the Hadoop-compatible filesystem where all Ariadne index data is stored. Each index creates a
 subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</code> (required — no default).
-</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if the configuration key is not set</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexFileOperations#storedSchema" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="storedSchema:org.apache.spark.sql.types.StructType"></a><a id="storedSchema:StructType"></a>
@@ -1369,14 +1369,14 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name">storedSchema</span><span class="result">: <span class="extype" name="org.apache.spark.sql.types.StructType">StructType</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the stored schema of the index.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the stored schema of the index.</p><p>Parses the JSON schema string from metadata into a Spark StructType.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   The StructType schema parsed from metadata</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a></dd><div class="block">Example:
                <ol><li class="cmt"><p></p><pre><span class="kw">val</span> schema = index.storedSchema
 schema.printTreeString()</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="SchemaParseException"><code>SchemaParseException</code></span>
-  if the schema string cannot be parsed as a StructType</p></span><span class="cmt"><p><a href="exceptions/MissingSchemaException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.MissingSchemaException"><code>dev.cjfravel.ariadne.exceptions.MissingSchemaException</code></a>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="SchemaParseException"><code>SchemaParseException</code></span> 
+  if the schema string cannot be parsed as a StructType</p></span><span class="cmt"><p><a href="exceptions/MissingSchemaException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.MissingSchemaException"><code>dev.cjfravel.ariadne.exceptions.MissingSchemaException</code></a> 
   if the schema is null in metadata</p></span></dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -1392,7 +1392,7 @@ schema.printTreeString()</pre></li></ol>
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -1408,7 +1408,7 @@ schema.printTreeString()</pre></li></ol>
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -1424,13 +1424,13 @@ schema.printTreeString()</pre></li></ol>
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -1446,15 +1446,15 @@ schema.printTreeString()</pre></li></ol>
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -1470,13 +1470,13 @@ schema.printTreeString()</pre></li></ol>
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadataOperations#writeMetadata" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="writeMetadata(metadata:dev.cjfravel.ariadne.IndexMetadata):Unit"></a><a id="writeMetadata(IndexMetadata):Unit"></a>
@@ -1492,19 +1492,19 @@ schema.printTreeString()</pre></li></ol>
       <span class="symbol">
         <span class="name">writeMetadata</span><span class="params">(<span name="metadata">metadata: <a href="IndexMetadata.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadata">IndexMetadata</a></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Writes metadata to the <code>metadata.json</code> file and updates the in-memory cache.</p><div class="fullcomment"><div class="comment cmt"><p>Writes metadata to the <code>metadata.json</code> file and updates the in-memory cache.</p><p>Creates the parent directory if it does not exist. JSON is written and validated at a unique sibling path, then
 replaced through Hadoop's overwrite rename operation. The replacement is atomic on filesystems with atomic rename
 semantics (such as HDFS); object-store connectors may implement rename as copy/delete and cannot provide the same
 guarantee.
 </p></div><dl class="paramcmts block"><dt class="param">metadata</dt><dd class="cmt"><p>
-  the metadata instance to serialize and persist</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  the metadata instance to serialize and persist</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the write fails (the error is logged before propagating)</p></span></dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -1522,15 +1522,15 @@ guarantee.
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -1548,13 +1548,13 @@ guarantee.
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/BloomIndexConfig.html
+++ b/docs/api/dev/cjfravel/ariadne/BloomIndexConfig.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.BloomIndexConfig" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.BloomIndexConfig" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="catalog/index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -147,7 +147,7 @@
       <span class="symbol">
         <a title="" href="exceptions/index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented3">
                         <span class="separator"></span>
@@ -256,7 +256,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Configuration for a bloom filter index.</p><p>Bloom filters are probabilistic data structures that provide:</p><ul><li>Guaranteed NO false negatives (if filter says &quot;no&quot;, value definitely absent)</li><li>Configurable false positive rate (if filter says &quot;yes&quot;, value MIGHT be present)</li><li>Space-efficient storage (approximately 10 bits per element at 1% FPR)
 </li></ul></div><dl class="paramcmts block"><dt class="param">column</dt><dd class="cmt"><p>
   The column name to create a bloom filter for</p></dd><dt class="param">fpr</dt><dd class="cmt"><p>
@@ -266,7 +266,7 @@
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="scala.Serializable">Serializable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.Product">Product</span>, <span class="extype" name="scala.Equals">Equals</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -281,7 +281,7 @@
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -324,16 +324,16 @@
       <span class="symbol">
         <span class="name">BloomIndexConfig</span><span class="params">(<span name="column">column: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="fpr">fpr: <span class="extype" name="scala.Double">Double</span> = <span class="symbol">0.01</span></span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">column</dt><dd class="cmt"><p>
   The column name to create a bloom filter for</p></dd><dt class="param">fpr</dt><dd class="cmt"><p>
   False positive rate (0.0 to 1.0, default 0.01 = 1%)</p></dd></dl></div>
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -352,7 +352,7 @@
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -368,7 +368,7 @@
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -384,7 +384,7 @@
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -400,7 +400,7 @@
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -416,17 +416,17 @@
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.BloomIndexConfig#column" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="column:String"></a>
@@ -442,8 +442,8 @@
       <span class="symbol">
         <span class="name">column</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
       <span class="permalink">
@@ -458,7 +458,7 @@
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.BloomIndexConfig#fpr" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="fpr:Double"></a>
@@ -474,8 +474,8 @@
       <span class="symbol">
         <span class="name">fpr</span><span class="result">: <span class="extype" name="scala.Double">Double</span></span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
       <span class="permalink">
@@ -490,12 +490,12 @@
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -511,7 +511,7 @@
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -527,7 +527,7 @@
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -543,12 +543,12 @@
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -564,12 +564,12 @@
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -585,7 +585,7 @@
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -601,13 +601,13 @@
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -623,15 +623,15 @@
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -647,19 +647,19 @@
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -677,15 +677,15 @@
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -705,13 +705,13 @@
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/ExplodedFieldMapping.html
+++ b/docs/api/dev/cjfravel/ariadne/ExplodedFieldMapping.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.ExplodedFieldMapping" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.ExplodedFieldMapping" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="catalog/index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -147,7 +147,7 @@
       <span class="symbol">
         <a title="" href="exceptions/index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented3">
                         <span class="separator"></span>
@@ -256,7 +256,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Represents a mapping for exploded field index configuration.</p><p>This case class defines how to extract and index fields from array elements. It maps array elements to a flat
 structure that can be used for efficient joins by exploding the array and indexing specific fields within each
 element.
@@ -273,7 +273,7 @@ element.
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="scala.Serializable">Serializable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.Product">Product</span>, <span class="extype" name="scala.Equals">Equals</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -288,7 +288,7 @@ element.
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -331,7 +331,7 @@ element.
       <span class="symbol">
         <span class="name">ExplodedFieldMapping</span><span class="params">(<span name="array_column">array_column: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="field_path">field_path: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="as_column">as_column: <span class="extype" name="scala.Predef.String">String</span></span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">array_column</dt><dd class="cmt"><p>
   The name of the array column in the schema</p></dd><dt class="param">field_path</dt><dd class="cmt"><p>
   The field path to extract from each array element (e.g., &quot;id&quot;, &quot;profile.user_id&quot;)</p></dd><dt class="param">as_column</dt><dd class="cmt"><p>
@@ -339,9 +339,9 @@ element.
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -360,7 +360,7 @@ element.
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -376,7 +376,7 @@ element.
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -392,7 +392,7 @@ element.
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.ExplodedFieldMapping#array_column" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="array_column:String"></a>
@@ -408,8 +408,8 @@ element.
       <span class="symbol">
         <span class="name">array_column</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
       <span class="permalink">
@@ -424,7 +424,7 @@ element.
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.ExplodedFieldMapping#as_column" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="as_column:String"></a>
@@ -440,8 +440,8 @@ element.
       <span class="symbol">
         <span class="name">as_column</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
       <span class="permalink">
@@ -456,17 +456,17 @@ element.
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -482,7 +482,7 @@ element.
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.ExplodedFieldMapping#field_path" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="field_path:String"></a>
@@ -498,8 +498,8 @@ element.
       <span class="symbol">
         <span class="name">field_path</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
       <span class="permalink">
@@ -514,12 +514,12 @@ element.
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -535,7 +535,7 @@ element.
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -551,7 +551,7 @@ element.
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -567,12 +567,12 @@ element.
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -588,12 +588,12 @@ element.
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -609,7 +609,7 @@ element.
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -625,13 +625,13 @@ element.
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -647,15 +647,15 @@ element.
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -671,19 +671,19 @@ element.
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -701,15 +701,15 @@ element.
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -729,13 +729,13 @@ element.
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/FileList$.html
+++ b/docs/api/dev/cjfravel/ariadne/FileList$.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.FileList" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.FileList" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="catalog/index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -147,7 +147,7 @@
       <span class="symbol">
         <a title="" href="exceptions/index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented3">
                         <span class="separator"></span>
@@ -258,7 +258,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Factory and utility methods for FileList instances.</p><p>Provides path resolution, existence checks, and removal operations for file lists stored as Delta tables.
 </p></div><div class="toggleContainer block">
           <span class="toggle">
@@ -266,7 +266,7 @@
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="scala.Serializable">Serializable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -281,7 +281,7 @@
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -308,11 +308,11 @@
 
       <div id="template">
         <div id="allMembers">
+        
 
+        
 
-
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -331,7 +331,7 @@
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -347,7 +347,7 @@
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -363,7 +363,7 @@
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.FileList#apply" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="apply(name:String)(implicitspark:org.apache.spark.sql.SparkSession):dev.cjfravel.ariadne.FileList"></a><a id="apply(String)(SparkSession):FileList"></a>
@@ -379,12 +379,12 @@
       <span class="symbol">
         <span class="name">apply</span><span class="params">(<span name="name">name: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="params">(<span class="implicit">implicit </span><span name="spark">spark: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span><span class="result">: <a href="FileList.html" class="extype" name="dev.cjfravel.ariadne.FileList">FileList</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Creates a new <a href="FileList.html" class="extype" name="dev.cjfravel.ariadne.FileList">FileList</a> instance for the given name.</p><div class="fullcomment"><div class="comment cmt"><p>Creates a new <a href="FileList.html" class="extype" name="dev.cjfravel.ariadne.FileList">FileList</a> instance for the given name.
 </p></div><dl class="paramcmts block"><dt class="param">name</dt><dd class="cmt"><p>
   the file list name</p></dd><dt class="param">spark</dt><dd class="cmt"><p>
   the implicit SparkSession</p></dd><dt>returns</dt><dd class="cmt"><p>
-  a new FileList backed by a Delta table at <code>storagePath/name</code></p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+  a new FileList backed by a Delta table at <code>storagePath/name</code></p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if name is null or blank</p></span></dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -400,7 +400,7 @@
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -416,17 +416,17 @@
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -442,7 +442,7 @@
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -458,7 +458,7 @@
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.FileList#exists" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exists(name:String)(implicitsparkSession:org.apache.spark.sql.SparkSession):Boolean"></a><a id="exists(String)(SparkSession):Boolean"></a>
@@ -474,12 +474,12 @@
       <span class="symbol">
         <span class="name">exists</span><span class="params">(<span name="name">name: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="params">(<span class="implicit">implicit </span><span name="sparkSession">sparkSession: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks if a file list with the given name exists on storage.</p><div class="fullcomment"><div class="comment cmt"><p>Checks if a file list with the given name exists on storage.
 </p></div><dl class="paramcmts block"><dt class="param">name</dt><dd class="cmt"><p>
   the file list name</p></dd><dt class="param">sparkSession</dt><dd class="cmt"><p>
   the implicit SparkSession</p></dd><dt>returns</dt><dd class="cmt"><p>
-  true if the Delta table directory exists</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+  true if the Delta table directory exists</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if name is null or blank</p></span></dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -495,12 +495,12 @@
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -516,12 +516,12 @@
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -537,7 +537,7 @@
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -553,7 +553,7 @@
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -569,12 +569,12 @@
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -590,12 +590,12 @@
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.FileList#remove" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="remove(name:String)(implicitsparkSession:org.apache.spark.sql.SparkSession):Boolean"></a><a id="remove(String)(SparkSession):Boolean"></a>
@@ -611,13 +611,13 @@
       <span class="symbol">
         <span class="name">remove</span><span class="params">(<span name="name">name: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="params">(<span class="implicit">implicit </span><span name="sparkSession">sparkSession: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Removes a file list's Delta table from storage.</p><div class="fullcomment"><div class="comment cmt"><p>Removes a file list's Delta table from storage.
 </p></div><dl class="paramcmts block"><dt class="param">name</dt><dd class="cmt"><p>
   the file list name</p></dd><dt class="param">sparkSession</dt><dd class="cmt"><p>
   the implicit SparkSession</p></dd><dt>returns</dt><dd class="cmt"><p>
-  true if deletion was successful</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="FileListNotFoundException"><code>FileListNotFoundException</code></span>
-  if the file list does not exist</p></span><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+  true if deletion was successful</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="FileListNotFoundException"><code>FileListNotFoundException</code></span> 
+  if the file list does not exist</p></span><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if name is null or blank</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.FileList#storagePath" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="storagePath(implicitsparkSession:org.apache.spark.sql.SparkSession):org.apache.hadoop.fs.Path"></a><a id="storagePath(SparkSession):Path"></a>
@@ -633,7 +633,7 @@
       <span class="symbol">
         <span class="name">storagePath</span><span class="params">(<span class="implicit">implicit </span><span name="sparkSession">sparkSession: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the base storage path for all file lists.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the base storage path for all file lists.
 </p></div><dl class="paramcmts block"><dt class="param">sparkSession</dt><dd class="cmt"><p>
   the implicit SparkSession</p></dd><dt>returns</dt><dd class="cmt"><p>
@@ -652,7 +652,7 @@
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -668,7 +668,7 @@
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -684,13 +684,13 @@
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -706,15 +706,15 @@
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -730,19 +730,19 @@
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -760,15 +760,15 @@
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -784,13 +784,13 @@
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/FileList.html
+++ b/docs/api/dev/cjfravel/ariadne/FileList.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.FileList" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.FileList" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="catalog/index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -147,7 +147,7 @@
       <span class="symbol">
         <a title="" href="exceptions/index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented3">
                         <span class="separator"></span>
@@ -258,7 +258,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Manages a tracked list of files associated with an Ariadne index.</p><p>Each file list is persisted as a Delta Lake table with two columns:</p><ul><li><code>filename</code> (<code>StringType</code>, not nullable) — the file path</li><li><code>addedAt</code> (<code>TimestampType</code>, not nullable) — when the file was registered</li></ul><p>The DataFrame is lazily loaded and cached in memory after the first access. Mutations (add, remove) invalidate the
 cache so the next read re-loads from the Delta table.</p><p><b>Thread safety:</b> <code>FileList</code> instances are <b>not</b> thread-safe. The mutable <code>_files</code> cache can produce
 inconsistent results if accessed concurrently from multiple threads. Each thread should use its own instance, or
@@ -269,7 +269,7 @@ external synchronization must be applied.
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="scala.Serializable">Serializable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.Product">Product</span>, <span class="extype" name="scala.Equals">Equals</span>, <a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -284,7 +284,7 @@ external synchronization must be applied.
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -311,11 +311,11 @@ external synchronization must be applied.
 
       <div id="template">
         <div id="allMembers">
+        
 
+        
 
-
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -334,7 +334,7 @@ external synchronization must be applied.
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -350,7 +350,7 @@ external synchronization must be applied.
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -366,7 +366,7 @@ external synchronization must be applied.
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.FileList#addFile" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addFile(fileNames:String*):Unit"></a><a id="addFile(String*):Unit"></a>
@@ -382,11 +382,11 @@ external synchronization must be applied.
       <span class="symbol">
         <span class="name">addFile</span><span class="params">(<span name="fileNames">fileNames: <span class="extype" name="scala.Predef.String">String</span>*</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Registers new files in the file list.</p><div class="fullcomment"><div class="comment cmt"><p>Registers new files in the file list.</p><p>Files already present are silently skipped. The additions are written to the Delta table immediately; if the write
 fails, the in-memory cache is rolled back to its previous state.
 </p></div><dl class="paramcmts block"><dt class="param">fileNames</dt><dd class="cmt"><p>
-  one or more file paths to add</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+  one or more file paths to add</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if fileNames is null or any individual file name is null or blank</p></span></dd><dt>Note</dt><dd><span class="cmt"><p>
   Collects all existing filenames to the driver for duplicate detection. May cause driver OOM for indexes tracking
   millions of files.</p></span></dd></dl></div>
@@ -404,7 +404,7 @@ fails, the in-memory cache is rolled back to its previous state.
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#autoBloomFpr" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="autoBloomFpr:Double"></a>
@@ -420,7 +420,7 @@ fails, the in-memory cache is rolled back to its previous state.
       <span class="symbol">
         <span class="name">autoBloomFpr</span><span class="result">: <span class="extype" name="scala.Double">Double</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">False positive rate for auto-bloom filters on large index columns.</p><div class="fullcomment"><div class="comment cmt"><p>False positive rate for auto-bloom filters on large index columns. When a column exceeds largeIndexLimit, an
 auto-bloom filter is built with this FPR to enable file pruning at query time. Reads from
 spark.ariadne.autoBloomFpr configuration (default: 0.01).
@@ -439,7 +439,7 @@ spark.ariadne.autoBloomFpr configuration (default: 0.01).
       <span class="symbol">
         <span class="name">autoCompactThreshold</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Int">Int</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Optional threshold for auto-compaction.</p><div class="fullcomment"><div class="comment cmt"><p>Optional threshold for auto-compaction. When set, the main index Delta table is compacted after an update if the
 number of Delta log JSON files meets or exceeds this value. Reads from spark.ariadne.autoCompactThreshold
 configuration (default: not set).
@@ -458,17 +458,17 @@ configuration (default: not set).
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#debugEnabled" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="debugEnabled:Boolean"></a>
@@ -484,7 +484,7 @@ configuration (default: not set).
       <span class="symbol">
         <span class="name">debugEnabled</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">When true, logs detailed diagnostics during join operations including partition counts, physical plans, and
 per-phase timing.</p><div class="fullcomment"><div class="comment cmt"><p>When true, logs detailed diagnostics during join operations including partition counts, physical plans, and
 per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
@@ -503,12 +503,12 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">delete</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Deletes a path recursively from the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Deletes a path recursively from the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to delete</p></dd><dt>returns</dt><dd class="cmt"><p>
-  true if the path was successfully deleted</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  true if the path was successfully deleted</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the filesystem operation fails</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#delta" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="delta(path:org.apache.hadoop.fs.Path):Option[io.delta.tables.DeltaTable]"></a><a id="delta(Path):Option[DeltaTable]"></a>
@@ -524,7 +524,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">delta</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="io.delta.tables.DeltaTable">DeltaTable</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns a <span class="extype" name="io.delta.tables.DeltaTable">io.delta.tables.DeltaTable</span> if the path exists and contains valid Delta metadata.</p><div class="fullcomment"><div class="comment cmt"><p>Returns a <span class="extype" name="io.delta.tables.DeltaTable">io.delta.tables.DeltaTable</span> if the path exists and contains valid Delta metadata.</p><p>If the path exists but is <i>not</i> a valid Delta table (e.g., leftover partial write), the directory is deleted and
 <code>None</code> is returned so it can be recreated cleanly on the next write.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
@@ -544,7 +544,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#exists" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exists(path:org.apache.hadoop.fs.Path):Boolean"></a><a id="exists(Path):Boolean"></a>
@@ -560,12 +560,12 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">exists</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks if a path exists on the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Checks if a path exists on the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to check</p></dd><dt>returns</dt><dd class="cmt"><p>
-  true if the path exists</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  true if the path exists</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the filesystem operation fails</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.FileList#files" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="files:org.apache.spark.sql.DataFrame"></a><a id="files:DataFrame"></a>
@@ -581,7 +581,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">files</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the DataFrame of tracked files with filename and addedAt columns.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the DataFrame of tracked files with filename and addedAt columns.</p><p>Lazily loaded from the Delta table on first access; subsequent calls return the cached DataFrame until the cache is
 invalidated by a mutation.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
@@ -600,7 +600,7 @@ invalidated by a mutation.
       <span class="symbol">
         <span class="name">fs</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.FileSystem">FileSystem</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop <code>FileSystem</code> instance resolved from the <a href="AriadneContextUser.html#storagePath:org.apache.hadoop.fs.Path" class="extmbr" name="dev.cjfravel.ariadne.AriadneContextUser#storagePath">storagePath</a> URI and the Spark Hadoop configuration.</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop <code>FileSystem</code> instance resolved from the <a href="AriadneContextUser.html#storagePath:org.apache.hadoop.fs.Path" class="extmbr" name="dev.cjfravel.ariadne.AriadneContextUser#storagePath">storagePath</a> URI and the Spark Hadoop configuration. Used for all
 filesystem operations (existence checks, reads, deletes, lock files).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -618,12 +618,12 @@ filesystem operations (existence checks, reads, deletes, lock files).
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.FileList#hasFile" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hasFile(fileName:String):Boolean"></a><a id="hasFile(String):Boolean"></a>
@@ -639,11 +639,11 @@ filesystem operations (existence checks, reads, deletes, lock files).
       <span class="symbol">
         <span class="name">hasFile</span><span class="params">(<span name="fileName">fileName: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks if a specific file is tracked in this file list.</p><div class="fullcomment"><div class="comment cmt"><p>Checks if a specific file is tracked in this file list.
 </p></div><dl class="paramcmts block"><dt class="param">fileName</dt><dd class="cmt"><p>
   the file path to check</p></dd><dt>returns</dt><dd class="cmt"><p>
-  true if the file exists in the list</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+  true if the file exists in the list</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if fileName is null or blank</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#indexRepartitionCount" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="indexRepartitionCount:Option[Int]"></a>
@@ -659,7 +659,7 @@ filesystem operations (existence checks, reads, deletes, lock files).
       <span class="symbol">
         <span class="name">indexRepartitionCount</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Int">Int</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Optional number of partitions to use when repartitioning the index DataFrame during joins.</p><div class="fullcomment"><div class="comment cmt"><p>Optional number of partitions to use when repartitioning the index DataFrame during joins. When set, the index
 DataFrame is repartitioned before expensive operations like explode to reduce per-executor memory pressure and
 avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepartitionCount configuration
@@ -679,7 +679,7 @@ avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepa
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#largeIndexLimit" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="largeIndexLimit:Long"></a>
@@ -695,7 +695,7 @@ avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepa
       <span class="symbol">
         <span class="name">largeIndexLimit</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Maximum number of distinct values per file before an index column is promoted to a &quot;large index&quot; (stored in a
 separate exploded Delta table).</p><div class="fullcomment"><div class="comment cmt"><p>Maximum number of distinct values per file before an index column is promoted to a &quot;large index&quot; (stored in a
 separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</code> (default: 500000).</p><p>If the configured value is not a valid positive number, a warning is logged and the default of 500,000 is used.
@@ -714,7 +714,7 @@ separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</
       <span class="symbol">
         <span class="name">lockMaxWait</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Maximum total time in seconds to wait for lock acquisition before failing.</p><div class="fullcomment"><div class="comment cmt"><p>Maximum total time in seconds to wait for lock acquisition before failing. Reads from spark.ariadne.lockMaxWait
 configuration (default: 3600).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Note</dt><dd><span class="cmt"><p>
@@ -734,7 +734,7 @@ configuration (default: 3600).
       <span class="symbol">
         <span class="name">lockRefreshInterval</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Refresh the update lock every N batches during updateBatched.</p><div class="fullcomment"><div class="comment cmt"><p>Refresh the update lock every N batches during updateBatched. Reads from spark.ariadne.lockRefreshInterval
 configuration (default: 1).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -752,7 +752,7 @@ configuration (default: 1).
       <span class="symbol">
         <span class="name">lockRetryInterval</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Base interval in seconds between lock acquisition retries (exponential backoff applied).</p><div class="fullcomment"><div class="comment cmt"><p>Base interval in seconds between lock acquisition retries (exponential backoff applied). Reads from
 spark.ariadne.lockRetryInterval configuration (default: 60).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -770,7 +770,7 @@ spark.ariadne.lockRetryInterval configuration (default: 60).
       <span class="symbol">
         <span class="name">lockTimeout</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Seconds since <code>lastRefreshedAt</code> before a lock is considered stale and eligible for auto-heal (forcible acquisition
 by another process).</p><div class="fullcomment"><div class="comment cmt"><p>Seconds since <code>lastRefreshedAt</code> before a lock is considered stale and eligible for auto-heal (forcible acquisition
 by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default: 1800).
@@ -789,7 +789,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">logger</span><span class="result">: <span class="extype" name="org.apache.logging.log4j.Logger">Logger</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Log4j logger shared by all Ariadne components.</p><div class="fullcomment"><div class="comment cmt"><p>Log4j logger shared by all Ariadne components. Uses the &quot;ariadne&quot; logger name. Marked <code>@transient lazy</code> so that
 <code>Index</code> (a case class) remains serializable across Spark stages — Log4j loggers are not <code>Serializable</code>.
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.FileList">FileList</a> → <a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -807,8 +807,8 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">name</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
       <span class="permalink">
@@ -823,7 +823,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -839,12 +839,12 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -860,12 +860,12 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#open" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="open(path:org.apache.hadoop.fs.Path):org.apache.hadoop.fs.FSDataInputStream"></a><a id="open(Path):FSDataInputStream"></a>
@@ -881,12 +881,12 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">open</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.FSDataInputStream">FSDataInputStream</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Opens an input stream to read from a path on the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Opens an input stream to read from a path on the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to open for reading</p></dd><dt>returns</dt><dd class="cmt"><p>
-  An FSDataInputStream for reading the file contents</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  An FSDataInputStream for reading the file contents</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the file does not exist or cannot be opened</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.FileList#removeFile" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="removeFile(fileNames:String*):Unit"></a><a id="removeFile(String*):Unit"></a>
@@ -902,10 +902,10 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">removeFile</span><span class="params">(<span name="fileNames">fileNames: <span class="extype" name="scala.Predef.String">String</span>*</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Removes files from the file list using a Delta merge-delete.</p><div class="fullcomment"><div class="comment cmt"><p>Removes files from the file list using a Delta merge-delete.</p><p>After deletion, the in-memory cache is invalidated so the next read reflects the updated state.
 </p></div><dl class="paramcmts block"><dt class="param">fileNames</dt><dd class="cmt"><p>
-  one or more file paths to remove</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+  one or more file paths to remove</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if fileNames is null or empty, or any individual file name is null or blank</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#repartitionDataFiles" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="repartitionDataFiles:Boolean"></a>
@@ -921,7 +921,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">repartitionDataFiles</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">When true, applies indexRepartitionCount repartitioning to the data files read during joinDf.</p><div class="fullcomment"><div class="comment cmt"><p>When true, applies indexRepartitionCount repartitioning to the data files read during joinDf. When false, data
 files keep their natural parquet partitioning. Disable when column selection significantly reduces data volume,
 making the repartition shuffle more expensive than useful. Reads from spark.ariadne.repartitionDataFiles
@@ -941,7 +941,7 @@ configuration (default: false).
       <span class="symbol">
         <span class="name">safeDestroyBroadcast</span><span class="params">(<span name="broadcast">broadcast: <span class="extype" name="org.apache.spark.broadcast.Broadcast">Broadcast</span>[_]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Safely destroys a broadcast variable, logging but swallowing any exception.</p><div class="fullcomment"><div class="comment cmt"><p>Safely destroys a broadcast variable, logging but swallowing any exception.</p><p>Intended for use inside <code>finally</code> blocks where a cleanup failure must not mask the original exception propagating
 out of the <code>try</code> block. Tolerates a null broadcast.
 </p></div><dl class="paramcmts block"><dt class="param">broadcast</dt><dd class="cmt"><p>
@@ -960,7 +960,7 @@ out of the <code>try</code> block. Tolerates a null broadcast.
       <span class="symbol">
         <span class="name">spark</span><span class="result">: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Implicit SparkSession that must be provided by the mixing class.</p><div class="fullcomment"><div class="comment cmt"><p>Implicit SparkSession that must be provided by the mixing class.</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.FileList">FileList</a> → <a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#stagingConsolidationThreshold" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="stagingConsolidationThreshold:Int"></a>
@@ -976,7 +976,7 @@ out of the <code>try</code> block. Tolerates a null broadcast.
       <span class="symbol">
         <span class="name">stagingConsolidationThreshold</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Number of batches to process before consolidating staged data into the main index.</p><div class="fullcomment"><div class="comment cmt"><p>Number of batches to process before consolidating staged data into the main index. This provides fault tolerance
 for large index builds - if a job fails, work is preserved up to the last consolidation point. Reads from
 spark.ariadne.stagingConsolidationThreshold configuration (default: 50).
@@ -995,10 +995,10 @@ spark.ariadne.stagingConsolidationThreshold configuration (default: 50).
       <span class="symbol">
         <span class="name">storagePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Base path on the Hadoop-compatible filesystem where all Ariadne index data is stored.</p><div class="fullcomment"><div class="comment cmt"><p>Base path on the Hadoop-compatible filesystem where all Ariadne index data is stored. Each index creates a
 subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</code> (required — no default).
-</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.FileList">FileList</a> → <a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.FileList">FileList</a> → <a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if the configuration key is not set</p></span></dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -1014,7 +1014,7 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -1030,13 +1030,13 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -1052,15 +1052,15 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -1076,19 +1076,19 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -1106,15 +1106,15 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -1136,13 +1136,13 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/Index$$DataFrameOps.html
+++ b/docs/api/dev/cjfravel/ariadne/Index$$DataFrameOps.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.Index.DataFrameOps" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.Index.DataFrameOps" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.Index" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="Index"></a><a id="Index:Index"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="Companion object for the Index class." href="Index$.html"><span class="name">Index</span></a><span class="result"> extends <span class="extype" name="scala.Serializable">Serializable</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Companion object for the Index class.</p><div class="fullcomment"><div class="comment cmt"><p>Companion object for the Index class.</p><p>Provides factory methods for creating or reconnecting to indexes, as well as utility methods for checking existence
 and removing indexes.
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
@@ -166,7 +166,7 @@ and removing indexes.
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Implicit enrichment enabling <code>df.join(index, columns, joinType)</code> syntax.</p><p>This provides the reverse join direction compared to <a href="Index.html#join(df:org.apache.spark.sql.DataFrame,usingColumns:Seq[String],joinType:String):org.apache.spark.sql.DataFrame" class="extmbr" name="dev.cjfravel.ariadne.Index#join">Index.join</a>: the driving DataFrame is on the left and the
 index-located data is on the right.</p><p>Usage:</p><pre><span class="kw">import</span> dev.cjfravel.ariadne.Index.DataFrameOps
 <span class="kw">val</span> result = myDataFrame.join(index, <span class="std">Seq</span>(<span class="lit">"user_id"</span>), <span class="lit">"inner"</span>)</pre></div><div class="toggleContainer block">
@@ -175,7 +175,7 @@ index-located data is on the right.</p><p>Usage:</p><pre><span class="kw">import
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -190,7 +190,7 @@ index-located data is on the right.</p><p>Usage:</p><pre><span class="kw">import
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -233,15 +233,15 @@ index-located data is on the right.</p><p>Usage:</p><pre><span class="kw">import
       <span class="symbol">
         <span class="name">DataFrameOps</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
   The DataFrame to enrich with implicit join capability</p></dd></dl></div>
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -260,7 +260,7 @@ index-located data is on the right.</p><p>Usage:</p><pre><span class="kw">import
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -276,7 +276,7 @@ index-located data is on the right.</p><p>Usage:</p><pre><span class="kw">import
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -292,7 +292,7 @@ index-located data is on the right.</p><p>Usage:</p><pre><span class="kw">import
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -308,7 +308,7 @@ index-located data is on the right.</p><p>Usage:</p><pre><span class="kw">import
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -324,17 +324,17 @@ index-located data is on the right.</p><p>Usage:</p><pre><span class="kw">import
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -350,7 +350,7 @@ index-located data is on the right.</p><p>Usage:</p><pre><span class="kw">import
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -366,7 +366,7 @@ index-located data is on the right.</p><p>Usage:</p><pre><span class="kw">import
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -382,12 +382,12 @@ index-located data is on the right.</p><p>Usage:</p><pre><span class="kw">import
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -403,12 +403,12 @@ index-located data is on the right.</p><p>Usage:</p><pre><span class="kw">import
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -424,7 +424,7 @@ index-located data is on the right.</p><p>Usage:</p><pre><span class="kw">import
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.Index.DataFrameOps#join" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="join(index:dev.cjfravel.ariadne.Index,usingColumns:Seq[String],joinType:String):org.apache.spark.sql.DataFrame"></a><a id="join(Index,Seq[String],String):DataFrame"></a>
@@ -440,14 +440,14 @@ index-located data is on the right.</p><p>Usage:</p><pre><span class="kw">import
       <span class="symbol">
         <span class="name">join</span><span class="params">(<span name="index">index: <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a></span>, <span name="usingColumns">usingColumns: <span class="extype" name="scala.Seq">Seq</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="joinType">joinType: <span class="extype" name="scala.Predef.String">String</span> = <span class="symbol">&quot;inner&quot;</span></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Joins this DataFrame with the data files identified by the Index.</p><div class="fullcomment"><div class="comment cmt"><p>Joins this DataFrame with the data files identified by the Index.</p><p>Locates relevant data files via the index, reads them, applies temporal deduplication if configured, and joins
 the result with this DataFrame.
 </p></div><dl class="paramcmts block"><dt class="param">index</dt><dd class="cmt"><p>
   The Index instance to join against</p></dd><dt class="param">usingColumns</dt><dd class="cmt"><p>
   Column names to join on (must be indexed columns)</p></dd><dt class="param">joinType</dt><dd class="cmt"><p>
   Spark join type: &quot;inner&quot;, &quot;left_outer&quot;, etc. (default &quot;inner&quot;)</p></dd><dt>returns</dt><dd class="cmt"><p>
-  The joined DataFrame</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="ColumnNotFoundException"><code>ColumnNotFoundException</code></span>
+  The joined DataFrame</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="ColumnNotFoundException"><code>ColumnNotFoundException</code></span> 
   if join columns are not in the schema or indexes</p></span></dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -463,7 +463,7 @@ the result with this DataFrame.
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -479,12 +479,12 @@ the result with this DataFrame.
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -500,12 +500,12 @@ the result with this DataFrame.
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -521,7 +521,7 @@ the result with this DataFrame.
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -537,7 +537,7 @@ the result with this DataFrame.
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -553,13 +553,13 @@ the result with this DataFrame.
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -575,15 +575,15 @@ the result with this DataFrame.
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -599,19 +599,19 @@ the result with this DataFrame.
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -629,15 +629,15 @@ the result with this DataFrame.
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -649,13 +649,13 @@ the result with this DataFrame.
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/Index$.html
+++ b/docs/api/dev/cjfravel/ariadne/Index$.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.Index" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.Index" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="catalog/index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -147,7 +147,7 @@
       <span class="symbol">
         <a title="" href="exceptions/index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented3">
                         <span class="separator"></span>
@@ -258,7 +258,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Companion object for the Index class.</p><p>Provides factory methods for creating or reconnecting to indexes, as well as utility methods for checking existence
 and removing indexes.
 </p></div><div class="toggleContainer block">
@@ -267,7 +267,7 @@ and removing indexes.
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="scala.Serializable">Serializable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -282,7 +282,7 @@ and removing indexes.
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -309,7 +309,7 @@ and removing indexes.
 
       <div id="template">
         <div id="allMembers">
-
+        
 
         <div id="types" class="types members">
               <h3>Type Members</h3>
@@ -327,14 +327,14 @@ and removing indexes.
       <span class="symbol">
         <a title="Implicit enrichment enabling df.join(index, columns, joinType) syntax." href="Index$$DataFrameOps.html"><span class="name">DataFrameOps</span></a><span class="result"> extends <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Implicit enrichment enabling <code>df.join(index, columns, joinType)</code> syntax.</p><div class="fullcomment"><div class="comment cmt"><p>Implicit enrichment enabling <code>df.join(index, columns, joinType)</code> syntax.</p><p>This provides the reverse join direction compared to <a href="Index.html#join(df:org.apache.spark.sql.DataFrame,usingColumns:Seq[String],joinType:String):org.apache.spark.sql.DataFrame" class="extmbr" name="dev.cjfravel.ariadne.Index#join">Index.join</a>: the driving DataFrame is on the left and the
 index-located data is on the right.</p><p>Usage:</p><pre><span class="kw">import</span> dev.cjfravel.ariadne.Index.DataFrameOps
 <span class="kw">val</span> result = myDataFrame.join(index, <span class="std">Seq</span>(<span class="lit">"user_id"</span>), <span class="lit">"inner"</span>)</pre></div></div>
     </li></ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -353,7 +353,7 @@ index-located data is on the right.</p><p>Usage:</p><pre><span class="kw">import
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -369,7 +369,7 @@ index-located data is on the right.</p><p>Usage:</p><pre><span class="kw">import
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -385,7 +385,7 @@ index-located data is on the right.</p><p>Usage:</p><pre><span class="kw">import
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.Index#apply" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="apply(name:String,schema:Option[org.apache.spark.sql.types.StructType],format:Option[String],allowSchemaMismatch:Boolean,readOptions:Option[Map[String,String]])(implicitspark:org.apache.spark.sql.SparkSession):dev.cjfravel.ariadne.Index"></a><a id="apply(String,Option[StructType],Option[String],Boolean,Option[Map[String,String]])(SparkSession):Index"></a>
@@ -401,7 +401,7 @@ index-located data is on the right.</p><p>Usage:</p><pre><span class="kw">import
       <span class="symbol">
         <span class="name">apply</span><span class="params">(<span name="name">name: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="schema">schema: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="org.apache.spark.sql.types.StructType">StructType</span>] = <span class="symbol">None</span></span>, <span name="format">format: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Predef.String">String</span>] = <span class="symbol">None</span></span>, <span name="allowSchemaMismatch">allowSchemaMismatch: <span class="extype" name="scala.Boolean">Boolean</span> = <span class="symbol">false</span></span>, <span name="readOptions">readOptions: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Predef.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Predef.String">String</span>]] = <span class="symbol">None</span></span>)</span><span class="params">(<span class="implicit">implicit </span><span name="spark">spark: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span><span class="result">: <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Primary factory method to create or reconnect to an Index instance.</p><div class="fullcomment"><div class="comment cmt"><p>Primary factory method to create or reconnect to an Index instance.</p><p>If metadata exists at the storage path, reconnects to the existing index and validates schema/format compatibility.
 If metadata does not exist, creates a new index with the provided schema and format.
 </p></div><dl class="paramcmts block"><dt class="param">name</dt><dd class="cmt"><p>
@@ -420,11 +420,11 @@ If metadata does not exist, creates a new index with the provided schema and for
 
 <span class="cmt">// Reconnect with schema evolution</span>
 <span class="kw">val</span> evolved = Index(<span class="lit">"orders"</span>, <span class="std">Some</span>(newSchema), allowSchemaMismatch = <span class="kw">true</span>)</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="FormatMismatchException"><code>FormatMismatchException</code></span>
-  if format differs from stored format</p></span><span class="cmt"><p><span class="extype" name="IndexNotFoundInNewSchemaException"><code>IndexNotFoundInNewSchemaException</code></span>
-  if allowSchemaMismatch is true but an indexed column is missing</p></span><span class="cmt"><p><span class="extype" name="MissingFormatException"><code>MissingFormatException</code></span>
-  if creating a new index without a format</p></span><span class="cmt"><p><span class="extype" name="SchemaMismatchException"><code>SchemaMismatchException</code></span>
-  if schema differs and allowSchemaMismatch is false</p></span><span class="cmt"><p><span class="extype" name="SchemaNotProvidedException"><code>SchemaNotProvidedException</code></span>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="FormatMismatchException"><code>FormatMismatchException</code></span> 
+  if format differs from stored format</p></span><span class="cmt"><p><span class="extype" name="IndexNotFoundInNewSchemaException"><code>IndexNotFoundInNewSchemaException</code></span> 
+  if allowSchemaMismatch is true but an indexed column is missing</p></span><span class="cmt"><p><span class="extype" name="MissingFormatException"><code>MissingFormatException</code></span> 
+  if creating a new index without a format</p></span><span class="cmt"><p><span class="extype" name="SchemaMismatchException"><code>SchemaMismatchException</code></span> 
+  if schema differs and allowSchemaMismatch is false</p></span><span class="cmt"><p><span class="extype" name="SchemaNotProvidedException"><code>SchemaNotProvidedException</code></span> 
   if creating a new index without a schema</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.Index#apply" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="apply(name:String,schema:org.apache.spark.sql.types.StructType,format:String,allowSchemaMismatch:Boolean,readOptions:Map[String,String])(implicitspark:org.apache.spark.sql.SparkSession):dev.cjfravel.ariadne.Index"></a><a id="apply(String,StructType,String,Boolean,Map[String,String])(SparkSession):Index"></a>
@@ -440,7 +440,7 @@ If metadata does not exist, creates a new index with the provided schema and for
       <span class="symbol">
         <span class="name">apply</span><span class="params">(<span name="name">name: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="schema">schema: <span class="extype" name="org.apache.spark.sql.types.StructType">StructType</span></span>, <span name="format">format: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="allowSchemaMismatch">allowSchemaMismatch: <span class="extype" name="scala.Boolean">Boolean</span></span>, <span name="readOptions">readOptions: <span class="extype" name="scala.Predef.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="params">(<span class="implicit">implicit </span><span name="spark">spark: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span><span class="result">: <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Convenience factory: creates or reconnects with schema mismatch tolerance and read options.</p><div class="fullcomment"><div class="comment cmt"><p>Convenience factory: creates or reconnects with schema mismatch tolerance and read options.
 </p></div><dl class="paramcmts block"><dt class="param">name</dt><dd class="cmt"><p>
   Unique index name</p></dd><dt class="param">schema</dt><dd class="cmt"><p>
@@ -464,7 +464,7 @@ If metadata does not exist, creates a new index with the provided schema and for
       <span class="symbol">
         <span class="name">apply</span><span class="params">(<span name="name">name: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="schema">schema: <span class="extype" name="org.apache.spark.sql.types.StructType">StructType</span></span>, <span name="format">format: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="readOptions">readOptions: <span class="extype" name="scala.Predef.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="params">(<span class="implicit">implicit </span><span name="spark">spark: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span><span class="result">: <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Convenience factory: creates or reconnects with read options.</p><div class="fullcomment"><div class="comment cmt"><p>Convenience factory: creates or reconnects with read options.
 </p></div><dl class="paramcmts block"><dt class="param">name</dt><dd class="cmt"><p>
   Unique index name</p></dd><dt class="param">schema</dt><dd class="cmt"><p>
@@ -487,7 +487,7 @@ If metadata does not exist, creates a new index with the provided schema and for
       <span class="symbol">
         <span class="name">apply</span><span class="params">(<span name="name">name: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="schema">schema: <span class="extype" name="org.apache.spark.sql.types.StructType">StructType</span></span>, <span name="format">format: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="allowSchemaMismatch">allowSchemaMismatch: <span class="extype" name="scala.Boolean">Boolean</span></span>)</span><span class="params">(<span class="implicit">implicit </span><span name="spark">spark: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span><span class="result">: <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Convenience factory: creates or reconnects with optional schema mismatch tolerance.</p><div class="fullcomment"><div class="comment cmt"><p>Convenience factory: creates or reconnects with optional schema mismatch tolerance.
 </p></div><dl class="paramcmts block"><dt class="param">name</dt><dd class="cmt"><p>
   Unique index name</p></dd><dt class="param">schema</dt><dd class="cmt"><p>
@@ -510,7 +510,7 @@ If metadata does not exist, creates a new index with the provided schema and for
       <span class="symbol">
         <span class="name">apply</span><span class="params">(<span name="name">name: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="schema">schema: <span class="extype" name="org.apache.spark.sql.types.StructType">StructType</span></span>, <span name="format">format: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="params">(<span class="implicit">implicit </span><span name="spark">spark: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span><span class="result">: <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Convenience factory: creates or reconnects with schema, format, and no schema mismatch.</p><div class="fullcomment"><div class="comment cmt"><p>Convenience factory: creates or reconnects with schema, format, and no schema mismatch.
 </p></div><dl class="paramcmts block"><dt class="param">name</dt><dd class="cmt"><p>
   Unique index name</p></dd><dt class="param">schema</dt><dd class="cmt"><p>
@@ -534,7 +534,7 @@ If metadata does not exist, creates a new index with the provided schema and for
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -550,17 +550,17 @@ If metadata does not exist, creates a new index with the provided schema and for
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -576,7 +576,7 @@ If metadata does not exist, creates a new index with the provided schema and for
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -592,7 +592,7 @@ If metadata does not exist, creates a new index with the provided schema and for
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.Index#exists" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exists(name:String)(implicitspark:org.apache.spark.sql.SparkSession):Boolean"></a><a id="exists(String)(SparkSession):Boolean"></a>
@@ -608,7 +608,7 @@ If metadata does not exist, creates a new index with the provided schema and for
       <span class="symbol">
         <span class="name">exists</span><span class="params">(<span name="name">name: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="params">(<span class="implicit">implicit </span><span name="spark">spark: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks if an index exists.</p><div class="fullcomment"><div class="comment cmt"><p>Checks if an index exists.
 </p></div><dl class="paramcmts block"><dt class="param">name</dt><dd class="cmt"><p>
   The index name</p></dd><dt>returns</dt><dd class="cmt"><p>
@@ -629,7 +629,7 @@ If metadata does not exist, creates a new index with the provided schema and for
       <span class="symbol">
         <span class="name">fileListName</span><span class="params">(<span name="name">name: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the file list name for an index.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the file list name for an index.
 </p></div><dl class="paramcmts block"><dt class="param">name</dt><dd class="cmt"><p>
   The index name</p></dd><dt>returns</dt><dd class="cmt"><p>
@@ -650,12 +650,12 @@ If metadata does not exist, creates a new index with the provided schema and for
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -671,12 +671,12 @@ If metadata does not exist, creates a new index with the provided schema and for
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -692,7 +692,7 @@ If metadata does not exist, creates a new index with the provided schema and for
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -708,7 +708,7 @@ If metadata does not exist, creates a new index with the provided schema and for
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -724,12 +724,12 @@ If metadata does not exist, creates a new index with the provided schema and for
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -745,12 +745,12 @@ If metadata does not exist, creates a new index with the provided schema and for
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.Index#remove" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="remove(name:String)(implicitspark:org.apache.spark.sql.SparkSession):Boolean"></a><a id="remove(String)(SparkSession):Boolean"></a>
@@ -766,13 +766,13 @@ If metadata does not exist, creates a new index with the provided schema and for
       <span class="symbol">
         <span class="name">remove</span><span class="params">(<span name="name">name: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="params">(<span class="implicit">implicit </span><span name="spark">spark: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Removes an index and its associated data.</p><div class="fullcomment"><div class="comment cmt"><p>Removes an index and its associated data.
 </p></div><dl class="paramcmts block"><dt class="param">name</dt><dd class="cmt"><p>
   The index name</p></dd><dt>returns</dt><dd class="cmt"><p>
   true if removal was successful</p></dd></dl><dl class="attributes block"> <div class="block">Example:
                <ol><li class="cmt"><p></p><pre>Index.remove(<span class="lit">"orders"</span>)</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IndexNotFoundException"><code>IndexNotFoundException</code></span>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IndexNotFoundException"><code>IndexNotFoundException</code></span> 
   if the index does not exist</p></span></dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -788,7 +788,7 @@ If metadata does not exist, creates a new index with the provided schema and for
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -804,7 +804,7 @@ If metadata does not exist, creates a new index with the provided schema and for
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -820,13 +820,13 @@ If metadata does not exist, creates a new index with the provided schema and for
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -842,15 +842,15 @@ If metadata does not exist, creates a new index with the provided schema and for
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -866,19 +866,19 @@ If metadata does not exist, creates a new index with the provided schema and for
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -896,15 +896,15 @@ If metadata does not exist, creates a new index with the provided schema and for
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -920,13 +920,13 @@ If metadata does not exist, creates a new index with the provided schema and for
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/Index.html
+++ b/docs/api/dev/cjfravel/ariadne/Index.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.Index" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.Index" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="catalog/index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -147,7 +147,7 @@
       <span class="symbol">
         <a title="" href="exceptions/index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented3">
                         <span class="separator"></span>
@@ -258,7 +258,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Represents an Index for managing metadata and file-based indexes in Apache Spark.</p><p>This class provides methods to add, locate, and manage file-based indexing in Spark using Delta Lake. It supports
 schema enforcement, metadata persistence, and file tracking.
 </p></div><dl class="attributes block"> <dt>Note</dt><dd><span class="cmt"><p>
@@ -269,7 +269,7 @@ schema enforcement, metadata persistence, and file tracking.
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="scala.Serializable">Serializable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.Product">Product</span>, <span class="extype" name="scala.Equals">Equals</span>, <a href="IndexQueryOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexQueryOperations">IndexQueryOperations</a>, <a href="IndexJoinOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexJoinOperations">IndexJoinOperations</a>, <a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a>, <a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a>, <a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a>, <a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a>, <a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -284,7 +284,7 @@ schema enforcement, metadata persistence, and file tracking.
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -311,7 +311,7 @@ schema enforcement, metadata persistence, and file tracking.
 
       <div id="template">
         <div id="allMembers">
-
+        
 
         <div id="types" class="types members">
               <h3>Type Members</h3>
@@ -329,7 +329,7 @@ schema enforcement, metadata persistence, and file tracking.
       <span class="symbol">
         <a title="Case class to hold file analysis results for batching decisions." href="IndexBuildOperations$FileAnalysis.html"><span class="name">FileAnalysis</span></a><span class="params">(<span name="filename">filename: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="distinctCounts">distinctCounts: <span class="extype" name="scala.Predef.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Long">Long</span>]</span>, <span name="maxDistinctCount">maxDistinctCount: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result"> extends <span class="extype" name="scala.Product">Product</span> with <span class="extype" name="scala.Serializable">Serializable</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Case class to hold file analysis results for batching decisions.</p><div class="fullcomment"><div class="comment cmt"><p>Case class to hold file analysis results for batching decisions.
 </p></div><dl class="paramcmts block"><dt class="param">filename</dt><dd class="cmt"><p>
   The name of the file</p></dd><dt class="param">distinctCounts</dt><dd class="cmt"><p>
@@ -338,7 +338,7 @@ schema enforcement, metadata persistence, and file tracking.
     </li></ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -357,7 +357,7 @@ schema enforcement, metadata persistence, and file tracking.
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -373,7 +373,7 @@ schema enforcement, metadata persistence, and file tracking.
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -389,7 +389,7 @@ schema enforcement, metadata persistence, and file tracking.
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.Index#addBloomIndex" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addBloomIndex(column:String,fpr:Double):Unit"></a><a id="addBloomIndex(String,Double):Unit"></a>
@@ -405,15 +405,15 @@ schema enforcement, metadata persistence, and file tracking.
       <span class="symbol">
         <span class="name">addBloomIndex</span><span class="params">(<span name="column">column: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="fpr">fpr: <span class="extype" name="scala.Double">Double</span> = <span class="symbol">0.01</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Adds a bloom filter index for the specified column.</p><div class="fullcomment"><div class="comment cmt"><p>Adds a bloom filter index for the specified column.</p><p>Bloom filters are probabilistic data structures that provide:</p><ul><li>Guaranteed NO false negatives (if filter says &quot;no&quot;, value definitely absent)</li><li>Configurable false positive rate (if filter says &quot;yes&quot;, value MIGHT be present)</li><li>Space-efficient storage (approximately 10 bits per element at 1% FPR)
 </li></ul></div><dl class="paramcmts block"><dt class="param">column</dt><dd class="cmt"><p>
   The column name to index with a bloom filter</p></dd><dt class="param">fpr</dt><dd class="cmt"><p>
   False positive rate between 0.0 and 1.0 (default 0.01 = 1%)</p></dd></dl><dl class="attributes block"> <div class="block">Example:
                <ol><li class="cmt"><p></p><pre>index.addBloomIndex(<span class="lit">"sessionId"</span>)
 index.addBloomIndex(<span class="lit">"ipAddress"</span>, <span class="num">0.001</span>)</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="ColumnNotFoundException"><code>ColumnNotFoundException</code></span>
-  if column doesn't exist in schema</p></span><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="ColumnNotFoundException"><code>ColumnNotFoundException</code></span> 
+  if column doesn't exist in schema</p></span><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if column is null/blank, FPR out of range, or column is already a regular or computed index</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.Index#addComputedIndex" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addComputedIndex(name:String,sql_expression:String):Unit"></a><a id="addComputedIndex(String,String):Unit"></a>
@@ -429,14 +429,14 @@ index.addBloomIndex(<span class="lit">"ipAddress"</span>, <span class="num">0.00
       <span class="symbol">
         <span class="name">addComputedIndex</span><span class="params">(<span name="name">name: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="sql_expression">sql_expression: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Adds a computed index derived from a SQL expression.</p><div class="fullcomment"><div class="comment cmt"><p>Adds a computed index derived from a SQL expression.</p><p>The expression is evaluated during <a href="#update:Unit" class="extmbr" name="dev.cjfravel.ariadne.Index#update">update</a> to produce a virtual column whose distinct values are stored in the
 index. Idempotent: calling again with the same name is a no-op.
 </p></div><dl class="paramcmts block"><dt class="param">name</dt><dd class="cmt"><p>
   The alias name for the computed column</p></dd><dt class="param">sql_expression</dt><dd class="cmt"><p>
   A Spark SQL expression evaluated against each data file</p></dd></dl><dl class="attributes block"> <div class="block">Example:
                <ol><li class="cmt"><p></p><pre>index.addComputedIndex(<span class="lit">"yearMonth"</span>, <span class="lit">"date_format(event_date, 'yyyy-MM')"</span>)</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if name or sql_expression is null/blank, or name conflicts with another index type</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.Index#addExplodedFieldIndex" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addExplodedFieldIndex(arrayColumn:String,fieldPath:String,asColumn:String):Unit"></a><a id="addExplodedFieldIndex(String,String,String):Unit"></a>
@@ -452,7 +452,7 @@ index. Idempotent: calling again with the same name is a no-op.
       <span class="symbol">
         <span class="name">addExplodedFieldIndex</span><span class="params">(<span name="arrayColumn">arrayColumn: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="fieldPath">fieldPath: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="asColumn">asColumn: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Adds an exploded field index for a nested field inside an array column.</p><div class="fullcomment"><div class="comment cmt"><p>Adds an exploded field index for a nested field inside an array column.</p><p>During <a href="#update:Unit" class="extmbr" name="dev.cjfravel.ariadne.Index#update">update</a>, each element of <code>arrayColumn</code> is exploded, the <code>fieldPath</code> is extracted, and the distinct values
 are stored under <code>asColumn</code> in the index. Joins on <code>asColumn</code> will locate files containing any matching array
 element. Idempotent: calling again with the same <code>asColumn</code> is a no-op.
@@ -462,7 +462,7 @@ element. Idempotent: calling again with the same <code>asColumn</code> is a no-o
   The virtual column name exposed for joins.</p></dd></dl><dl class="attributes block"> <div class="block">Example:
                <ol><li class="cmt"><p></p><pre><span class="cmt">// Index the "id" field from each element of the "items" array column</span>
 index.addExplodedFieldIndex(<span class="lit">"items"</span>, <span class="lit">"id"</span>, <span class="lit">"item_id"</span>)</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if any parameter is null/blank, or <code>asColumn</code> conflicts with another index type</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.Index#addFile" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addFile(fileNames:String*):Unit"></a><a id="addFile(String*):Unit"></a>
@@ -478,14 +478,14 @@ index.addExplodedFieldIndex(<span class="lit">"items"</span>, <span class="lit">
       <span class="symbol">
         <span class="name">addFile</span><span class="params">(<span name="fileNames">fileNames: <span class="extype" name="scala.Predef.String">String</span>*</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Adds files to the index's file list for future indexing.</p><div class="fullcomment"><div class="comment cmt"><p>Adds files to the index's file list for future indexing. Acquires a file list lock to prevent concurrent
 modifications.
 </p></div><dl class="paramcmts block"><dt class="param">fileNames</dt><dd class="cmt"><p>
   One or more file paths to register</p></dd></dl><dl class="attributes block"> <div class="block">Example:
                <ol><li class="cmt"><p></p><pre>index.addFile(<span class="lit">"/data/events/2024-01-01.parquet"</span>)
 index.addFile(<span class="lit">"/data/events/2024-01-02.parquet"</span>, <span class="lit">"/data/events/2024-01-03.parquet"</span>)</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if fileNames is null/empty or any fileName is null/blank</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexFileOperations#addFilenameColumn" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addFilenameColumn(df:org.apache.spark.sql.DataFrame,files:Set[String]):org.apache.spark.sql.DataFrame"></a><a id="addFilenameColumn(DataFrame,Set[String]):DataFrame"></a>
@@ -501,7 +501,7 @@ index.addFile(<span class="lit">"/data/events/2024-01-02.parquet"</span>, <span 
       <span class="symbol">
         <span class="name">addFilenameColumn</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="files">files: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Adds a stable filename column to the DataFrame.</p><div class="fullcomment"><div class="comment cmt"><p>Adds a stable filename column to the DataFrame.</p><p>Uses <code>input_file_name()</code> to capture the source file path. For single-file reads where Spark may report an empty
 filename, falls back to the known file path.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
@@ -522,14 +522,14 @@ filename, falls back to the known file path.
       <span class="symbol">
         <span class="name">addIndex</span><span class="params">(<span name="index">index: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Adds a regular (array-of-distinct-values) index for the specified column.</p><div class="fullcomment"><div class="comment cmt"><p>Adds a regular (array-of-distinct-values) index for the specified column.</p><p>Idempotent: calling again with the same column is a no-op.
 </p></div><dl class="paramcmts block"><dt class="param">index</dt><dd class="cmt"><p>
   The column name to index.</p></dd></dl><dl class="attributes block"> <div class="block">Example:
                <ol><li class="cmt"><p></p><pre><span class="kw">val</span> index = Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"parquet"</span>)
 index.addIndex(<span class="lit">"userId"</span>)</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="ColumnNotFoundException"><code>ColumnNotFoundException</code></span>
-  if the column doesn't exist in the schema</p></span><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="ColumnNotFoundException"><code>ColumnNotFoundException</code></span> 
+  if the column doesn't exist in the schema</p></span><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if the column name is null/blank or already indexed by another type (bloom, temporal, or range)</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.Index#addRangeIndex" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addRangeIndex(column:String):Unit"></a><a id="addRangeIndex(String):Unit"></a>
@@ -545,14 +545,14 @@ index.addIndex(<span class="lit">"userId"</span>)</pre></li></ol>
       <span class="symbol">
         <span class="name">addRangeIndex</span><span class="params">(<span name="column">column: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Adds a range index for the specified column.</p><div class="fullcomment"><div class="comment cmt"><p>Adds a range index for the specified column.</p><p>Range indexes store min/max values per file, enabling file pruning at query time. Files whose [min, max] range does
 not overlap with the queried values are skipped.
 </p></div><dl class="paramcmts block"><dt class="param">column</dt><dd class="cmt"><p>
   The column to index with min/max range</p></dd></dl><dl class="attributes block"> <div class="block">Example:
                <ol><li class="cmt"><p></p><pre>index.addRangeIndex(<span class="lit">"timestamp"</span>)</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="ColumnNotFoundException"><code>ColumnNotFoundException</code></span>
-  if column doesn't exist in schema</p></span><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="ColumnNotFoundException"><code>ColumnNotFoundException</code></span> 
+  if column doesn't exist in schema</p></span><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if column is null/blank or already indexed by another type</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.Index#addTemporalIndex" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addTemporalIndex(column:String,timestampColumn:String):Unit"></a><a id="addTemporalIndex(String,String):Unit"></a>
@@ -568,15 +568,15 @@ not overlap with the queried values are skipped.
       <span class="symbol">
         <span class="name">addTemporalIndex</span><span class="params">(<span name="column">column: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="timestampColumn">timestampColumn: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Adds a temporal index for the specified column using a timestamp for versioning.</p><div class="fullcomment"><div class="comment cmt"><p>Adds a temporal index for the specified column using a timestamp for versioning.</p><p>When joining on a temporal index column, only the latest version (by timestamp) of each value is returned. This is
 useful when multiple files contain the same entity at different points in time.
 </p></div><dl class="paramcmts block"><dt class="param">column</dt><dd class="cmt"><p>
   The value column to index on (e.g., &quot;user_id&quot;)</p></dd><dt class="param">timestampColumn</dt><dd class="cmt"><p>
   The timestamp column for ordering versions (e.g., &quot;updated_at&quot;)</p></dd></dl><dl class="attributes block"> <div class="block">Example:
                <ol><li class="cmt"><p></p><pre>index.addTemporalIndex(<span class="lit">"userId"</span>, <span class="lit">"updated_at"</span>)</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="ColumnNotFoundException"><code>ColumnNotFoundException</code></span>
-  if either column doesn't exist in schema</p></span><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="ColumnNotFoundException"><code>ColumnNotFoundException</code></span> 
+  if either column doesn't exist in schema</p></span><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if column or timestampColumn is null/blank, or column is already indexed by another type</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#analyzeFiles" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="analyzeFiles(files:Set[String]):Seq[IndexBuildOperations.this.FileAnalysis]"></a><a id="analyzeFiles(Set[String]):Seq[FileAnalysis]"></a>
@@ -592,7 +592,7 @@ useful when multiple files contain the same entity at different points in time.
       <span class="symbol">
         <span class="name">analyzeFiles</span><span class="params">(<span name="files">files: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Seq">Seq</span>[<a href="#FileAnalysisextendsProductwithSerializable" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations.FileAnalysis">FileAnalysis</a>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Performs pre-flight analysis on unindexed files to determine optimal batching strategy.</p><div class="fullcomment"><div class="comment cmt"><p>Performs pre-flight analysis on unindexed files to determine optimal batching strategy.</p><p>Reads the source files, applies computed indexes, and counts distinct values per indexed column per file. The
 resulting <a href="IndexBuildOperations$FileAnalysis.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations.FileAnalysis">FileAnalysis</a> objects are used by <a href="IndexBuildOperations.html#createOptimalBatches(fileAnalyses:Seq[IndexBuildOperations.this.FileAnalysis]):Seq[Set[String]]" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#createOptimalBatches">createOptimalBatches</a> to group files into batches that stay under
 the <code>largeIndexLimit</code>.</p><p>If no storage columns are configured (e.g., only bloom or range indexes), returns trivial analyses with zero
@@ -617,7 +617,7 @@ distinct counts.
       <span class="symbol">
         <span class="name">appendToLargeIndex</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Appends large index data to per-column Delta tables under <code>large_indexes/</code>.</p><div class="fullcomment"><div class="comment cmt"><p>Appends large index data to per-column Delta tables under <code>large_indexes/</code>.</p><p>For each storage column, identifies rows where the array size meets or exceeds <code>largeIndexLimit</code>, explodes those
 arrays into individual rows, and writes them to <code>large_indexes/{column}/</code>. Before appending, any existing rows for
 the same filenames are removed via Delta MERGE to prevent duplicates (important during column backfill or
@@ -642,7 +642,7 @@ re-indexing).
       <span class="symbol">
         <span class="name">appendToStaging</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Appends the processed DataFrame to the staging Delta table.</p><div class="fullcomment"><div class="comment cmt"><p>Appends the processed DataFrame to the staging Delta table.</p><p>Before writing, any column whose array size meets or exceeds <code>largeIndexLimit</code> is nulled out (those values are
 stored separately via <a href="IndexBuildOperations.html#appendToLargeIndex(df:org.apache.spark.sql.DataFrame):Unit" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#appendToLargeIndex">appendToLargeIndex</a>). The DataFrame is written in append mode with schema merge enabled.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
@@ -661,7 +661,7 @@ stored separately via <a href="IndexBuildOperations.html#appendToLargeIndex(df:o
       <span class="symbol">
         <span class="name">applyColumnSelection</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Applies column selection if columns have been specified via select().</p><div class="fullcomment"><div class="comment cmt"><p>Applies column selection if columns have been specified via select(). Only reads the explicitly selected columns.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
   The DataFrame to apply column selection to</p></dd><dt>returns</dt><dd class="cmt"><p>
@@ -680,12 +680,12 @@ stored separately via <a href="IndexBuildOperations.html#appendToLargeIndex(df:o
       <span class="symbol">
         <span class="name">applyComputedIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Applies computed indexes to a DataFrame by adding computed columns.</p><div class="fullcomment"><div class="comment cmt"><p>Applies computed indexes to a DataFrame by adding computed columns.</p><p>Each computed index is a Spark SQL expression stored in metadata. The expression is evaluated via <code>expr()</code> and
 added as a new column. If no computed indexes are configured, the DataFrame is returned unchanged.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
   The base DataFrame</p></dd><dt>returns</dt><dd class="cmt"><p>
-  DataFrame with computed index columns added</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="org.apache.spark.sql.AnalysisException"><code>org.apache.spark.sql.AnalysisException</code></span>
+  DataFrame with computed index columns added</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="org.apache.spark.sql.AnalysisException"><code>org.apache.spark.sql.AnalysisException</code></span> 
   if a computed index expression is invalid or references non-existent columns</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexFileOperations#applyExplodedFields" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="applyExplodedFields(df:org.apache.spark.sql.DataFrame):org.apache.spark.sql.DataFrame"></a><a id="applyExplodedFields(DataFrame):DataFrame"></a>
@@ -701,7 +701,7 @@ added as a new column. If no computed indexes are configured, the DataFrame is r
       <span class="symbol">
         <span class="name">applyExplodedFields</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Applies exploded field transformations to a DataFrame.</p><div class="fullcomment"><div class="comment cmt"><p>Applies exploded field transformations to a DataFrame.</p><p>For each configured exploded field, extracts the nested field path from the array column and explodes it into a
 top-level column. This is used on the read/join path to prepare data for joining on exploded field values.</p><p>Note that <code>explode()</code> (not <code>explode_outer()</code>) is used intentionally — rows with null or empty arrays are dropped
 because they contain no matchable values for the join. This is consistent with the index build path which also
@@ -723,7 +723,7 @@ excludes null/empty arrays.
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#autoBloomColumnPrefix" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="autoBloomColumnPrefix:String"></a>
@@ -739,7 +739,7 @@ excludes null/empty arrays.
       <span class="symbol">
         <span class="name">autoBloomColumnPrefix</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Column name prefix for auto-bloom filter storage in the main index table.</p><div class="fullcomment"><div class="comment cmt"><p>Column name prefix for auto-bloom filter storage in the main index table.
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#autoBloomFpr" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -756,7 +756,7 @@ excludes null/empty arrays.
       <span class="symbol">
         <span class="name">autoBloomFpr</span><span class="result">: <span class="extype" name="scala.Double">Double</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">False positive rate for auto-bloom filters on large index columns.</p><div class="fullcomment"><div class="comment cmt"><p>False positive rate for auto-bloom filters on large index columns. When a column exceeds largeIndexLimit, an
 auto-bloom filter is built with this FPR to enable file pruning at query time. Reads from
 spark.ariadne.autoBloomFpr configuration (default: 0.01).
@@ -775,7 +775,7 @@ spark.ariadne.autoBloomFpr configuration (default: 0.01).
       <span class="symbol">
         <span class="name">autoBloomStorageColumns</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the set of auto-bloom storage column names (each prefixed with <code>auto_bloom_</code>).</p><div class="fullcomment"><div class="comment cmt"><p>Returns the set of auto-bloom storage column names (each prefixed with <code>auto_bloom_</code>).
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   set of prefixed column names (e.g., <code>auto_bloom_user_id</code>)</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
@@ -793,7 +793,7 @@ spark.ariadne.autoBloomFpr configuration (default: 0.01).
       <span class="symbol">
         <span class="name">autoCompactThreshold</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Int">Int</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Optional threshold for auto-compaction.</p><div class="fullcomment"><div class="comment cmt"><p>Optional threshold for auto-compaction. When set, the main index Delta table is compacted after an update if the
 number of Delta log JSON files meets or exceeds this value. Reads from spark.ariadne.autoCompactThreshold
 configuration (default: not set).
@@ -812,7 +812,7 @@ configuration (default: not set).
       <span class="symbol">
         <span class="name">batchesSinceCompact</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Counter tracking batches processed since the last auto-compaction.</p><div class="fullcomment"><div class="comment cmt"><p>Counter tracking batches processed since the last auto-compaction.</p><p>Incremented after each batch in <code>updateBatched</code> and reset to zero after each compaction cycle or at the start of
 each <a href="#update:Unit" class="extmbr" name="dev.cjfravel.ariadne.Index#update">update</a> call to prevent stale counts from a previous <code>update</code> from triggering premature
 compaction.
@@ -831,7 +831,7 @@ compaction.
       <span class="symbol">
         <span class="name">bloomColumnPrefix</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Column name prefix used when storing bloom filter binary data in the index Delta table.</p><div class="fullcomment"><div class="comment cmt"><p>Column name prefix used when storing bloom filter binary data in the index Delta table.
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.BloomFilterOperations#bloomColumns" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -848,7 +848,7 @@ compaction.
       <span class="symbol">
         <span class="name">bloomColumns</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the set of source column names that have bloom indexes configured.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the set of source column names that have bloom indexes configured.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   set of column names (without the <code>bloom_</code> prefix)</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd></dl></div>
@@ -866,7 +866,7 @@ compaction.
       <span class="symbol">
         <span class="name">bloomContainsUdf</span><span class="result">: <span class="extype" name="org.apache.spark.sql.expressions.UserDefinedFunction">UserDefinedFunction</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Creates a Spark UDF for checking bloom filter membership at query time.</p><div class="fullcomment"><div class="comment cmt"><p>Creates a Spark UDF for checking bloom filter membership at query time.</p><p>The returned UDF accepts a serialized bloom filter (<code>Array[Byte]</code>) and a candidate value (<code>String</code>), and returns
 <code>true</code> if the bloom filter indicates the value might be present.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
@@ -885,7 +885,7 @@ compaction.
       <span class="symbol">
         <span class="name">bloomIndexConfigs</span><span class="result">: <span class="extype" name="scala.Seq">Seq</span>[<a href="BloomIndexConfig.html" class="extype" name="dev.cjfravel.ariadne.BloomIndexConfig">BloomIndexConfig</a>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the bloom index configurations from the current index metadata.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the bloom index configurations from the current index metadata.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   sequence of <a href="BloomIndexConfig.html" class="extype" name="dev.cjfravel.ariadne.BloomIndexConfig">BloomIndexConfig</a> objects, one per bloom-indexed column</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd></dl></div>
@@ -903,7 +903,7 @@ compaction.
       <span class="symbol">
         <span class="name">bloomMightContain</span><span class="params">(<span name="bloomBytes">bloomBytes: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Byte">Byte</span>]</span>, <span name="value">value: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks if a value might be contained in a serialized bloom filter.</p><div class="fullcomment"><div class="comment cmt"><p>Checks if a value might be contained in a serialized bloom filter.</p><p>Deserializes the bloom filter and performs a <code>mightContain</code> check. Returns <code>false</code> if either argument is <code>null</code>.
 </p></div><dl class="paramcmts block"><dt class="param">bloomBytes</dt><dd class="cmt"><p>
   serialized bloom filter bytes</p></dd><dt class="param">value</dt><dd class="cmt"><p>
@@ -923,7 +923,7 @@ compaction.
       <span class="symbol">
         <span class="name">bloomStorageColumns</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the set of storage column names used for bloom filter binary data.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the set of storage column names used for bloom filter binary data.</p><p>Each name is the source column name prefixed with <a href="BloomFilterOperations.html#bloomColumnPrefix:String" class="extmbr" name="dev.cjfravel.ariadne.BloomFilterOperations#bloomColumnPrefix">bloomColumnPrefix</a>.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   set of prefixed column names (e.g., <code>bloom_user_id</code>)</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd></dl></div>
@@ -941,7 +941,7 @@ compaction.
       <span class="symbol">
         <span class="name">buildAutoBloomIndexes</span><span class="params">(<span name="combinedDf">combinedDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds auto-bloom filters for columns that exceed the large index limit.</p><div class="fullcomment"><div class="comment cmt"><p>Builds auto-bloom filters for columns that exceed the large index limit.</p><p>Scans the combined DataFrame to identify columns with any file whose array size meets or exceeds <code>largeIndexLimit</code>.
 For each such column, a bloom filter is built from the full array and stored in the main index with the
 <code>auto_bloom_</code> prefix. At query time, these bloom filters enable fast pre-filtering to determine which files need to
@@ -966,7 +966,7 @@ unpersisted before the exception is rethrown.
       <span class="symbol">
         <span class="name">buildBloomFilterIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds bloom filter indexes for all configured bloom columns.</p><div class="fullcomment"><div class="comment cmt"><p>Builds bloom filter indexes for all configured bloom columns.</p><p>For each <a href="BloomIndexConfig.html" class="extype" name="dev.cjfravel.ariadne.BloomIndexConfig">BloomIndexConfig</a>, this method:</p><ol class="decimal"><li>Groups the input data by filename 2. Collects distinct values per file into a set 3. Creates a bloom filter
      from the collected values using <a href="BloomFilterOperations.html#createBloomFilterUdf(fprValue:Double):org.apache.spark.sql.expressions.UserDefinedFunction" class="extmbr" name="dev.cjfravel.ariadne.BloomFilterOperations#createBloomFilterUdf">createBloomFilterUdf</a> 4. Joins the resulting bloom column back onto the
      accumulating DataFrame</li></ol><p>If no bloom indexes are configured, returns a distinct filename-only DataFrame.
@@ -987,7 +987,7 @@ unpersisted before the exception is rethrown.
       <span class="symbol">
         <span class="name">buildExplodedFieldIndexes</span><span class="params">(<span name="baseData">baseData: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="resultDf">resultDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds exploded field indexes and joins them onto the result DataFrame.</p><div class="fullcomment"><div class="comment cmt"><p>Builds exploded field indexes and joins them onto the result DataFrame.</p><p>For each configured exploded field index, extracts the nested field path from the array column, explodes it,
 collects distinct values back into an array per file, and joins the result onto <code>resultDf</code>.
 </p></div><dl class="paramcmts block"><dt class="param">baseData</dt><dd class="cmt"><p>
@@ -1008,7 +1008,7 @@ collects distinct values back into an array per file, and joins the result onto 
       <span class="symbol">
         <span class="name">buildRangeIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds range indexes storing <code>Struct(min, max)</code> per file.</p><div class="fullcomment"><div class="comment cmt"><p>Builds range indexes storing <code>Struct(min, max)</code> per file.</p><p>For each range index configuration, groups by <code>filename</code> and computes the <code>min</code> and <code>max</code> of the column per file.
 The result is a struct column named <code>range_{column}</code>.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
@@ -1029,7 +1029,7 @@ The result is a struct column named <code>range_{column}</code>.
       <span class="symbol">
         <span class="name">buildRegularIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds regular (array-aggregated) indexes for all configured regular and computed columns.</p><div class="fullcomment"><div class="comment cmt"><p>Builds regular (array-aggregated) indexes for all configured regular and computed columns.</p><p>Groups the input data by filename and collects distinct values into arrays via <code>collect_set</code>. If no regular or
 computed indexes are configured, returns a distinct filename-only DataFrame.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
@@ -1049,7 +1049,7 @@ computed indexes are configured, returns a distinct filename-only DataFrame.
       <span class="symbol">
         <span class="name">buildTemporalIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds temporal indexes storing <code>Array[Struct(value, max_ts)]</code> per file.</p><div class="fullcomment"><div class="comment cmt"><p>Builds temporal indexes storing <code>Array[Struct(value, max_ts)]</code> per file.</p><p>For each temporal index configuration, groups by <code>(filename, value_column)</code> to find the maximum timestamp per value
 per file, then collects the <code>(value, max_ts)</code> structs into an array per file. This enables temporal deduplication
 at query time.
@@ -1071,17 +1071,17 @@ at query time.
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.Index#compact" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="compact():Unit"></a>
@@ -1097,12 +1097,12 @@ at query time.
       <span class="symbol">
         <span class="name">compact</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Compacts all Delta tables belonging to this index using OPTIMIZE.</p><div class="fullcomment"><div class="comment cmt"><p>Compacts all Delta tables belonging to this index using OPTIMIZE. Acquires the update lock to prevent concurrent
 modifications.
 </p></div><dl class="attributes block"> <div class="block">Example:
                <ol><li class="cmt"><p></p><pre>index.compact()</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IndexLockException"><code>IndexLockException</code></span>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IndexLockException"><code>IndexLockException</code></span> 
   if the update lock cannot be acquired within the configured timeout</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#compactDeltaTables" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="compactDeltaTables():Unit"></a>
@@ -1118,7 +1118,7 @@ modifications.
       <span class="symbol">
         <span class="name">compactDeltaTables</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Compacts all Delta tables (main index and large index tables) using Delta OPTIMIZE.</p><div class="fullcomment"><div class="comment cmt"><p>Compacts all Delta tables (main index and large index tables) using Delta OPTIMIZE.</p><p>Runs Delta Lake's OPTIMIZE command to consolidate small files into larger ones, improving read performance.
 Processes the main index table first, then each large index column table.
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
@@ -1136,7 +1136,7 @@ Processes the main index table first, then each large index column table.
       <span class="symbol">
         <span class="name">consolidateStaging</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Consolidates staged data into the main index table.</p><div class="fullcomment"><div class="comment cmt"><p>Consolidates staged data into the main index table.</p><p>Delegates to <span class="extype" name="consolidateMainStaging">consolidateMainStaging</span> which performs a Delta MERGE (upsert) of all staged rows into the main
 index, then deletes the staging table. Logs the total time taken.
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
@@ -1154,12 +1154,12 @@ index, then deletes the staging table. Logs the total time taken.
       <span class="symbol">
         <span class="name">createBaseDataFrame</span><span class="params">(<span name="files">files: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Creates a base DataFrame from the provided files using the stored format and schema.</p><div class="fullcomment"><div class="comment cmt"><p>Creates a base DataFrame from the provided files using the stored format and schema. Applies any read options
 configured in the index metadata.</p><p>Returns an empty DataFrame (with the stored schema) if all file paths are blank after normalization.
 </p></div><dl class="paramcmts block"><dt class="param">files</dt><dd class="cmt"><p>
   Set of file paths to read</p></dd><dt>returns</dt><dd class="cmt"><p>
-  DataFrame with data from the specified files</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+  DataFrame with data from the specified files</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if the stored format is not csv, parquet, or json</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.BloomFilterOperations#createBloomFilterUdf" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="createBloomFilterUdf(fprValue:Double):org.apache.spark.sql.expressions.UserDefinedFunction"></a><a id="createBloomFilterUdf(Double):UserDefinedFunction"></a>
@@ -1175,7 +1175,7 @@ configured in the index metadata.</p><p>Returns an empty DataFrame (with the sto
       <span class="symbol">
         <span class="name">createBloomFilterUdf</span><span class="params">(<span name="fprValue">fprValue: <span class="extype" name="scala.Double">Double</span></span>)</span><span class="result">: <span class="extype" name="org.apache.spark.sql.expressions.UserDefinedFunction">UserDefinedFunction</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Creates a Spark UDF that converts a collected set of values into a serialized bloom filter.</p><div class="fullcomment"><div class="comment cmt"><p>Creates a Spark UDF that converts a collected set of values into a serialized bloom filter.</p><p>The UDF is designed for use inside <code>agg(bloomUdf(collect_set(...)))</code>. It:</p><ol class="decimal"><li>Filters out null values from the input sequence 2. Creates a Guava <code>BloomFilter</code> sized for the actual number
      of non-null elements 3. Inserts each value (converted to <code>String</code>) into the filter 4. Serializes the filter to
      <code>Array[Byte]</code> via <code>ByteArrayOutputStream</code></li></ol><p>The <code>fprValue</code> parameter is captured as a local <code>val</code> to ensure it is serializable when the UDF closure is shipped
@@ -1183,7 +1183,7 @@ to Spark executors.
 </p></div><dl class="paramcmts block"><dt class="param">fprValue</dt><dd class="cmt"><p>
   the desired false positive rate (e.g., 0.01 for 1%); must be strictly between 0 and 1 (exclusive)</p></dd><dt>returns</dt><dd class="cmt"><p>
   a UDF that accepts <code>Seq[Any]</code> (from <code>collect_set</code>) and returns <code>Array[Byte]</code>, or <code>null</code> if the input is null or
-  contains only nulls</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+  contains only nulls</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if <code>fprValue</code> is not in the range (0, 1)</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#createOptimalBatches" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="createOptimalBatches(fileAnalyses:Seq[IndexBuildOperations.this.FileAnalysis]):Seq[Set[String]]"></a><a id="createOptimalBatches(Seq[FileAnalysis]):Seq[Set[String]]"></a>
@@ -1199,7 +1199,7 @@ to Spark executors.
       <span class="symbol">
         <span class="name">createOptimalBatches</span><span class="params">(<span name="fileAnalyses">fileAnalyses: <span class="extype" name="scala.Seq">Seq</span>[<a href="#FileAnalysisextendsProductwithSerializable" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations.FileAnalysis">FileAnalysis</a>]</span>)</span><span class="result">: <span class="extype" name="scala.Seq">Seq</span>[<span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Groups files into batches whose aggregate <code>maxDistinctCount</code> stays at or below <code>largeIndexLimit</code>.</p><div class="fullcomment"><div class="comment cmt"><p>Groups files into batches whose aggregate <code>maxDistinctCount</code> stays at or below <code>largeIndexLimit</code>.</p><p>The algorithm sorts files by <code>maxDistinctCount</code> (largest first) and packs them sequentially into batches. When
 adding a file would push the batch total past the limit, a new batch is started. Files that individually exceed the
 limit are placed into single-file batches to guarantee progress.
@@ -1220,7 +1220,7 @@ limit are placed into single-file batches to guarantee progress.
       <span class="symbol">
         <span class="name">debugEnabled</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">When true, logs detailed diagnostics during join operations including partition counts, physical plans, and
 per-phase timing.</p><div class="fullcomment"><div class="comment cmt"><p>When true, logs detailed diagnostics during join operations including partition counts, physical plans, and
 per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
@@ -1239,12 +1239,12 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">delete</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Deletes a path recursively from the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Deletes a path recursively from the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to delete</p></dd><dt>returns</dt><dd class="cmt"><p>
-  true if the path was successfully deleted</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  true if the path was successfully deleted</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the filesystem operation fails</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.Index#deleteFiles" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="deleteFiles(filenames:String*):Unit"></a><a id="deleteFiles(String*):Unit"></a>
@@ -1260,15 +1260,15 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">deleteFiles</span><span class="params">(<span name="filenames">filenames: <span class="extype" name="scala.Predef.String">String</span>*</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Deletes the specified files from the index, large index tables, and file list.</p><div class="fullcomment"><div class="comment cmt"><p>Deletes the specified files from the index, large index tables, and file list.</p><p>Acquires the update lock, removes matching rows from the main index Delta table, all large index Delta tables, and
 the FileList. If a filename doesn't exist in the index, it is silently ignored.
 </p></div><dl class="paramcmts block"><dt class="param">filenames</dt><dd class="cmt"><p>
   One or more filenames to remove from the index.</p></dd></dl><dl class="attributes block"> <div class="block">Example:
                <ol><li class="cmt"><p></p><pre>index.deleteFiles(<span class="lit">"/data/events/2024-01-01.parquet"</span>)
 index.deleteFiles(<span class="lit">"/data/old1.parquet"</span>, <span class="lit">"/data/old2.parquet"</span>)</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if filenames is null/empty or contains null/blank entries</p></span><span class="cmt"><p><span class="extype" name="IndexLockException"><code>IndexLockException</code></span>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if filenames is null/empty or contains null/blank entries</p></span><span class="cmt"><p><span class="extype" name="IndexLockException"><code>IndexLockException</code></span> 
   if the update lock cannot be acquired within the configured timeout</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#delta" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="delta(path:org.apache.hadoop.fs.Path):Option[io.delta.tables.DeltaTable]"></a><a id="delta(Path):Option[DeltaTable]"></a>
@@ -1284,7 +1284,7 @@ index.deleteFiles(<span class="lit">"/data/old1.parquet"</span>, <span class="li
       <span class="symbol">
         <span class="name">delta</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="io.delta.tables.DeltaTable">DeltaTable</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns a <span class="extype" name="io.delta.tables.DeltaTable">io.delta.tables.DeltaTable</span> if the path exists and contains valid Delta metadata.</p><div class="fullcomment"><div class="comment cmt"><p>Returns a <span class="extype" name="io.delta.tables.DeltaTable">io.delta.tables.DeltaTable</span> if the path exists and contains valid Delta metadata.</p><p>If the path exists but is <i>not</i> a valid Delta table (e.g., leftover partial write), the directory is deleted and
 <code>None</code> is returned so it can be recreated cleanly on the next write.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
@@ -1304,12 +1304,12 @@ index.deleteFiles(<span class="lit">"/data/old1.parquet"</span>, <span class="li
       <span class="symbol">
         <span class="name">deserializeBloomFilter</span><span class="params">(<span name="bytes">bytes: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Byte">Byte</span>]</span>)</span><span class="result">: <span class="extype" name="com.google.common.hash.BloomFilter">BloomFilter</span>[<span class="extype" name="java.lang.CharSequence">CharSequence</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Deserializes a Guava bloom filter from its byte representation.</p><div class="fullcomment"><div class="comment cmt"><p>Deserializes a Guava bloom filter from its byte representation.</p><p>Uses <code>BloomFilter.readFrom</code> with a UTF-8 <code>StringFunnel</code>, which must match the funnel used during creation in
 <a href="BloomFilterOperations.html#createBloomFilterUdf(fprValue:Double):org.apache.spark.sql.expressions.UserDefinedFunction" class="extmbr" name="dev.cjfravel.ariadne.BloomFilterOperations#createBloomFilterUdf">createBloomFilterUdf</a>.
 </p></div><dl class="paramcmts block"><dt class="param">bytes</dt><dd class="cmt"><p>
   serialized bloom filter bytes (produced by <code>BloomFilter.writeTo</code>)</p></dd><dt>returns</dt><dd class="cmt"><p>
-  a <code>BloomFilter[CharSequence]</code> instance ready for membership queries</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  a <code>BloomFilter[CharSequence]</code> instance ready for membership queries</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the byte array is malformed or corrupted</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#ensureStorageReadyUnderLock" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ensureStorageReadyUnderLock(lock:dev.cjfravel.ariadne.IndexLock,correlationId:String,refresh:Boolean):Unit"></a><a id="ensureStorageReadyUnderLock(IndexLock,String,Boolean):Unit"></a>
@@ -1325,7 +1325,7 @@ index.deleteFiles(<span class="lit">"/data/old1.parquet"</span>, <span class="li
       <span class="symbol">
         <span class="name">ensureStorageReadyUnderLock</span><span class="params">(<span name="lock">lock: <a href="IndexLock.html" class="extype" name="dev.cjfravel.ariadne.IndexLock">IndexLock</a></span>, <span name="correlationId">correlationId: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="refresh">refresh: <span class="extype" name="scala.Boolean">Boolean</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Runs migration preflight while the caller holds the update lock.</p><div class="fullcomment"><div class="comment cmt"><p>Runs migration preflight while the caller holds the update lock.
 </p></div><dl class="paramcmts block"><dt class="param">refresh</dt><dd class="cmt"><p>
   whether to reload metadata after lock acquisition</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
@@ -1343,7 +1343,7 @@ index.deleteFiles(<span class="lit">"/data/old1.parquet"</span>, <span class="li
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#exists" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exists(path:org.apache.hadoop.fs.Path):Boolean"></a><a id="exists(Path):Boolean"></a>
@@ -1359,12 +1359,12 @@ index.deleteFiles(<span class="lit">"/data/old1.parquet"</span>, <span class="li
       <span class="symbol">
         <span class="name">exists</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks if a path exists on the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Checks if a path exists on the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to check</p></dd><dt>returns</dt><dd class="cmt"><p>
-  true if the path exists</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  true if the path exists</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the filesystem operation fails</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadataOperations#format" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="format:String"></a>
@@ -1380,7 +1380,7 @@ index.deleteFiles(<span class="lit">"/data/old1.parquet"</span>, <span class="li
       <span class="symbol">
         <span class="name">format</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the file format of the indexed data (e.g., &quot;parquet&quot;, &quot;csv&quot;, &quot;json&quot;).</p><div class="fullcomment"><div class="comment cmt"><p>Returns the file format of the indexed data (e.g., &quot;parquet&quot;, &quot;csv&quot;, &quot;json&quot;).</p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   the format string from the stored metadata</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#fs" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -1397,7 +1397,7 @@ index.deleteFiles(<span class="lit">"/data/old1.parquet"</span>, <span class="li
       <span class="symbol">
         <span class="name">fs</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.FileSystem">FileSystem</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop <code>FileSystem</code> instance resolved from the <a href="AriadneContextUser.html#storagePath:org.apache.hadoop.fs.Path" class="extmbr" name="dev.cjfravel.ariadne.AriadneContextUser#storagePath">storagePath</a> URI and the Spark Hadoop configuration.</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop <code>FileSystem</code> instance resolved from the <a href="AriadneContextUser.html#storagePath:org.apache.hadoop.fs.Path" class="extmbr" name="dev.cjfravel.ariadne.AriadneContextUser#storagePath">storagePath</a> URI and the Spark Hadoop configuration. Used for all
 filesystem operations (existence checks, reads, deletes, lock files).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -1415,7 +1415,7 @@ filesystem operations (existence checks, reads, deletes, lock files).
       <span class="symbol">
         <span class="name">getAutoBloomCandidates</span><span class="params">(<span name="column">column: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="values">values: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Any">Any</span>]</span>, <span name="indexDf">indexDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Gets candidate files from the auto-bloom filter for a specific column.</p><div class="fullcomment"><div class="comment cmt"><p>Gets candidate files from the auto-bloom filter for a specific column.</p><p>Collects all bloom filter byte arrays from the index to the driver and tests each value against them. Files whose
 bloom filter is null are included as candidates for backward compatibility with indexes built before auto-bloom was
 added.
@@ -1440,7 +1440,7 @@ added.
       <span class="symbol">
         <span class="name">getAutoBloomCandidatesFromDf</span><span class="params">(<span name="storageColumn">storageColumn: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="joinColumn">joinColumn: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="valuesDf">valuesDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="indexDf">indexDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Gets candidate files from the auto-bloom filter using values extracted from a DataFrame.</p><div class="fullcomment"><div class="comment cmt"><p>Gets candidate files from the auto-bloom filter using values extracted from a DataFrame.</p><p>Collects distinct non-null values from the given DataFrame column, then delegates to <a href="IndexQueryOperations.html#getAutoBloomCandidates(column:String,values:Array[Any],indexDf:org.apache.spark.sql.DataFrame):Option[Set[String]]" class="extmbr" name="dev.cjfravel.ariadne.IndexQueryOperations#getAutoBloomCandidates">getAutoBloomCandidates</a> for
 the actual bloom filter probing.
 </p></div><dl class="paramcmts block"><dt class="param">storageColumn</dt><dd class="cmt"><p>
@@ -1466,12 +1466,12 @@ the actual bloom filter probing.
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#getFileSizes" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getFileSizes(files:Set[String]):Map[String,Long]"></a><a id="getFileSizes(Set[String]):Map[String,Long]"></a>
@@ -1487,7 +1487,7 @@ the actual bloom filter probing.
       <span class="symbol">
         <span class="name">getFileSizes</span><span class="params">(<span name="files">files: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Predef.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Long">Long</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Computes file sizes in bytes for the given files using the Hadoop FileSystem.</p><div class="fullcomment"><div class="comment cmt"><p>Computes file sizes in bytes for the given files using the Hadoop FileSystem.</p><p>Files that cannot be found or read are silently skipped with a warning log.
 </p></div><dl class="paramcmts block"><dt class="param">files</dt><dd class="cmt"><p>
   set of fully-qualified file paths to measure</p></dd><dt>returns</dt><dd class="cmt"><p>
@@ -1506,7 +1506,7 @@ the actual bloom filter probing.
       <span class="symbol">
         <span class="name">handleLargeIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks all storage columns for arrays exceeding <code>largeIndexLimit</code> and delegates to <a href="IndexBuildOperations.html#appendToLargeIndex(df:org.apache.spark.sql.DataFrame):Unit" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#appendToLargeIndex">appendToLargeIndex</a> for
 separation.</p><div class="fullcomment"><div class="comment cmt"><p>Checks all storage columns for arrays exceeding <code>largeIndexLimit</code> and delegates to <a href="IndexBuildOperations.html#appendToLargeIndex(df:org.apache.spark.sql.DataFrame):Unit" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#appendToLargeIndex">appendToLargeIndex</a> for
 separation.
@@ -1526,7 +1526,7 @@ separation.
       <span class="symbol">
         <span class="name">hasFile</span><span class="params">(<span name="fileName">fileName: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks if a file is tracked by this index's file list.</p><div class="fullcomment"><div class="comment cmt"><p>Checks if a file is tracked by this index's file list.
 </p></div><dl class="paramcmts block"><dt class="param">fileName</dt><dd class="cmt"><p>
   The file path to check</p></dd><dt>returns</dt><dd class="cmt"><p>
@@ -1547,7 +1547,7 @@ separation.
       <span class="symbol">
         <span class="name">index</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Helper function to load the index.</p><div class="fullcomment"><div class="comment cmt"><p>Helper function to load the index.</p><p>On first call, checks for and performs any needed exploded field column migration (pre-0.1.1 indexes stored columns
 under <code>array_column</code> names).
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
@@ -1567,7 +1567,7 @@ under <code>array_column</code> names).
       <span class="symbol">
         <span class="name">indexFilePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop path for the main index Delta table (<code>{storagePath}/index/</code>).</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop path for the main index Delta table (<code>{storagePath}/index/</code>).</p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#indexRepartitionCount" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="indexRepartitionCount:Option[Int]"></a>
@@ -1583,7 +1583,7 @@ under <code>array_column</code> names).
       <span class="symbol">
         <span class="name">indexRepartitionCount</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Int">Int</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Optional number of partitions to use when repartitioning the index DataFrame during joins.</p><div class="fullcomment"><div class="comment cmt"><p>Optional number of partitions to use when repartitioning the index DataFrame during joins. When set, the index
 DataFrame is repartitioned before expensive operations like explode to reduce per-executor memory pressure and
 avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepartitionCount configuration
@@ -1603,7 +1603,7 @@ avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepa
       <span class="symbol">
         <span class="name">indexes</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns all column names that can be used in joins across all index types.</p><div class="fullcomment"><div class="comment cmt"><p>Returns all column names that can be used in joins across all index types.</p><p>Includes regular, computed, exploded field, bloom, temporal, and range index columns.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   the union of all indexed column names across every index type</p></dd></dl><dl class="attributes block"> <div class="block">Example:
@@ -1623,7 +1623,7 @@ avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepa
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.Index#join" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="join(df:org.apache.spark.sql.DataFrame,usingColumns:Seq[String],joinType:String):org.apache.spark.sql.DataFrame"></a><a id="join(DataFrame,Seq[String],String):DataFrame"></a>
@@ -1639,7 +1639,7 @@ avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepa
       <span class="symbol">
         <span class="name">join</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="usingColumns">usingColumns: <span class="extype" name="scala.Seq">Seq</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="joinType">joinType: <span class="extype" name="scala.Predef.String">String</span> = <span class="symbol">&quot;inner&quot;</span></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Joins the indexed data with the provided DataFrame.</p><div class="fullcomment"><div class="comment cmt"><p>Joins the indexed data with the provided DataFrame.</p><p>Locates relevant data files via the index, reads them, applies temporal deduplication if configured, and joins the
 result with the provided DataFrame.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
@@ -1650,7 +1650,7 @@ result with the provided DataFrame.
                <ol><li class="cmt"><p></p><pre><span class="kw">val</span> lookupDf = spark.read.parquet(<span class="lit">"/data/lookups"</span>)
 <span class="kw">val</span> result = index.join(lookupDf, <span class="std">Seq</span>(<span class="lit">"userId"</span>))
 <span class="kw">val</span> leftResult = index.join(lookupDf, <span class="std">Seq</span>(<span class="lit">"userId"</span>), <span class="lit">"left_outer"</span>)</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if df is null or usingColumns is null/empty</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexJoinOperations#joinDf" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="joinDf(df:org.apache.spark.sql.DataFrame,usingColumns:Seq[String]):org.apache.spark.sql.DataFrame"></a><a id="joinDf(DataFrame,Seq[String]):DataFrame"></a>
@@ -1666,7 +1666,7 @@ result with the provided DataFrame.
       <span class="symbol">
         <span class="name">joinDf</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="usingColumns">usingColumns: <span class="extype" name="scala.Seq">Seq</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Locates and reads indexed data files relevant to the given DataFrame.</p><div class="fullcomment"><div class="comment cmt"><p>Locates and reads indexed data files relevant to the given DataFrame.</p><p>Uses the index to identify which files contain matching values, then reads those files into a lazy DataFrame. If no
 matching files are found, returns an empty DataFrame with the stored schema. The actual row-level filtering happens
 in the subsequent join in <a href="IndexJoinOperations.html#join(df:org.apache.spark.sql.DataFrame,usingColumns:Seq[String],joinType:String):org.apache.spark.sql.DataFrame" class="extmbr" name="dev.cjfravel.ariadne.IndexJoinOperations#join">join</a>.</p><p>Logs data pruning metrics (file count, data size saved) when available, and includes detailed file-level debug
@@ -1674,8 +1674,8 @@ information when debug mode is enabled.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
   The DataFrame to match against the index.</p></dd><dt class="param">usingColumns</dt><dd class="cmt"><p>
   The columns used for the join.</p></dd><dt>returns</dt><dd class="cmt"><p>
-  A lazy DataFrame containing data from indexed files, or an empty DataFrame if no files match.</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexJoinOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexJoinOperations">IndexJoinOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if none of the join columns have indexes, or if df/usingColumns are null/empty</p></span><span class="cmt"><p><a href="exceptions/ColumnNotFoundException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.ColumnNotFoundException"><code>dev.cjfravel.ariadne.exceptions.ColumnNotFoundException</code></a>
+  A lazy DataFrame containing data from indexed files, or an empty DataFrame if no files match.</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexJoinOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexJoinOperations">IndexJoinOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if none of the join columns have indexes, or if df/usingColumns are null/empty</p></span><span class="cmt"><p><a href="exceptions/ColumnNotFoundException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.ColumnNotFoundException"><code>dev.cjfravel.ariadne.exceptions.ColumnNotFoundException</code></a> 
   if join columns are not in the selected columns, schema, or indexes</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexQueryOperations#largeIndexColumns" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="largeIndexColumns:Set[String]"></a>
@@ -1691,7 +1691,7 @@ information when debug mode is enabled.
       <span class="symbol">
         <span class="name">largeIndexColumns</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the set of column names that have large index Delta tables.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the set of column names that have large index Delta tables.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   Set of column names with large index storage</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexQueryOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexQueryOperations">IndexQueryOperations</a></dd></dl></div>
@@ -1709,7 +1709,7 @@ information when debug mode is enabled.
       <span class="symbol">
         <span class="name">largeIndexLimit</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Maximum number of distinct values per file before an index column is promoted to a &quot;large index&quot; (stored in a
 separate exploded Delta table).</p><div class="fullcomment"><div class="comment cmt"><p>Maximum number of distinct values per file before an index column is promoted to a &quot;large index&quot; (stored in a
 separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</code> (default: 500000).</p><p>If the configured value is not a valid positive number, a warning is logged and the default of 500,000 is used.
@@ -1728,7 +1728,7 @@ separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</
       <span class="symbol">
         <span class="name">largeIndexesFilePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop root path for large index Delta tables (<code>{storagePath}/large_indexes/</code>).</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop root path for large index Delta tables (<code>{storagePath}/large_indexes/</code>).
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#lastAutoBloomCache" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -1745,11 +1745,11 @@ separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</
       <span class="symbol">
         <span class="name">lastAutoBloomCache</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Tracks the cached DataFrame from <a href="IndexBuildOperations.html#buildAutoBloomIndexes(combinedDf:org.apache.spark.sql.DataFrame):org.apache.spark.sql.DataFrame" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#buildAutoBloomIndexes">buildAutoBloomIndexes</a> for deferred cleanup.</p><div class="fullcomment"><div class="comment cmt"><p>Tracks the cached DataFrame from <a href="IndexBuildOperations.html#buildAutoBloomIndexes(combinedDf:org.apache.spark.sql.DataFrame):org.apache.spark.sql.DataFrame" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#buildAutoBloomIndexes">buildAutoBloomIndexes</a> for deferred cleanup.</p><p>Set during auto-bloom processing and unpersisted after staging is complete.
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd><dt>Annotations</dt><dd>
                 <span class="name">@transient</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexQueryOperations#loadColumnIndex" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="loadColumnIndex(indexDf:org.apache.spark.sql.DataFrame,colName:String,bloomCandidateFiles:Option[Set[String]]):org.apache.spark.sql.DataFrame"></a><a id="loadColumnIndex(DataFrame,String,Option[Set[String]]):DataFrame"></a>
@@ -1765,7 +1765,7 @@ separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</
       <span class="symbol">
         <span class="name">loadColumnIndex</span><span class="params">(<span name="indexDf">indexDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="colName">colName: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="bloomCandidateFiles">bloomCandidateFiles: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]] = <span class="symbol">None</span></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns a unified (filename, colName) DataFrame for a regular index column by exploding the main index arrays and
 unioning with any large index rows that exist for that column.</p><div class="fullcomment"><div class="comment cmt"><p>Returns a unified (filename, colName) DataFrame for a regular index column by exploding the main index arrays and
 unioning with any large index rows that exist for that column.
@@ -1789,7 +1789,7 @@ unioning with any large index rows that exist for that column.
       <span class="symbol">
         <span class="name">loadLargeIndex</span><span class="params">(<span name="colName">colName: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Loads a large index Delta table for a specific column.</p><div class="fullcomment"><div class="comment cmt"><p>Loads a large index Delta table for a specific column. Large indexes store data in exploded (filename, value) row
 form rather than as arrays.
 </p></div><dl class="paramcmts block"><dt class="param">colName</dt><dd class="cmt"><p>
@@ -1809,7 +1809,7 @@ form rather than as arrays.
       <span class="symbol">
         <span class="name">loadTemporalColumnIndex</span><span class="params">(<span name="indexDf">indexDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="colName">colName: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns a unified (filename, _value, _max_ts) DataFrame for a temporal index column by exploding the main index
 struct arrays and unioning with any large index rows that exist for that column.</p><div class="fullcomment"><div class="comment cmt"><p>Returns a unified (filename, _value, _max_ts) DataFrame for a temporal index column by exploding the main index
 struct arrays and unioning with any large index rows that exist for that column.
@@ -1831,7 +1831,7 @@ struct arrays and unioning with any large index rows that exist for that column.
       <span class="symbol">
         <span class="name">locateFiles</span><span class="params">(<span name="indexes">indexes: <span class="extype" name="scala.Predef.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Any">Any</span>]]</span>)</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Locates files matching the given index values across all index types.</p><div class="fullcomment"><div class="comment cmt"><p>Locates files matching the given index values across all index types.</p><p>Queries regular, bloom, temporal, range, and auto-bloom indexes in parallel and intersects results with AND
 semantics. Each index type independently returns candidate files, and only files present in all queried categories
 are included in the final result.
@@ -1840,7 +1840,7 @@ are included in the final result.
   appropriate index type (bloom, temporal, range, or regular).</p></dd><dt>returns</dt><dd class="cmt"><p>
   A set of file paths matching all query criteria, or an empty set if no matches are found or no index exists</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexQueryOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexQueryOperations">IndexQueryOperations</a></dd><div class="block">Example:
                <ol><li class="cmt"><p></p><pre><span class="kw">val</span> matchingFiles = index.locateFiles(<span class="std">Map</span>(<span class="lit">"userId"</span> -&gt; <span class="std">Array</span>(<span class="lit">"u1"</span>, <span class="lit">"u2"</span>)))</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if <code>indexes</code> is null</p></span></dd><dt>Note</dt><dd><span class="cmt"><p>
   If a staging table exists, its contents are collected to the driver for merging. This may cause driver OOM for
   very large staging tables.</p></span></dd></dl></div>
@@ -1858,7 +1858,7 @@ are included in the final result.
       <span class="symbol">
         <span class="name">locateFilesFromDataFrame</span><span class="params">(<span name="valuesDf">valuesDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="columnMappings">columnMappings: <span class="extype" name="scala.Predef.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="joinColumns">joinColumns: <span class="extype" name="scala.Seq">Seq</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Locates files based on a DataFrame containing join column values.</p><div class="fullcomment"><div class="comment cmt"><p>Locates files based on a DataFrame containing join column values. Handles both regular indexes and bloom filter
 indexes.
 </p></div><dl class="paramcmts block"><dt class="param">valuesDf</dt><dd class="cmt"><p>
@@ -1868,7 +1868,7 @@ indexes.
   A set of file names matching the criteria.</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexQueryOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexQueryOperations">IndexQueryOperations</a></dd><div class="block">Example:
                <ol><li class="cmt"><p></p><pre><span class="kw">val</span> columnMappings = <span class="std">Map</span>(<span class="lit">"userId"</span> -&gt; <span class="lit">"userId"</span>)
 <span class="kw">val</span> files = index.locateFilesFromDataFrame(lookupDf, columnMappings, <span class="std">Seq</span>(<span class="lit">"userId"</span>))</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if <code>valuesDf</code> is null or <code>columnMappings</code> is null or empty</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.BloomFilterOperations#locateFilesWithBloom" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="locateFilesWithBloom(column:String,values:Array[Any],indexDf:org.apache.spark.sql.DataFrame):Set[String]"></a><a id="locateFilesWithBloom(String,Array[Any],DataFrame):Set[String]"></a>
@@ -1884,7 +1884,7 @@ indexes.
       <span class="symbol">
         <span class="name">locateFilesWithBloom</span><span class="params">(<span name="column">column: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="values">values: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Any">Any</span>]</span>, <span name="indexDf">indexDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Locates files that might contain any of the given values using bloom filters.</p><div class="fullcomment"><div class="comment cmt"><p>Locates files that might contain any of the given values using bloom filters.</p><p>Collects all rows from the index, deserializes each file's bloom filter for the specified column, and tests every
 candidate value. A file is included in the result if any value passes the <code>mightContain</code> check.
 </p></div><dl class="paramcmts block"><dt class="param">column</dt><dd class="cmt"><p>
@@ -1910,7 +1910,7 @@ candidate value. A file is included in the result if any value passes the <code>
       <span class="symbol">
         <span class="name">locateFilesWithBloomFromDataFrame</span><span class="params">(<span name="column">column: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="valuesDf">valuesDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="indexDf">indexDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Locates files that might contain values from a DataFrame using bloom filters.</p><div class="fullcomment"><div class="comment cmt"><p>Locates files that might contain values from a DataFrame using bloom filters.</p><p>Collects distinct non-null values from the specified column of <code>valuesDf</code>, then delegates to
 <a href="BloomFilterOperations.html#locateFilesWithBloom(column:String,values:Array[Any],indexDf:org.apache.spark.sql.DataFrame):Set[String]" class="extmbr" name="dev.cjfravel.ariadne.BloomFilterOperations#locateFilesWithBloom">locateFilesWithBloom</a> for the actual bloom filter check.
 </p></div><dl class="paramcmts block"><dt class="param">column</dt><dd class="cmt"><p>
@@ -1936,7 +1936,7 @@ candidate value. A file is included in the result if any value passes the <code>
       <span class="symbol">
         <span class="name">lockMaxWait</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Maximum total time in seconds to wait for lock acquisition before failing.</p><div class="fullcomment"><div class="comment cmt"><p>Maximum total time in seconds to wait for lock acquisition before failing. Reads from spark.ariadne.lockMaxWait
 configuration (default: 3600).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Note</dt><dd><span class="cmt"><p>
@@ -1956,7 +1956,7 @@ configuration (default: 3600).
       <span class="symbol">
         <span class="name">lockRefreshInterval</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Refresh the update lock every N batches during updateBatched.</p><div class="fullcomment"><div class="comment cmt"><p>Refresh the update lock every N batches during updateBatched. Reads from spark.ariadne.lockRefreshInterval
 configuration (default: 1).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -1974,7 +1974,7 @@ configuration (default: 1).
       <span class="symbol">
         <span class="name">lockRetryInterval</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Base interval in seconds between lock acquisition retries (exponential backoff applied).</p><div class="fullcomment"><div class="comment cmt"><p>Base interval in seconds between lock acquisition retries (exponential backoff applied). Reads from
 spark.ariadne.lockRetryInterval configuration (default: 60).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -1992,7 +1992,7 @@ spark.ariadne.lockRetryInterval configuration (default: 60).
       <span class="symbol">
         <span class="name">lockTimeout</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Seconds since <code>lastRefreshedAt</code> before a lock is considered stale and eligible for auto-heal (forcible acquisition
 by another process).</p><div class="fullcomment"><div class="comment cmt"><p>Seconds since <code>lastRefreshedAt</code> before a lock is considered stale and eligible for auto-heal (forcible acquisition
 by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default: 1800).
@@ -2011,7 +2011,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">logger</span><span class="result">: <span class="extype" name="org.apache.logging.log4j.Logger">Logger</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Log4j logger shared by all Ariadne components.</p><div class="fullcomment"><div class="comment cmt"><p>Log4j logger shared by all Ariadne components. Uses the &quot;ariadne&quot; logger name. Marked <code>@transient lazy</code> so that
 <code>Index</code> (a case class) remains serializable across Spark stages — Log4j loggers are not <code>Serializable</code>.
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a> → <a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -2029,7 +2029,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">mapJoinColumnsToStorage</span><span class="params">(<span name="joinColumns">joinColumns: <span class="extype" name="scala.Seq">Seq</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Predef.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Maps join column names to their corresponding storage column names.</p><div class="fullcomment"><div class="comment cmt"><p>Maps join column names to their corresponding storage column names.</p><p>Bloom filter columns are prefixed with the bloom prefix, range columns are prefixed with &quot;range_&quot;, exploded field
 columns are mapped to their backing array column, and all other columns map to themselves.
 </p></div><dl class="paramcmts block"><dt class="param">joinColumns</dt><dd class="cmt"><p>
@@ -2049,7 +2049,7 @@ columns are mapped to their backing array column, and all other columns map to t
       <span class="symbol">
         <span class="name">maybeAutoCompact</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Triggers compaction if the auto-compact threshold has been reached.</p><div class="fullcomment"><div class="comment cmt"><p>Triggers compaction if the auto-compact threshold has been reached.</p><p>Checks the <a href="IndexBuildOperations.html#batchesSinceCompact:Int" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#batchesSinceCompact">batchesSinceCompact</a> counter against the configured <code>autoCompactThreshold</code>. If the threshold is met,
 compacts all Delta tables and resets the counter to zero. The counter is persisted to metadata so it survives
 across Spark jobs.
@@ -2068,7 +2068,7 @@ across Spark jobs.
       <span class="symbol">
         <span class="name">maybeRepartition</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Conditionally repartitions a DataFrame if indexRepartitionCount is configured.</p><div class="fullcomment"><div class="comment cmt"><p>Conditionally repartitions a DataFrame if indexRepartitionCount is configured. This helps avoid
 FetchFailedExceptions when working with very large index DataFrames by spreading data across more partitions before
 expensive operations like explode.
@@ -2089,7 +2089,7 @@ expensive operations like explode.
       <span class="symbol">
         <span class="name">metadataExists</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks if metadata exists in the storage location.</p><div class="fullcomment"><div class="comment cmt"><p>Checks if metadata exists in the storage location.</p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   True if metadata exists, otherwise false.</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadataOperations#metadataFilePath" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -2106,7 +2106,7 @@ expensive operations like explode.
       <span class="symbol">
         <span class="name">metadataFilePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop path for the metadata file.</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop path for the metadata file.</p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   the path to <code>metadata.json</code> under the index storage directory</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#migrateExplodedFieldColumns" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -2123,7 +2123,7 @@ expensive operations like explode.
       <span class="symbol">
         <span class="name">migrateExplodedFieldColumns</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Migrates pre-0.1.1 indexes that stored exploded field columns under <code>array_column</code> names to the current <code>as_column</code>
 naming convention.</p><div class="fullcomment"><div class="comment cmt"><p>Migrates pre-0.1.1 indexes that stored exploded field columns under <code>array_column</code> names to the current <code>as_column</code>
 naming convention.</p><p>Detection: reads the main and staging Delta table schemas and checks whether any
@@ -2145,8 +2145,8 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">name</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
       <span class="permalink">
@@ -2161,7 +2161,7 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -2177,12 +2177,12 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -2198,12 +2198,12 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#open" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="open(path:org.apache.hadoop.fs.Path):org.apache.hadoop.fs.FSDataInputStream"></a><a id="open(Path):FSDataInputStream"></a>
@@ -2219,12 +2219,12 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">open</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.FSDataInputStream">FSDataInputStream</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Opens an input stream to read from a path on the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Opens an input stream to read from a path on the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to open for reading</p></dd><dt>returns</dt><dd class="cmt"><p>
-  An FSDataInputStream for reading the file contents</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  An FSDataInputStream for reading the file contents</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the file does not exist or cannot be opened</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#rangeStorageColumns" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="rangeStorageColumns:Set[String]"></a>
@@ -2240,7 +2240,7 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">rangeStorageColumns</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the set of range index storage column names (each prefixed with <code>range_</code>).</p><div class="fullcomment"><div class="comment cmt"><p>Returns the set of range index storage column names (each prefixed with <code>range_</code>).
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   set of prefixed column names (e.g., <code>range_event_date</code>)</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
@@ -2258,10 +2258,10 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">refreshMetadata</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Forces a reload of metadata from the <code>metadata.json</code> file on disk.</p><div class="fullcomment"><div class="comment cmt"><p>Forces a reload of metadata from the <code>metadata.json</code> file on disk.</p><p>Replaces the in-memory cached metadata with a freshly deserialized copy. This is called automatically by
 <span class="extype" name="metadata">metadata</span> on first access; callers may invoke it explicitly to pick up external changes.
-</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="MetadataMissingOrCorruptException"><code>MetadataMissingOrCorruptException</code></span>
+</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="MetadataMissingOrCorruptException"><code>MetadataMissingOrCorruptException</code></span> 
   if the metadata file does not exist, cannot be read, or contains invalid JSON</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#repartitionDataFiles" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="repartitionDataFiles:Boolean"></a>
@@ -2277,7 +2277,7 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">repartitionDataFiles</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">When true, applies indexRepartitionCount repartitioning to the data files read during joinDf.</p><div class="fullcomment"><div class="comment cmt"><p>When true, applies indexRepartitionCount repartitioning to the data files read during joinDf. When false, data
 files keep their natural parquet partitioning. Disable when column selection significantly reduces data volume,
 making the repartition shuffle more expensive than useful. Reads from spark.ariadne.repartitionDataFiles
@@ -2297,7 +2297,7 @@ configuration (default: false).
       <span class="symbol">
         <span class="name">requireNonReservedStagingColumn</span><span class="params">(<span name="column">column: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#safeDestroyBroadcast" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="safeDestroyBroadcast(broadcast:org.apache.spark.broadcast.Broadcast[_]):Unit"></a><a id="safeDestroyBroadcast(Broadcast[_]):Unit"></a>
@@ -2313,7 +2313,7 @@ configuration (default: false).
       <span class="symbol">
         <span class="name">safeDestroyBroadcast</span><span class="params">(<span name="broadcast">broadcast: <span class="extype" name="org.apache.spark.broadcast.Broadcast">Broadcast</span>[_]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Safely destroys a broadcast variable, logging but swallowing any exception.</p><div class="fullcomment"><div class="comment cmt"><p>Safely destroys a broadcast variable, logging but swallowing any exception.</p><p>Intended for use inside <code>finally</code> blocks where a cleanup failure must not mask the original exception propagating
 out of the <code>try</code> block. Tolerates a null broadcast.
 </p></div><dl class="paramcmts block"><dt class="param">broadcast</dt><dd class="cmt"><p>
@@ -2332,8 +2332,8 @@ out of the <code>try</code> block. Tolerates a null broadcast.
       <span class="symbol">
         <span class="name">schema</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="org.apache.spark.sql.types.StructType">StructType</span>]</span>
       </span>
-
-
+      
+      
     </li><li name="dev.cjfravel.ariadne.Index#select" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="select(columns:String*):dev.cjfravel.ariadne.Index"></a><a id="select(String*):Index"></a>
       <span class="permalink">
@@ -2348,15 +2348,15 @@ out of the <code>try</code> block. Tolerates a null broadcast.
       <span class="symbol">
         <span class="name">select</span><span class="params">(<span name="columns">columns: <span class="extype" name="scala.Predef.String">String</span>*</span>)</span><span class="result">: <a href="" class="extype" name="dev.cjfravel.ariadne.Index">Index</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Selects specific columns for optimized reading.</p><div class="fullcomment"><div class="comment cmt"><p>Selects specific columns for optimized reading.</p><p>When set, only the selected columns (plus any join columns) are read from data files, reducing I/O. Returns this
 Index for method chaining.
 </p></div><dl class="paramcmts block"><dt class="param">columns</dt><dd class="cmt"><p>
   The column names to select</p></dd><dt>returns</dt><dd class="cmt"><p>
   This Index instance for method chaining</p></dd></dl><dl class="attributes block"> <div class="block">Example:
                <ol><li class="cmt"><p></p><pre><span class="kw">val</span> result = index.select(<span class="lit">"name"</span>, <span class="lit">"email"</span>).join(df, <span class="std">Seq</span>(<span class="lit">"userId"</span>))</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="ColumnNotFoundException"><code>ColumnNotFoundException</code></span>
-  if any specified column doesn't exist in the schema</p></span><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="ColumnNotFoundException"><code>ColumnNotFoundException</code></span> 
+  if any specified column doesn't exist in the schema</p></span><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if columns is null/empty or any column is null/blank</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.Index#spark" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="spark:org.apache.spark.sql.SparkSession"></a><a id="spark:SparkSession"></a>
@@ -2372,7 +2372,7 @@ Index for method chaining.
       <span class="symbol">
         <span class="name">spark</span><span class="result">: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Implicit SparkSession that must be provided by the mixing class.</p><div class="fullcomment"><div class="comment cmt"><p>Implicit SparkSession that must be provided by the mixing class.</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.Index">Index</a> → <a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#stagingConsolidationThreshold" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="stagingConsolidationThreshold:Int"></a>
@@ -2388,7 +2388,7 @@ Index for method chaining.
       <span class="symbol">
         <span class="name">stagingConsolidationThreshold</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Number of batches to process before consolidating staged data into the main index.</p><div class="fullcomment"><div class="comment cmt"><p>Number of batches to process before consolidating staged data into the main index. This provides fault tolerance
 for large index builds - if a job fails, work is preserved up to the last consolidation point. Reads from
 spark.ariadne.stagingConsolidationThreshold configuration (default: 50).
@@ -2407,7 +2407,7 @@ spark.ariadne.stagingConsolidationThreshold configuration (default: 50).
       <span class="symbol">
         <span class="name">stagingFilePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop path for the staging Delta table (<code>{storagePath}/staging/</code>).</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop path for the staging Delta table (<code>{storagePath}/staging/</code>).</p><p>The staging table accumulates batch results during <a href="#update:Unit" class="extmbr" name="dev.cjfravel.ariadne.Index#update">update</a> and is merged into the main index by
 <a href="IndexBuildOperations.html#consolidateStaging():Unit" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#consolidateStaging">consolidateStaging</a>.
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
@@ -2425,7 +2425,7 @@ spark.ariadne.stagingConsolidationThreshold configuration (default: 50).
       <span class="symbol">
         <span class="name">stats</span><span class="params">()</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns a DataFrame of per-column index statistics and total file count.</p><div class="fullcomment"><div class="comment cmt"><p>Returns a DataFrame of per-column index statistics and total file count.</p><p>For each indexed column, computes statistics on the array length (number of distinct values per file): min, max,
 avg, median, and standard deviation. Also includes the total number of indexed files.</p><p>Returns an empty DataFrame if no index table exists. If <code>storageColumns</code> is empty (e.g., only bloom or range
 indexes), the result contains zero stat rows.
@@ -2454,7 +2454,7 @@ statsDF.show()
       <span class="symbol">
         <span class="name">storageColumns</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the set of all storage column names across regular, computed, exploded-field, and temporal index types.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the set of all storage column names across regular, computed, exploded-field, and temporal index types.</p><p>This is used internally to determine which columns to check for large-index separation and to build aggregation
 expressions.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
@@ -2473,7 +2473,7 @@ expressions.
       <span class="symbol">
         <span class="name">storagePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Path to the storage location of the index.</p><div class="fullcomment"><div class="comment cmt"><p>Path to the storage location of the index.</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.Index">Index</a> → <a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexFileOperations#storedSchema" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="storedSchema:org.apache.spark.sql.types.StructType"></a><a id="storedSchema:StructType"></a>
@@ -2489,14 +2489,14 @@ expressions.
       <span class="symbol">
         <span class="name">storedSchema</span><span class="result">: <span class="extype" name="org.apache.spark.sql.types.StructType">StructType</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the stored schema of the index.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the stored schema of the index.</p><p>Parses the JSON schema string from metadata into a Spark StructType.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   The StructType schema parsed from metadata</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a></dd><div class="block">Example:
                <ol><li class="cmt"><p></p><pre><span class="kw">val</span> schema = index.storedSchema
 schema.printTreeString()</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="SchemaParseException"><code>SchemaParseException</code></span>
-  if the schema string cannot be parsed as a StructType</p></span><span class="cmt"><p><a href="exceptions/MissingSchemaException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.MissingSchemaException"><code>dev.cjfravel.ariadne.exceptions.MissingSchemaException</code></a>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="SchemaParseException"><code>SchemaParseException</code></span> 
+  if the schema string cannot be parsed as a StructType</p></span><span class="cmt"><p><a href="exceptions/MissingSchemaException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.MissingSchemaException"><code>dev.cjfravel.ariadne.exceptions.MissingSchemaException</code></a> 
   if the schema is null in metadata</p></span></dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -2512,7 +2512,7 @@ schema.printTreeString()</pre></li></ol>
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.Index#update" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="update:Unit"></a>
@@ -2528,7 +2528,7 @@ schema.printTreeString()</pre></li></ol>
       <span class="symbol">
         <span class="name">update</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Updates the index with new files and backfills newly added columns.</p><div class="fullcomment"><div class="comment cmt"><p>Updates the index with new files and backfills newly added columns.</p><p>Processes all unindexed files registered via <a href="#addFile(fileNames:String*):Unit" class="extmbr" name="dev.cjfravel.ariadne.Index#addFile">addFile</a>, using intelligent batching based on pre-flight analysis.
 Also backfills existing files when new index columns have been added since the last update.
 </p></div><dl class="attributes block"> <div class="block">Example:
@@ -2536,7 +2536,7 @@ Also backfills existing files when new index columns have been added since the l
 index.addIndex(<span class="lit">"userId"</span>)
 index.addFile(<span class="lit">"/data/events/2024-01-01.parquet"</span>)
 index.update</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IndexLockException"><code>IndexLockException</code></span>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IndexLockException"><code>IndexLockException</code></span> 
   if the update lock cannot be acquired within the configured timeout</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.Index#updateLockPath" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="updateLockPath:org.apache.hadoop.fs.Path"></a><a id="updateLockPath:Path"></a>
@@ -2552,7 +2552,7 @@ index.update</pre></li></ol>
       <span class="symbol">
         <span class="name">updateLockPath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Lock path for index update and storage migration operations.</p><div class="fullcomment"><div class="comment cmt"><p>Lock path for index update and storage migration operations.</p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.Index#vacuum" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="vacuum(retentionHours:Int):Unit"></a><a id="vacuum(Int):Unit"></a>
@@ -2568,14 +2568,14 @@ index.update</pre></li></ol>
       <span class="symbol">
         <span class="name">vacuum</span><span class="params">(<span name="retentionHours">retentionHours: <span class="extype" name="scala.Int">Int</span> = <span class="symbol">168</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Vacuums all Delta tables belonging to this index to remove old files.</p><div class="fullcomment"><div class="comment cmt"><p>Vacuums all Delta tables belonging to this index to remove old files. Acquires the update lock to prevent
 concurrent modifications.
 </p></div><dl class="paramcmts block"><dt class="param">retentionHours</dt><dd class="cmt"><p>
   number of hours of history to retain (default 168 = 7 days)</p></dd></dl><dl class="attributes block"> <div class="block">Example:
                <ol><li class="cmt"><p></p><pre>index.vacuum()          <span class="cmt">// default 7 days retention</span>
 index.vacuum(<span class="num">24</span>)        <span class="cmt">// 1 day retention</span></pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IndexLockException"><code>IndexLockException</code></span>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IndexLockException"><code>IndexLockException</code></span> 
   if the update lock cannot be acquired within the configured timeout</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#vacuumDeltaTables" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="vacuumDeltaTables(retentionHours:Int):Unit"></a><a id="vacuumDeltaTables(Int):Unit"></a>
@@ -2591,7 +2591,7 @@ index.vacuum(<span class="num">24</span>)        <span class="cmt">// 1 day rete
       <span class="symbol">
         <span class="name">vacuumDeltaTables</span><span class="params">(<span name="retentionHours">retentionHours: <span class="extype" name="scala.Int">Int</span> = <span class="symbol">168</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Vacuums all Delta tables (main index and large index tables) to remove old files.</p><div class="fullcomment"><div class="comment cmt"><p>Vacuums all Delta tables (main index and large index tables) to remove old files.</p><p>Uses Delta Lake's VACUUM command to delete data files no longer referenced by the transaction log. Temporarily
 disables the retention duration safety check when <code>retentionHours</code> is zero or negative.
 </p></div><dl class="paramcmts block"><dt class="param">retentionHours</dt><dd class="cmt"><p>
@@ -2613,13 +2613,13 @@ disables the retention duration safety check when <code>retentionHours</code> is
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -2635,15 +2635,15 @@ disables the retention duration safety check when <code>retentionHours</code> is
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -2659,13 +2659,13 @@ disables the retention duration safety check when <code>retentionHours</code> is
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadataOperations#writeMetadata" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="writeMetadata(metadata:dev.cjfravel.ariadne.IndexMetadata):Unit"></a><a id="writeMetadata(IndexMetadata):Unit"></a>
@@ -2681,19 +2681,19 @@ disables the retention duration safety check when <code>retentionHours</code> is
       <span class="symbol">
         <span class="name">writeMetadata</span><span class="params">(<span name="metadata">metadata: <a href="IndexMetadata.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadata">IndexMetadata</a></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Writes metadata to the <code>metadata.json</code> file and updates the in-memory cache.</p><div class="fullcomment"><div class="comment cmt"><p>Writes metadata to the <code>metadata.json</code> file and updates the in-memory cache.</p><p>Creates the parent directory if it does not exist. JSON is written and validated at a unique sibling path, then
 replaced through Hadoop's overwrite rename operation. The replacement is atomic on filesystems with atomic rename
 semantics (such as HDFS); object-store connectors may implement rename as copy/delete and cannot provide the same
 guarantee.
 </p></div><dl class="paramcmts block"><dt class="param">metadata</dt><dd class="cmt"><p>
-  the metadata instance to serialize and persist</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  the metadata instance to serialize and persist</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the write fails (the error is logged before propagating)</p></span></dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -2711,15 +2711,15 @@ guarantee.
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -2753,13 +2753,13 @@ guarantee.
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/IndexBuildOperations$FileAnalysis.html
+++ b/docs/api/dev/cjfravel/ariadne/IndexBuildOperations$FileAnalysis.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.IndexBuildOperations.FileAnalysis" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.IndexBuildOperations.FileAnalysis" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations" visbl="pub" class="indented4 " data-isabs="true" fullComment="yes" group="Ungrouped">
       <a id="IndexBuildOperationsextendsBloomFilterOperations"></a><a id="IndexBuildOperations:IndexBuildOperations"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="Trait providing index building and maintenance operations for Index instances." href="IndexBuildOperations.html"><span class="name">IndexBuildOperations</span></a><span class="result"> extends <a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Trait providing index building and maintenance operations for <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a> instances.</p><div class="fullcomment"><div class="comment cmt"><p>Trait providing index building and maintenance operations for <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a> instances.</p><p>This trait implements the core data pipeline for building and maintaining file-level indexes. It is mixed into
 <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a> via the trait hierarchy and handles the complete update lifecycle:</p><p>Update pipeline (data flow):</p><ol class="decimal"><li><a href="IndexBuildOperations.html#analyzeFiles(files:Set[String]):Seq[IndexBuildOperations.this.FileAnalysis]" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#analyzeFiles">analyzeFiles</a> — Pre-flight scan that computes per-file distinct value counts for all indexed columns. This
      information drives batching decisions.
@@ -180,7 +180,7 @@ are built for these columns in the main index to enable pre-filtering at query t
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Case class to hold file analysis results for batching decisions.
 </p></div><dl class="paramcmts block"><dt class="param">filename</dt><dd class="cmt"><p>
   The name of the file</p></dd><dt class="param">distinctCounts</dt><dd class="cmt"><p>
@@ -191,7 +191,7 @@ are built for these columns in the main index to enable pre-filtering at query t
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="scala.Serializable">Serializable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.Product">Product</span>, <span class="extype" name="scala.Equals">Equals</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -206,7 +206,7 @@ are built for these columns in the main index to enable pre-filtering at query t
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -249,7 +249,7 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <span class="name">FileAnalysis</span><span class="params">(<span name="filename">filename: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="distinctCounts">distinctCounts: <span class="extype" name="scala.Predef.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Long">Long</span>]</span>, <span name="maxDistinctCount">maxDistinctCount: <span class="extype" name="scala.Long">Long</span></span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">filename</dt><dd class="cmt"><p>
   The name of the file</p></dd><dt class="param">distinctCounts</dt><dd class="cmt"><p>
   Map of column name to distinct value count for that file</p></dd><dt class="param">maxDistinctCount</dt><dd class="cmt"><p>
@@ -257,9 +257,9 @@ are built for these columns in the main index to enable pre-filtering at query t
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -278,7 +278,7 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -294,7 +294,7 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -310,7 +310,7 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -326,7 +326,7 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -342,17 +342,17 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations.FileAnalysis#distinctCounts" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="distinctCounts:Map[String,Long]"></a>
@@ -368,8 +368,8 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <span class="name">distinctCounts</span><span class="result">: <span class="extype" name="scala.Predef.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Long">Long</span>]</span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
       <span class="permalink">
@@ -384,7 +384,7 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations.FileAnalysis#filename" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="filename:String"></a>
@@ -400,8 +400,8 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <span class="name">filename</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
       <span class="permalink">
@@ -416,12 +416,12 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -437,7 +437,7 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations.FileAnalysis#maxDistinctCount" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="maxDistinctCount:Long"></a>
@@ -453,8 +453,8 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <span class="name">maxDistinctCount</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
       <span class="permalink">
@@ -469,7 +469,7 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -485,12 +485,12 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -506,12 +506,12 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -527,7 +527,7 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -543,13 +543,13 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -565,15 +565,15 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -589,19 +589,19 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -619,15 +619,15 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -647,13 +647,13 @@ are built for these columns in the main index to enable pre-filtering at query t
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/IndexBuildOperations.html
+++ b/docs/api/dev/cjfravel/ariadne/IndexBuildOperations.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.IndexBuildOperations" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.IndexBuildOperations" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="catalog/index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -147,7 +147,7 @@
       <span class="symbol">
         <a title="" href="exceptions/index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented3">
                         <span class="separator"></span>
@@ -256,7 +256,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Trait providing index building and maintenance operations for <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a> instances.</p><p>This trait implements the core data pipeline for building and maintaining file-level indexes. It is mixed into
 <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a> via the trait hierarchy and handles the complete update lifecycle:</p><p>Update pipeline (data flow):</p><ol class="decimal"><li><a href="#analyzeFiles(files:Set[String]):Seq[IndexBuildOperations.this.FileAnalysis]" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#analyzeFiles">analyzeFiles</a> — Pre-flight scan that computes per-file distinct value counts for all indexed columns. This
      information drives batching decisions.
@@ -284,7 +284,7 @@ are built for these columns in the main index to enable pre-filtering at query t
             </span>
             <div class="subClasses hiddenContent"><a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a>, <a href="IndexJoinOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexJoinOperations">IndexJoinOperations</a>, <a href="IndexQueryOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexQueryOperations">IndexQueryOperations</a></div>
           </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -299,7 +299,7 @@ are built for these columns in the main index to enable pre-filtering at query t
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -326,7 +326,7 @@ are built for these columns in the main index to enable pre-filtering at query t
 
       <div id="template">
         <div id="allMembers">
-
+        
 
         <div id="types" class="types members">
               <h3>Type Members</h3>
@@ -344,7 +344,7 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <a title="Case class to hold file analysis results for batching decisions." href="IndexBuildOperations$FileAnalysis.html"><span class="name">FileAnalysis</span></a><span class="params">(<span name="filename">filename: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="distinctCounts">distinctCounts: <span class="extype" name="scala.Predef.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Long">Long</span>]</span>, <span name="maxDistinctCount">maxDistinctCount: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result"> extends <span class="extype" name="scala.Product">Product</span> with <span class="extype" name="scala.Serializable">Serializable</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Case class to hold file analysis results for batching decisions.</p><div class="fullcomment"><div class="comment cmt"><p>Case class to hold file analysis results for batching decisions.
 </p></div><dl class="paramcmts block"><dt class="param">filename</dt><dd class="cmt"><p>
   The name of the file</p></dd><dt class="param">distinctCounts</dt><dd class="cmt"><p>
@@ -369,7 +369,7 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <span class="name">spark</span><span class="result">: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Implicit SparkSession that must be provided by the mixing class.</p><div class="fullcomment"><div class="comment cmt"><p>Implicit SparkSession that must be provided by the mixing class.</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
     </li></ol>
             </div>
@@ -391,7 +391,7 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -407,7 +407,7 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -423,7 +423,7 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexFileOperations#addFilenameColumn" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addFilenameColumn(df:org.apache.spark.sql.DataFrame,files:Set[String]):org.apache.spark.sql.DataFrame"></a><a id="addFilenameColumn(DataFrame,Set[String]):DataFrame"></a>
@@ -439,7 +439,7 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <span class="name">addFilenameColumn</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="files">files: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Adds a stable filename column to the DataFrame.</p><div class="fullcomment"><div class="comment cmt"><p>Adds a stable filename column to the DataFrame.</p><p>Uses <code>input_file_name()</code> to capture the source file path. For single-file reads where Spark may report an empty
 filename, falls back to the known file path.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
@@ -460,7 +460,7 @@ filename, falls back to the known file path.
       <span class="symbol">
         <span class="name">analyzeFiles</span><span class="params">(<span name="files">files: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Seq">Seq</span>[<a href="Index.html#FileAnalysisextendsProductwithSerializable" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations.FileAnalysis">Index.FileAnalysis</a>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Performs pre-flight analysis on unindexed files to determine optimal batching strategy.</p><div class="fullcomment"><div class="comment cmt"><p>Performs pre-flight analysis on unindexed files to determine optimal batching strategy.</p><p>Reads the source files, applies computed indexes, and counts distinct values per indexed column per file. The
 resulting <a href="IndexBuildOperations$FileAnalysis.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations.FileAnalysis">FileAnalysis</a> objects are used by <a href="#createOptimalBatches(fileAnalyses:Seq[IndexBuildOperations.this.FileAnalysis]):Seq[Set[String]]" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#createOptimalBatches">createOptimalBatches</a> to group files into batches that stay under
 the <code>largeIndexLimit</code>.</p><p>If no storage columns are configured (e.g., only bloom or range indexes), returns trivial analyses with zero
@@ -485,7 +485,7 @@ distinct counts.
       <span class="symbol">
         <span class="name">appendToLargeIndex</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Appends large index data to per-column Delta tables under <code>large_indexes/</code>.</p><div class="fullcomment"><div class="comment cmt"><p>Appends large index data to per-column Delta tables under <code>large_indexes/</code>.</p><p>For each storage column, identifies rows where the array size meets or exceeds <code>largeIndexLimit</code>, explodes those
 arrays into individual rows, and writes them to <code>large_indexes/{column}/</code>. Before appending, any existing rows for
 the same filenames are removed via Delta MERGE to prevent duplicates (important during column backfill or
@@ -510,7 +510,7 @@ re-indexing).
       <span class="symbol">
         <span class="name">appendToStaging</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Appends the processed DataFrame to the staging Delta table.</p><div class="fullcomment"><div class="comment cmt"><p>Appends the processed DataFrame to the staging Delta table.</p><p>Before writing, any column whose array size meets or exceeds <code>largeIndexLimit</code> is nulled out (those values are
 stored separately via <a href="#appendToLargeIndex(df:org.apache.spark.sql.DataFrame):Unit" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#appendToLargeIndex">appendToLargeIndex</a>). The DataFrame is written in append mode with schema merge enabled.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
@@ -529,7 +529,7 @@ stored separately via <a href="#appendToLargeIndex(df:org.apache.spark.sql.DataF
       <span class="symbol">
         <span class="name">applyColumnSelection</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Applies column selection if columns have been specified via select().</p><div class="fullcomment"><div class="comment cmt"><p>Applies column selection if columns have been specified via select(). Only reads the explicitly selected columns.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
   The DataFrame to apply column selection to</p></dd><dt>returns</dt><dd class="cmt"><p>
@@ -548,12 +548,12 @@ stored separately via <a href="#appendToLargeIndex(df:org.apache.spark.sql.DataF
       <span class="symbol">
         <span class="name">applyComputedIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Applies computed indexes to a DataFrame by adding computed columns.</p><div class="fullcomment"><div class="comment cmt"><p>Applies computed indexes to a DataFrame by adding computed columns.</p><p>Each computed index is a Spark SQL expression stored in metadata. The expression is evaluated via <code>expr()</code> and
 added as a new column. If no computed indexes are configured, the DataFrame is returned unchanged.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
   The base DataFrame</p></dd><dt>returns</dt><dd class="cmt"><p>
-  DataFrame with computed index columns added</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="org.apache.spark.sql.AnalysisException"><code>org.apache.spark.sql.AnalysisException</code></span>
+  DataFrame with computed index columns added</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="org.apache.spark.sql.AnalysisException"><code>org.apache.spark.sql.AnalysisException</code></span> 
   if a computed index expression is invalid or references non-existent columns</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexFileOperations#applyExplodedFields" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="applyExplodedFields(df:org.apache.spark.sql.DataFrame):org.apache.spark.sql.DataFrame"></a><a id="applyExplodedFields(DataFrame):DataFrame"></a>
@@ -569,7 +569,7 @@ added as a new column. If no computed indexes are configured, the DataFrame is r
       <span class="symbol">
         <span class="name">applyExplodedFields</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Applies exploded field transformations to a DataFrame.</p><div class="fullcomment"><div class="comment cmt"><p>Applies exploded field transformations to a DataFrame.</p><p>For each configured exploded field, extracts the nested field path from the array column and explodes it into a
 top-level column. This is used on the read/join path to prepare data for joining on exploded field values.</p><p>Note that <code>explode()</code> (not <code>explode_outer()</code>) is used intentionally — rows with null or empty arrays are dropped
 because they contain no matchable values for the join. This is consistent with the index build path which also
@@ -591,7 +591,7 @@ excludes null/empty arrays.
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#autoBloomColumnPrefix" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="autoBloomColumnPrefix:String"></a>
@@ -607,7 +607,7 @@ excludes null/empty arrays.
       <span class="symbol">
         <span class="name">autoBloomColumnPrefix</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Column name prefix for auto-bloom filter storage in the main index table.</p><div class="fullcomment"><div class="comment cmt"><p>Column name prefix for auto-bloom filter storage in the main index table.
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#autoBloomFpr" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -624,7 +624,7 @@ excludes null/empty arrays.
       <span class="symbol">
         <span class="name">autoBloomFpr</span><span class="result">: <span class="extype" name="scala.Double">Double</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">False positive rate for auto-bloom filters on large index columns.</p><div class="fullcomment"><div class="comment cmt"><p>False positive rate for auto-bloom filters on large index columns. When a column exceeds largeIndexLimit, an
 auto-bloom filter is built with this FPR to enable file pruning at query time. Reads from
 spark.ariadne.autoBloomFpr configuration (default: 0.01).
@@ -643,7 +643,7 @@ spark.ariadne.autoBloomFpr configuration (default: 0.01).
       <span class="symbol">
         <span class="name">autoBloomStorageColumns</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the set of auto-bloom storage column names (each prefixed with <code>auto_bloom_</code>).</p><div class="fullcomment"><div class="comment cmt"><p>Returns the set of auto-bloom storage column names (each prefixed with <code>auto_bloom_</code>).
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   set of prefixed column names (e.g., <code>auto_bloom_user_id</code>)</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd></dl></div>
@@ -661,7 +661,7 @@ spark.ariadne.autoBloomFpr configuration (default: 0.01).
       <span class="symbol">
         <span class="name">autoCompactThreshold</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Int">Int</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Optional threshold for auto-compaction.</p><div class="fullcomment"><div class="comment cmt"><p>Optional threshold for auto-compaction. When set, the main index Delta table is compacted after an update if the
 number of Delta log JSON files meets or exceeds this value. Reads from spark.ariadne.autoCompactThreshold
 configuration (default: not set).
@@ -680,7 +680,7 @@ configuration (default: not set).
       <span class="symbol">
         <span class="name">batchesSinceCompact</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Counter tracking batches processed since the last auto-compaction.</p><div class="fullcomment"><div class="comment cmt"><p>Counter tracking batches processed since the last auto-compaction.</p><p>Incremented after each batch in <code>updateBatched</code> and reset to zero after each compaction cycle or at the start of
 each <a href="Index.html#update:Unit" class="extmbr" name="dev.cjfravel.ariadne.Index#update">update</a> call to prevent stale counts from a previous <code>update</code> from triggering premature
 compaction.
@@ -699,7 +699,7 @@ compaction.
       <span class="symbol">
         <span class="name">bloomColumnPrefix</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Column name prefix used when storing bloom filter binary data in the index Delta table.</p><div class="fullcomment"><div class="comment cmt"><p>Column name prefix used when storing bloom filter binary data in the index Delta table.
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.BloomFilterOperations#bloomColumns" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -716,7 +716,7 @@ compaction.
       <span class="symbol">
         <span class="name">bloomColumns</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the set of source column names that have bloom indexes configured.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the set of source column names that have bloom indexes configured.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   set of column names (without the <code>bloom_</code> prefix)</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd></dl></div>
@@ -734,7 +734,7 @@ compaction.
       <span class="symbol">
         <span class="name">bloomContainsUdf</span><span class="result">: <span class="extype" name="org.apache.spark.sql.expressions.UserDefinedFunction">UserDefinedFunction</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Creates a Spark UDF for checking bloom filter membership at query time.</p><div class="fullcomment"><div class="comment cmt"><p>Creates a Spark UDF for checking bloom filter membership at query time.</p><p>The returned UDF accepts a serialized bloom filter (<code>Array[Byte]</code>) and a candidate value (<code>String</code>), and returns
 <code>true</code> if the bloom filter indicates the value might be present.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
@@ -753,7 +753,7 @@ compaction.
       <span class="symbol">
         <span class="name">bloomIndexConfigs</span><span class="result">: <span class="extype" name="scala.Seq">Seq</span>[<a href="BloomIndexConfig.html" class="extype" name="dev.cjfravel.ariadne.BloomIndexConfig">BloomIndexConfig</a>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the bloom index configurations from the current index metadata.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the bloom index configurations from the current index metadata.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   sequence of <a href="BloomIndexConfig.html" class="extype" name="dev.cjfravel.ariadne.BloomIndexConfig">BloomIndexConfig</a> objects, one per bloom-indexed column</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd></dl></div>
@@ -771,7 +771,7 @@ compaction.
       <span class="symbol">
         <span class="name">bloomMightContain</span><span class="params">(<span name="bloomBytes">bloomBytes: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Byte">Byte</span>]</span>, <span name="value">value: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks if a value might be contained in a serialized bloom filter.</p><div class="fullcomment"><div class="comment cmt"><p>Checks if a value might be contained in a serialized bloom filter.</p><p>Deserializes the bloom filter and performs a <code>mightContain</code> check. Returns <code>false</code> if either argument is <code>null</code>.
 </p></div><dl class="paramcmts block"><dt class="param">bloomBytes</dt><dd class="cmt"><p>
   serialized bloom filter bytes</p></dd><dt class="param">value</dt><dd class="cmt"><p>
@@ -791,7 +791,7 @@ compaction.
       <span class="symbol">
         <span class="name">bloomStorageColumns</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the set of storage column names used for bloom filter binary data.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the set of storage column names used for bloom filter binary data.</p><p>Each name is the source column name prefixed with <a href="BloomFilterOperations.html#bloomColumnPrefix:String" class="extmbr" name="dev.cjfravel.ariadne.BloomFilterOperations#bloomColumnPrefix">bloomColumnPrefix</a>.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   set of prefixed column names (e.g., <code>bloom_user_id</code>)</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd></dl></div>
@@ -809,7 +809,7 @@ compaction.
       <span class="symbol">
         <span class="name">buildAutoBloomIndexes</span><span class="params">(<span name="combinedDf">combinedDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds auto-bloom filters for columns that exceed the large index limit.</p><div class="fullcomment"><div class="comment cmt"><p>Builds auto-bloom filters for columns that exceed the large index limit.</p><p>Scans the combined DataFrame to identify columns with any file whose array size meets or exceeds <code>largeIndexLimit</code>.
 For each such column, a bloom filter is built from the full array and stored in the main index with the
 <code>auto_bloom_</code> prefix. At query time, these bloom filters enable fast pre-filtering to determine which files need to
@@ -834,7 +834,7 @@ unpersisted before the exception is rethrown.
       <span class="symbol">
         <span class="name">buildBloomFilterIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds bloom filter indexes for all configured bloom columns.</p><div class="fullcomment"><div class="comment cmt"><p>Builds bloom filter indexes for all configured bloom columns.</p><p>For each <a href="BloomIndexConfig.html" class="extype" name="dev.cjfravel.ariadne.BloomIndexConfig">BloomIndexConfig</a>, this method:</p><ol class="decimal"><li>Groups the input data by filename 2. Collects distinct values per file into a set 3. Creates a bloom filter
      from the collected values using <a href="BloomFilterOperations.html#createBloomFilterUdf(fprValue:Double):org.apache.spark.sql.expressions.UserDefinedFunction" class="extmbr" name="dev.cjfravel.ariadne.BloomFilterOperations#createBloomFilterUdf">createBloomFilterUdf</a> 4. Joins the resulting bloom column back onto the
      accumulating DataFrame</li></ol><p>If no bloom indexes are configured, returns a distinct filename-only DataFrame.
@@ -855,7 +855,7 @@ unpersisted before the exception is rethrown.
       <span class="symbol">
         <span class="name">buildExplodedFieldIndexes</span><span class="params">(<span name="baseData">baseData: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="resultDf">resultDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds exploded field indexes and joins them onto the result DataFrame.</p><div class="fullcomment"><div class="comment cmt"><p>Builds exploded field indexes and joins them onto the result DataFrame.</p><p>For each configured exploded field index, extracts the nested field path from the array column, explodes it,
 collects distinct values back into an array per file, and joins the result onto <code>resultDf</code>.
 </p></div><dl class="paramcmts block"><dt class="param">baseData</dt><dd class="cmt"><p>
@@ -876,7 +876,7 @@ collects distinct values back into an array per file, and joins the result onto 
       <span class="symbol">
         <span class="name">buildRangeIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds range indexes storing <code>Struct(min, max)</code> per file.</p><div class="fullcomment"><div class="comment cmt"><p>Builds range indexes storing <code>Struct(min, max)</code> per file.</p><p>For each range index configuration, groups by <code>filename</code> and computes the <code>min</code> and <code>max</code> of the column per file.
 The result is a struct column named <code>range_{column}</code>.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
@@ -897,7 +897,7 @@ The result is a struct column named <code>range_{column}</code>.
       <span class="symbol">
         <span class="name">buildRegularIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds regular (array-aggregated) indexes for all configured regular and computed columns.</p><div class="fullcomment"><div class="comment cmt"><p>Builds regular (array-aggregated) indexes for all configured regular and computed columns.</p><p>Groups the input data by filename and collects distinct values into arrays via <code>collect_set</code>. If no regular or
 computed indexes are configured, returns a distinct filename-only DataFrame.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
@@ -917,7 +917,7 @@ computed indexes are configured, returns a distinct filename-only DataFrame.
       <span class="symbol">
         <span class="name">buildTemporalIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds temporal indexes storing <code>Array[Struct(value, max_ts)]</code> per file.</p><div class="fullcomment"><div class="comment cmt"><p>Builds temporal indexes storing <code>Array[Struct(value, max_ts)]</code> per file.</p><p>For each temporal index configuration, groups by <code>(filename, value_column)</code> to find the maximum timestamp per value
 per file, then collects the <code>(value, max_ts)</code> structs into an array per file. This enables temporal deduplication
 at query time.
@@ -939,17 +939,17 @@ at query time.
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#compactDeltaTables" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="compactDeltaTables():Unit"></a>
@@ -965,7 +965,7 @@ at query time.
       <span class="symbol">
         <span class="name">compactDeltaTables</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Compacts all Delta tables (main index and large index tables) using Delta OPTIMIZE.</p><div class="fullcomment"><div class="comment cmt"><p>Compacts all Delta tables (main index and large index tables) using Delta OPTIMIZE.</p><p>Runs Delta Lake's OPTIMIZE command to consolidate small files into larger ones, improving read performance.
 Processes the main index table first, then each large index column table.
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd></dl></div>
@@ -983,7 +983,7 @@ Processes the main index table first, then each large index column table.
       <span class="symbol">
         <span class="name">consolidateStaging</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Consolidates staged data into the main index table.</p><div class="fullcomment"><div class="comment cmt"><p>Consolidates staged data into the main index table.</p><p>Delegates to <span class="extype" name="consolidateMainStaging">consolidateMainStaging</span> which performs a Delta MERGE (upsert) of all staged rows into the main
 index, then deletes the staging table. Logs the total time taken.
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd></dl></div>
@@ -1001,12 +1001,12 @@ index, then deletes the staging table. Logs the total time taken.
       <span class="symbol">
         <span class="name">createBaseDataFrame</span><span class="params">(<span name="files">files: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Creates a base DataFrame from the provided files using the stored format and schema.</p><div class="fullcomment"><div class="comment cmt"><p>Creates a base DataFrame from the provided files using the stored format and schema. Applies any read options
 configured in the index metadata.</p><p>Returns an empty DataFrame (with the stored schema) if all file paths are blank after normalization.
 </p></div><dl class="paramcmts block"><dt class="param">files</dt><dd class="cmt"><p>
   Set of file paths to read</p></dd><dt>returns</dt><dd class="cmt"><p>
-  DataFrame with data from the specified files</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+  DataFrame with data from the specified files</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if the stored format is not csv, parquet, or json</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.BloomFilterOperations#createBloomFilterUdf" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="createBloomFilterUdf(fprValue:Double):org.apache.spark.sql.expressions.UserDefinedFunction"></a><a id="createBloomFilterUdf(Double):UserDefinedFunction"></a>
@@ -1022,7 +1022,7 @@ configured in the index metadata.</p><p>Returns an empty DataFrame (with the sto
       <span class="symbol">
         <span class="name">createBloomFilterUdf</span><span class="params">(<span name="fprValue">fprValue: <span class="extype" name="scala.Double">Double</span></span>)</span><span class="result">: <span class="extype" name="org.apache.spark.sql.expressions.UserDefinedFunction">UserDefinedFunction</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Creates a Spark UDF that converts a collected set of values into a serialized bloom filter.</p><div class="fullcomment"><div class="comment cmt"><p>Creates a Spark UDF that converts a collected set of values into a serialized bloom filter.</p><p>The UDF is designed for use inside <code>agg(bloomUdf(collect_set(...)))</code>. It:</p><ol class="decimal"><li>Filters out null values from the input sequence 2. Creates a Guava <code>BloomFilter</code> sized for the actual number
      of non-null elements 3. Inserts each value (converted to <code>String</code>) into the filter 4. Serializes the filter to
      <code>Array[Byte]</code> via <code>ByteArrayOutputStream</code></li></ol><p>The <code>fprValue</code> parameter is captured as a local <code>val</code> to ensure it is serializable when the UDF closure is shipped
@@ -1030,7 +1030,7 @@ to Spark executors.
 </p></div><dl class="paramcmts block"><dt class="param">fprValue</dt><dd class="cmt"><p>
   the desired false positive rate (e.g., 0.01 for 1%); must be strictly between 0 and 1 (exclusive)</p></dd><dt>returns</dt><dd class="cmt"><p>
   a UDF that accepts <code>Seq[Any]</code> (from <code>collect_set</code>) and returns <code>Array[Byte]</code>, or <code>null</code> if the input is null or
-  contains only nulls</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+  contains only nulls</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if <code>fprValue</code> is not in the range (0, 1)</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#createOptimalBatches" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="createOptimalBatches(fileAnalyses:Seq[IndexBuildOperations.this.FileAnalysis]):Seq[Set[String]]"></a><a id="createOptimalBatches(Seq[Index.FileAnalysis]):Seq[Set[String]]"></a>
@@ -1046,7 +1046,7 @@ to Spark executors.
       <span class="symbol">
         <span class="name">createOptimalBatches</span><span class="params">(<span name="fileAnalyses">fileAnalyses: <span class="extype" name="scala.Seq">Seq</span>[<a href="Index.html#FileAnalysisextendsProductwithSerializable" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations.FileAnalysis">Index.FileAnalysis</a>]</span>)</span><span class="result">: <span class="extype" name="scala.Seq">Seq</span>[<span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Groups files into batches whose aggregate <code>maxDistinctCount</code> stays at or below <code>largeIndexLimit</code>.</p><div class="fullcomment"><div class="comment cmt"><p>Groups files into batches whose aggregate <code>maxDistinctCount</code> stays at or below <code>largeIndexLimit</code>.</p><p>The algorithm sorts files by <code>maxDistinctCount</code> (largest first) and packs them sequentially into batches. When
 adding a file would push the batch total past the limit, a new batch is started. Files that individually exceed the
 limit are placed into single-file batches to guarantee progress.
@@ -1067,7 +1067,7 @@ limit are placed into single-file batches to guarantee progress.
       <span class="symbol">
         <span class="name">debugEnabled</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">When true, logs detailed diagnostics during join operations including partition counts, physical plans, and
 per-phase timing.</p><div class="fullcomment"><div class="comment cmt"><p>When true, logs detailed diagnostics during join operations including partition counts, physical plans, and
 per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
@@ -1086,12 +1086,12 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">delete</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Deletes a path recursively from the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Deletes a path recursively from the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to delete</p></dd><dt>returns</dt><dd class="cmt"><p>
-  true if the path was successfully deleted</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  true if the path was successfully deleted</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the filesystem operation fails</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#delta" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="delta(path:org.apache.hadoop.fs.Path):Option[io.delta.tables.DeltaTable]"></a><a id="delta(Path):Option[DeltaTable]"></a>
@@ -1107,7 +1107,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">delta</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="io.delta.tables.DeltaTable">DeltaTable</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns a <span class="extype" name="io.delta.tables.DeltaTable">io.delta.tables.DeltaTable</span> if the path exists and contains valid Delta metadata.</p><div class="fullcomment"><div class="comment cmt"><p>Returns a <span class="extype" name="io.delta.tables.DeltaTable">io.delta.tables.DeltaTable</span> if the path exists and contains valid Delta metadata.</p><p>If the path exists but is <i>not</i> a valid Delta table (e.g., leftover partial write), the directory is deleted and
 <code>None</code> is returned so it can be recreated cleanly on the next write.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
@@ -1127,12 +1127,12 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">deserializeBloomFilter</span><span class="params">(<span name="bytes">bytes: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Byte">Byte</span>]</span>)</span><span class="result">: <span class="extype" name="com.google.common.hash.BloomFilter">BloomFilter</span>[<span class="extype" name="java.lang.CharSequence">CharSequence</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Deserializes a Guava bloom filter from its byte representation.</p><div class="fullcomment"><div class="comment cmt"><p>Deserializes a Guava bloom filter from its byte representation.</p><p>Uses <code>BloomFilter.readFrom</code> with a UTF-8 <code>StringFunnel</code>, which must match the funnel used during creation in
 <a href="BloomFilterOperations.html#createBloomFilterUdf(fprValue:Double):org.apache.spark.sql.expressions.UserDefinedFunction" class="extmbr" name="dev.cjfravel.ariadne.BloomFilterOperations#createBloomFilterUdf">createBloomFilterUdf</a>.
 </p></div><dl class="paramcmts block"><dt class="param">bytes</dt><dd class="cmt"><p>
   serialized bloom filter bytes (produced by <code>BloomFilter.writeTo</code>)</p></dd><dt>returns</dt><dd class="cmt"><p>
-  a <code>BloomFilter[CharSequence]</code> instance ready for membership queries</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  a <code>BloomFilter[CharSequence]</code> instance ready for membership queries</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the byte array is malformed or corrupted</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#ensureStorageReadyUnderLock" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ensureStorageReadyUnderLock(lock:dev.cjfravel.ariadne.IndexLock,correlationId:String,refresh:Boolean):Unit"></a><a id="ensureStorageReadyUnderLock(IndexLock,String,Boolean):Unit"></a>
@@ -1148,7 +1148,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">ensureStorageReadyUnderLock</span><span class="params">(<span name="lock">lock: <a href="IndexLock.html" class="extype" name="dev.cjfravel.ariadne.IndexLock">IndexLock</a></span>, <span name="correlationId">correlationId: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="refresh">refresh: <span class="extype" name="scala.Boolean">Boolean</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Runs migration preflight while the caller holds the update lock.</p><div class="fullcomment"><div class="comment cmt"><p>Runs migration preflight while the caller holds the update lock.
 </p></div><dl class="paramcmts block"><dt class="param">refresh</dt><dd class="cmt"><p>
   whether to reload metadata after lock acquisition</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd></dl></div>
@@ -1166,7 +1166,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -1182,7 +1182,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#exists" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exists(path:org.apache.hadoop.fs.Path):Boolean"></a><a id="exists(Path):Boolean"></a>
@@ -1198,12 +1198,12 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">exists</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks if a path exists on the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Checks if a path exists on the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to check</p></dd><dt>returns</dt><dd class="cmt"><p>
-  true if the path exists</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  true if the path exists</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the filesystem operation fails</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadataOperations#format" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="format:String"></a>
@@ -1219,7 +1219,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">format</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the file format of the indexed data (e.g., &quot;parquet&quot;, &quot;csv&quot;, &quot;json&quot;).</p><div class="fullcomment"><div class="comment cmt"><p>Returns the file format of the indexed data (e.g., &quot;parquet&quot;, &quot;csv&quot;, &quot;json&quot;).</p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   the format string from the stored metadata</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#fs" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -1236,7 +1236,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">fs</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.FileSystem">FileSystem</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop <code>FileSystem</code> instance resolved from the <a href="AriadneContextUser.html#storagePath:org.apache.hadoop.fs.Path" class="extmbr" name="dev.cjfravel.ariadne.AriadneContextUser#storagePath">storagePath</a> URI and the Spark Hadoop configuration.</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop <code>FileSystem</code> instance resolved from the <a href="AriadneContextUser.html#storagePath:org.apache.hadoop.fs.Path" class="extmbr" name="dev.cjfravel.ariadne.AriadneContextUser#storagePath">storagePath</a> URI and the Spark Hadoop configuration. Used for all
 filesystem operations (existence checks, reads, deletes, lock files).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -1254,12 +1254,12 @@ filesystem operations (existence checks, reads, deletes, lock files).
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#getFileSizes" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getFileSizes(files:Set[String]):Map[String,Long]"></a><a id="getFileSizes(Set[String]):Map[String,Long]"></a>
@@ -1275,7 +1275,7 @@ filesystem operations (existence checks, reads, deletes, lock files).
       <span class="symbol">
         <span class="name">getFileSizes</span><span class="params">(<span name="files">files: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Predef.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Long">Long</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Computes file sizes in bytes for the given files using the Hadoop FileSystem.</p><div class="fullcomment"><div class="comment cmt"><p>Computes file sizes in bytes for the given files using the Hadoop FileSystem.</p><p>Files that cannot be found or read are silently skipped with a warning log.
 </p></div><dl class="paramcmts block"><dt class="param">files</dt><dd class="cmt"><p>
   set of fully-qualified file paths to measure</p></dd><dt>returns</dt><dd class="cmt"><p>
@@ -1294,7 +1294,7 @@ filesystem operations (existence checks, reads, deletes, lock files).
       <span class="symbol">
         <span class="name">handleLargeIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks all storage columns for arrays exceeding <code>largeIndexLimit</code> and delegates to <a href="#appendToLargeIndex(df:org.apache.spark.sql.DataFrame):Unit" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#appendToLargeIndex">appendToLargeIndex</a> for
 separation.</p><div class="fullcomment"><div class="comment cmt"><p>Checks all storage columns for arrays exceeding <code>largeIndexLimit</code> and delegates to <a href="#appendToLargeIndex(df:org.apache.spark.sql.DataFrame):Unit" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#appendToLargeIndex">appendToLargeIndex</a> for
 separation.
@@ -1314,12 +1314,12 @@ separation.
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#indexFilePath" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="indexFilePath:org.apache.hadoop.fs.Path"></a><a id="indexFilePath:Path"></a>
@@ -1335,7 +1335,7 @@ separation.
       <span class="symbol">
         <span class="name">indexFilePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop path for the main index Delta table (<code>{storagePath}/index/</code>).</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop path for the main index Delta table (<code>{storagePath}/index/</code>).</p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#indexRepartitionCount" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="indexRepartitionCount:Option[Int]"></a>
@@ -1351,7 +1351,7 @@ separation.
       <span class="symbol">
         <span class="name">indexRepartitionCount</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Int">Int</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Optional number of partitions to use when repartitioning the index DataFrame during joins.</p><div class="fullcomment"><div class="comment cmt"><p>Optional number of partitions to use when repartitioning the index DataFrame during joins. When set, the index
 DataFrame is repartitioned before expensive operations like explode to reduce per-executor memory pressure and
 avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepartitionCount configuration
@@ -1371,7 +1371,7 @@ avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepa
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#largeIndexLimit" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="largeIndexLimit:Long"></a>
@@ -1387,7 +1387,7 @@ avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepa
       <span class="symbol">
         <span class="name">largeIndexLimit</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Maximum number of distinct values per file before an index column is promoted to a &quot;large index&quot; (stored in a
 separate exploded Delta table).</p><div class="fullcomment"><div class="comment cmt"><p>Maximum number of distinct values per file before an index column is promoted to a &quot;large index&quot; (stored in a
 separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</code> (default: 500000).</p><p>If the configured value is not a valid positive number, a warning is logged and the default of 500,000 is used.
@@ -1406,7 +1406,7 @@ separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</
       <span class="symbol">
         <span class="name">largeIndexesFilePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop root path for large index Delta tables (<code>{storagePath}/large_indexes/</code>).</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop root path for large index Delta tables (<code>{storagePath}/large_indexes/</code>).
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#lastAutoBloomCache" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -1423,11 +1423,11 @@ separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</
       <span class="symbol">
         <span class="name">lastAutoBloomCache</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Tracks the cached DataFrame from <a href="#buildAutoBloomIndexes(combinedDf:org.apache.spark.sql.DataFrame):org.apache.spark.sql.DataFrame" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#buildAutoBloomIndexes">buildAutoBloomIndexes</a> for deferred cleanup.</p><div class="fullcomment"><div class="comment cmt"><p>Tracks the cached DataFrame from <a href="#buildAutoBloomIndexes(combinedDf:org.apache.spark.sql.DataFrame):org.apache.spark.sql.DataFrame" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#buildAutoBloomIndexes">buildAutoBloomIndexes</a> for deferred cleanup.</p><p>Set during auto-bloom processing and unpersisted after staging is complete.
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Annotations</dt><dd>
                 <span class="name">@transient</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.BloomFilterOperations#locateFilesWithBloom" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="locateFilesWithBloom(column:String,values:Array[Any],indexDf:org.apache.spark.sql.DataFrame):Set[String]"></a><a id="locateFilesWithBloom(String,Array[Any],DataFrame):Set[String]"></a>
@@ -1443,7 +1443,7 @@ separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</
       <span class="symbol">
         <span class="name">locateFilesWithBloom</span><span class="params">(<span name="column">column: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="values">values: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Any">Any</span>]</span>, <span name="indexDf">indexDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Locates files that might contain any of the given values using bloom filters.</p><div class="fullcomment"><div class="comment cmt"><p>Locates files that might contain any of the given values using bloom filters.</p><p>Collects all rows from the index, deserializes each file's bloom filter for the specified column, and tests every
 candidate value. A file is included in the result if any value passes the <code>mightContain</code> check.
 </p></div><dl class="paramcmts block"><dt class="param">column</dt><dd class="cmt"><p>
@@ -1469,7 +1469,7 @@ candidate value. A file is included in the result if any value passes the <code>
       <span class="symbol">
         <span class="name">locateFilesWithBloomFromDataFrame</span><span class="params">(<span name="column">column: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="valuesDf">valuesDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="indexDf">indexDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Locates files that might contain values from a DataFrame using bloom filters.</p><div class="fullcomment"><div class="comment cmt"><p>Locates files that might contain values from a DataFrame using bloom filters.</p><p>Collects distinct non-null values from the specified column of <code>valuesDf</code>, then delegates to
 <a href="BloomFilterOperations.html#locateFilesWithBloom(column:String,values:Array[Any],indexDf:org.apache.spark.sql.DataFrame):Set[String]" class="extmbr" name="dev.cjfravel.ariadne.BloomFilterOperations#locateFilesWithBloom">locateFilesWithBloom</a> for the actual bloom filter check.
 </p></div><dl class="paramcmts block"><dt class="param">column</dt><dd class="cmt"><p>
@@ -1495,7 +1495,7 @@ candidate value. A file is included in the result if any value passes the <code>
       <span class="symbol">
         <span class="name">lockMaxWait</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Maximum total time in seconds to wait for lock acquisition before failing.</p><div class="fullcomment"><div class="comment cmt"><p>Maximum total time in seconds to wait for lock acquisition before failing. Reads from spark.ariadne.lockMaxWait
 configuration (default: 3600).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Note</dt><dd><span class="cmt"><p>
@@ -1515,7 +1515,7 @@ configuration (default: 3600).
       <span class="symbol">
         <span class="name">lockRefreshInterval</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Refresh the update lock every N batches during updateBatched.</p><div class="fullcomment"><div class="comment cmt"><p>Refresh the update lock every N batches during updateBatched. Reads from spark.ariadne.lockRefreshInterval
 configuration (default: 1).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -1533,7 +1533,7 @@ configuration (default: 1).
       <span class="symbol">
         <span class="name">lockRetryInterval</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Base interval in seconds between lock acquisition retries (exponential backoff applied).</p><div class="fullcomment"><div class="comment cmt"><p>Base interval in seconds between lock acquisition retries (exponential backoff applied). Reads from
 spark.ariadne.lockRetryInterval configuration (default: 60).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -1551,7 +1551,7 @@ spark.ariadne.lockRetryInterval configuration (default: 60).
       <span class="symbol">
         <span class="name">lockTimeout</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Seconds since <code>lastRefreshedAt</code> before a lock is considered stale and eligible for auto-heal (forcible acquisition
 by another process).</p><div class="fullcomment"><div class="comment cmt"><p>Seconds since <code>lastRefreshedAt</code> before a lock is considered stale and eligible for auto-heal (forcible acquisition
 by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default: 1800).
@@ -1570,7 +1570,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">logger</span><span class="result">: <span class="extype" name="org.apache.logging.log4j.Logger">Logger</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Log4j logger shared by all Ariadne components.</p><div class="fullcomment"><div class="comment cmt"><p>Log4j logger shared by all Ariadne components. Uses the &quot;ariadne&quot; logger name. Marked <code>@transient lazy</code> so that
 <code>Index</code> (a case class) remains serializable across Spark stages — Log4j loggers are not <code>Serializable</code>.
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a> → <a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -1588,7 +1588,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">maybeAutoCompact</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Triggers compaction if the auto-compact threshold has been reached.</p><div class="fullcomment"><div class="comment cmt"><p>Triggers compaction if the auto-compact threshold has been reached.</p><p>Checks the <a href="#batchesSinceCompact:Int" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#batchesSinceCompact">batchesSinceCompact</a> counter against the configured <code>autoCompactThreshold</code>. If the threshold is met,
 compacts all Delta tables and resets the counter to zero. The counter is persisted to metadata so it survives
 across Spark jobs.
@@ -1607,7 +1607,7 @@ across Spark jobs.
       <span class="symbol">
         <span class="name">metadataExists</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks if metadata exists in the storage location.</p><div class="fullcomment"><div class="comment cmt"><p>Checks if metadata exists in the storage location.</p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   True if metadata exists, otherwise false.</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadataOperations#metadataFilePath" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -1624,7 +1624,7 @@ across Spark jobs.
       <span class="symbol">
         <span class="name">metadataFilePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop path for the metadata file.</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop path for the metadata file.</p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   the path to <code>metadata.json</code> under the index storage directory</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#migrateExplodedFieldColumns" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -1641,7 +1641,7 @@ across Spark jobs.
       <span class="symbol">
         <span class="name">migrateExplodedFieldColumns</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Migrates pre-0.1.1 indexes that stored exploded field columns under <code>array_column</code> names to the current <code>as_column</code>
 naming convention.</p><div class="fullcomment"><div class="comment cmt"><p>Migrates pre-0.1.1 indexes that stored exploded field columns under <code>array_column</code> names to the current <code>as_column</code>
 naming convention.</p><p>Detection: reads the main and staging Delta table schemas and checks whether any
@@ -1663,7 +1663,7 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -1679,12 +1679,12 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -1700,12 +1700,12 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#open" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="open(path:org.apache.hadoop.fs.Path):org.apache.hadoop.fs.FSDataInputStream"></a><a id="open(Path):FSDataInputStream"></a>
@@ -1721,12 +1721,12 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">open</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.FSDataInputStream">FSDataInputStream</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Opens an input stream to read from a path on the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Opens an input stream to read from a path on the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to open for reading</p></dd><dt>returns</dt><dd class="cmt"><p>
-  An FSDataInputStream for reading the file contents</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  An FSDataInputStream for reading the file contents</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the file does not exist or cannot be opened</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#rangeStorageColumns" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="rangeStorageColumns:Set[String]"></a>
@@ -1742,7 +1742,7 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">rangeStorageColumns</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the set of range index storage column names (each prefixed with <code>range_</code>).</p><div class="fullcomment"><div class="comment cmt"><p>Returns the set of range index storage column names (each prefixed with <code>range_</code>).
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   set of prefixed column names (e.g., <code>range_event_date</code>)</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd></dl></div>
@@ -1760,10 +1760,10 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">refreshMetadata</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Forces a reload of metadata from the <code>metadata.json</code> file on disk.</p><div class="fullcomment"><div class="comment cmt"><p>Forces a reload of metadata from the <code>metadata.json</code> file on disk.</p><p>Replaces the in-memory cached metadata with a freshly deserialized copy. This is called automatically by
 <span class="extype" name="metadata">metadata</span> on first access; callers may invoke it explicitly to pick up external changes.
-</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="MetadataMissingOrCorruptException"><code>MetadataMissingOrCorruptException</code></span>
+</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="MetadataMissingOrCorruptException"><code>MetadataMissingOrCorruptException</code></span> 
   if the metadata file does not exist, cannot be read, or contains invalid JSON</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#repartitionDataFiles" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="repartitionDataFiles:Boolean"></a>
@@ -1779,7 +1779,7 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">repartitionDataFiles</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">When true, applies indexRepartitionCount repartitioning to the data files read during joinDf.</p><div class="fullcomment"><div class="comment cmt"><p>When true, applies indexRepartitionCount repartitioning to the data files read during joinDf. When false, data
 files keep their natural parquet partitioning. Disable when column selection significantly reduces data volume,
 making the repartition shuffle more expensive than useful. Reads from spark.ariadne.repartitionDataFiles
@@ -1799,7 +1799,7 @@ configuration (default: false).
       <span class="symbol">
         <span class="name">requireNonReservedStagingColumn</span><span class="params">(<span name="column">column: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#safeDestroyBroadcast" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="safeDestroyBroadcast(broadcast:org.apache.spark.broadcast.Broadcast[_]):Unit"></a><a id="safeDestroyBroadcast(Broadcast[_]):Unit"></a>
@@ -1815,7 +1815,7 @@ configuration (default: false).
       <span class="symbol">
         <span class="name">safeDestroyBroadcast</span><span class="params">(<span name="broadcast">broadcast: <span class="extype" name="org.apache.spark.broadcast.Broadcast">Broadcast</span>[_]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Safely destroys a broadcast variable, logging but swallowing any exception.</p><div class="fullcomment"><div class="comment cmt"><p>Safely destroys a broadcast variable, logging but swallowing any exception.</p><p>Intended for use inside <code>finally</code> blocks where a cleanup failure must not mask the original exception propagating
 out of the <code>try</code> block. Tolerates a null broadcast.
 </p></div><dl class="paramcmts block"><dt class="param">broadcast</dt><dd class="cmt"><p>
@@ -1834,7 +1834,7 @@ out of the <code>try</code> block. Tolerates a null broadcast.
       <span class="symbol">
         <span class="name">stagingConsolidationThreshold</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Number of batches to process before consolidating staged data into the main index.</p><div class="fullcomment"><div class="comment cmt"><p>Number of batches to process before consolidating staged data into the main index. This provides fault tolerance
 for large index builds - if a job fails, work is preserved up to the last consolidation point. Reads from
 spark.ariadne.stagingConsolidationThreshold configuration (default: 50).
@@ -1853,7 +1853,7 @@ spark.ariadne.stagingConsolidationThreshold configuration (default: 50).
       <span class="symbol">
         <span class="name">stagingFilePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop path for the staging Delta table (<code>{storagePath}/staging/</code>).</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop path for the staging Delta table (<code>{storagePath}/staging/</code>).</p><p>The staging table accumulates batch results during <a href="Index.html#update:Unit" class="extmbr" name="dev.cjfravel.ariadne.Index#update">update</a> and is merged into the main index by
 <a href="#consolidateStaging():Unit" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#consolidateStaging">consolidateStaging</a>.
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd></dl></div>
@@ -1871,7 +1871,7 @@ spark.ariadne.stagingConsolidationThreshold configuration (default: 50).
       <span class="symbol">
         <span class="name">storageColumns</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the set of all storage column names across regular, computed, exploded-field, and temporal index types.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the set of all storage column names across regular, computed, exploded-field, and temporal index types.</p><p>This is used internally to determine which columns to check for large-index separation and to build aggregation
 expressions.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
@@ -1890,10 +1890,10 @@ expressions.
       <span class="symbol">
         <span class="name">storagePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Base path on the Hadoop-compatible filesystem where all Ariadne index data is stored.</p><div class="fullcomment"><div class="comment cmt"><p>Base path on the Hadoop-compatible filesystem where all Ariadne index data is stored. Each index creates a
 subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</code> (required — no default).
-</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if the configuration key is not set</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexFileOperations#storedSchema" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="storedSchema:org.apache.spark.sql.types.StructType"></a><a id="storedSchema:StructType"></a>
@@ -1909,14 +1909,14 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name">storedSchema</span><span class="result">: <span class="extype" name="org.apache.spark.sql.types.StructType">StructType</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the stored schema of the index.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the stored schema of the index.</p><p>Parses the JSON schema string from metadata into a Spark StructType.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   The StructType schema parsed from metadata</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a></dd><div class="block">Example:
                <ol><li class="cmt"><p></p><pre><span class="kw">val</span> schema = index.storedSchema
 schema.printTreeString()</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="SchemaParseException"><code>SchemaParseException</code></span>
-  if the schema string cannot be parsed as a StructType</p></span><span class="cmt"><p><a href="exceptions/MissingSchemaException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.MissingSchemaException"><code>dev.cjfravel.ariadne.exceptions.MissingSchemaException</code></a>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="SchemaParseException"><code>SchemaParseException</code></span> 
+  if the schema string cannot be parsed as a StructType</p></span><span class="cmt"><p><a href="exceptions/MissingSchemaException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.MissingSchemaException"><code>dev.cjfravel.ariadne.exceptions.MissingSchemaException</code></a> 
   if the schema is null in metadata</p></span></dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -1932,7 +1932,7 @@ schema.printTreeString()</pre></li></ol>
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -1948,7 +1948,7 @@ schema.printTreeString()</pre></li></ol>
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#vacuumDeltaTables" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="vacuumDeltaTables(retentionHours:Int):Unit"></a><a id="vacuumDeltaTables(Int):Unit"></a>
@@ -1964,7 +1964,7 @@ schema.printTreeString()</pre></li></ol>
       <span class="symbol">
         <span class="name">vacuumDeltaTables</span><span class="params">(<span name="retentionHours">retentionHours: <span class="extype" name="scala.Int">Int</span> = <span class="symbol">168</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Vacuums all Delta tables (main index and large index tables) to remove old files.</p><div class="fullcomment"><div class="comment cmt"><p>Vacuums all Delta tables (main index and large index tables) to remove old files.</p><p>Uses Delta Lake's VACUUM command to delete data files no longer referenced by the transaction log. Temporarily
 disables the retention duration safety check when <code>retentionHours</code> is zero or negative.
 </p></div><dl class="paramcmts block"><dt class="param">retentionHours</dt><dd class="cmt"><p>
@@ -1986,13 +1986,13 @@ disables the retention duration safety check when <code>retentionHours</code> is
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -2008,15 +2008,15 @@ disables the retention duration safety check when <code>retentionHours</code> is
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -2032,13 +2032,13 @@ disables the retention duration safety check when <code>retentionHours</code> is
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadataOperations#writeMetadata" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="writeMetadata(metadata:dev.cjfravel.ariadne.IndexMetadata):Unit"></a><a id="writeMetadata(IndexMetadata):Unit"></a>
@@ -2054,19 +2054,19 @@ disables the retention duration safety check when <code>retentionHours</code> is
       <span class="symbol">
         <span class="name">writeMetadata</span><span class="params">(<span name="metadata">metadata: <a href="IndexMetadata.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadata">IndexMetadata</a></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Writes metadata to the <code>metadata.json</code> file and updates the in-memory cache.</p><div class="fullcomment"><div class="comment cmt"><p>Writes metadata to the <code>metadata.json</code> file and updates the in-memory cache.</p><p>Creates the parent directory if it does not exist. JSON is written and validated at a unique sibling path, then
 replaced through Hadoop's overwrite rename operation. The replacement is atomic on filesystems with atomic rename
 semantics (such as HDFS); object-store connectors may implement rename as copy/delete and cannot provide the same
 guarantee.
 </p></div><dl class="paramcmts block"><dt class="param">metadata</dt><dd class="cmt"><p>
-  the metadata instance to serialize and persist</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  the metadata instance to serialize and persist</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the write fails (the error is logged before propagating)</p></span></dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -2084,15 +2084,15 @@ guarantee.
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -2112,13 +2112,13 @@ guarantee.
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/IndexCatalog$.html
+++ b/docs/api/dev/cjfravel/ariadne/IndexCatalog$.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.IndexCatalog" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.IndexCatalog" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="catalog/index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -147,7 +147,7 @@
       <span class="symbol">
         <a title="" href="exceptions/index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented3">
                         <span class="separator"></span>
@@ -256,7 +256,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Catalog for discovering, inspecting, and managing all Ariadne indexes under the configured
 <code>spark.ariadne.storagePath</code>.</p><p><code>IndexCatalog</code> is stateless — every call scans the filesystem for the current set of indexes. It complements the
 per-index API on <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a> by providing a global view of the storage path.</p><p><b>Usage:</b></p><pre><span class="kw">import</span> dev.cjfravel.ariadne.IndexCatalog
@@ -277,7 +277,7 @@ IndexCatalog.toDF().show()
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -292,7 +292,7 @@ IndexCatalog.toDF().show()
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -319,11 +319,11 @@ IndexCatalog.toDF().show()
 
       <div id="template">
         <div id="allMembers">
+        
 
+        
 
-
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -342,7 +342,7 @@ IndexCatalog.toDF().show()
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -358,7 +358,7 @@ IndexCatalog.toDF().show()
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -374,7 +374,7 @@ IndexCatalog.toDF().show()
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -390,7 +390,7 @@ IndexCatalog.toDF().show()
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -406,17 +406,17 @@ IndexCatalog.toDF().show()
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexCatalog#describe" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="describe(name:String)(implicitspark:org.apache.spark.sql.SparkSession):dev.cjfravel.ariadne.IndexSummary"></a><a id="describe(String)(SparkSession):IndexSummary"></a>
@@ -432,7 +432,7 @@ IndexCatalog.toDF().show()
       <span class="symbol">
         <span class="name">describe</span><span class="params">(<span name="name">name: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="params">(<span class="implicit">implicit </span><span name="spark">spark: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span><span class="result">: <a href="IndexSummary.html" class="extype" name="dev.cjfravel.ariadne.IndexSummary">IndexSummary</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns a summary of a single index.</p><div class="fullcomment"><div class="comment cmt"><p>Returns a summary of a single index.</p><p>Reads the index's <code>metadata.json</code> and file list to populate an <a href="IndexSummary.html" class="extype" name="dev.cjfravel.ariadne.IndexSummary">IndexSummary</a> with all configured index types and
 tracked file count.
 </p></div><dl class="paramcmts block"><dt class="param">name</dt><dd class="cmt"><p>
@@ -441,8 +441,8 @@ tracked file count.
   the index summary</p></dd></dl><dl class="attributes block"> <div class="block">Example:
                <ol><li class="cmt"><p></p><pre><span class="kw">val</span> summary: IndexSummary = IndexCatalog.describe(<span class="lit">"myIndex"</span>)
 println(summary.name, summary.fileCount)</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if name is null or blank</p></span><span class="cmt"><p><span class="extype" name="IndexNotFoundException"><code>IndexNotFoundException</code></span>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if name is null or blank</p></span><span class="cmt"><p><span class="extype" name="IndexNotFoundException"><code>IndexNotFoundException</code></span> 
   if the index does not exist</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexCatalog#describeAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="describeAll()(implicitspark:org.apache.spark.sql.SparkSession):Seq[dev.cjfravel.ariadne.IndexSummary]"></a><a id="describeAll()(SparkSession):Seq[IndexSummary]"></a>
@@ -458,7 +458,7 @@ println(summary.name, summary.fileCount)</pre></li></ol>
       <span class="symbol">
         <span class="name">describeAll</span><span class="params">()</span><span class="params">(<span class="implicit">implicit </span><span name="spark">spark: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span><span class="result">: <span class="extype" name="scala.Seq">Seq</span>[<a href="IndexSummary.html" class="extype" name="dev.cjfravel.ariadne.IndexSummary">IndexSummary</a>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns summaries for all indexes in the storage path.</p><div class="fullcomment"><div class="comment cmt"><p>Returns summaries for all indexes in the storage path.</p><p>Equivalent to calling <a href="#describe(name:String)(implicitspark:org.apache.spark.sql.SparkSession):dev.cjfravel.ariadne.IndexSummary" class="extmbr" name="dev.cjfravel.ariadne.IndexCatalog#describe">describe</a> for each name returned by <a href="#list()(implicitspark:org.apache.spark.sql.SparkSession):Seq[String]" class="extmbr" name="dev.cjfravel.ariadne.IndexCatalog#list">list</a>, but logs a single message for the batch
 operation. Indexes whose metadata cannot be read are skipped with a warning.
 </p></div><dl class="paramcmts block"><dt class="param">spark</dt><dd class="cmt"><p>
@@ -481,7 +481,7 @@ summaries.foreach(s <span class="kw">=&gt;</span> println(s.name))</pre></li></o
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -497,7 +497,7 @@ summaries.foreach(s <span class="kw">=&gt;</span> println(s.name))</pre></li></o
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexCatalog#exists" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exists(name:String)(implicitspark:org.apache.spark.sql.SparkSession):Boolean"></a><a id="exists(String)(SparkSession):Boolean"></a>
@@ -513,7 +513,7 @@ summaries.foreach(s <span class="kw">=&gt;</span> println(s.name))</pre></li></o
       <span class="symbol">
         <span class="name">exists</span><span class="params">(<span name="name">name: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="params">(<span class="implicit">implicit </span><span name="spark">spark: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks whether an index with the given name exists.</p><div class="fullcomment"><div class="comment cmt"><p>Checks whether an index with the given name exists.</p><p>An index is considered a valid catalog entry only when its <code>metadata.json</code> file is present. Partial storage
 directories and orphaned FileLists remain removable recovery artifacts but are not exposed through catalog APIs.
 </p></div><dl class="paramcmts block"><dt class="param">name</dt><dd class="cmt"><p>
@@ -521,7 +521,7 @@ directories and orphaned FileLists remain removable recovery artifacts but are n
   implicit SparkSession</p></dd><dt>returns</dt><dd class="cmt"><p>
   true if the index exists</p></dd></dl><dl class="attributes block"> <div class="block">Example:
                <ol><li class="cmt"><p></p><pre><span class="kw">if</span> (IndexCatalog.exists(<span class="lit">"orders"</span>)) println(<span class="lit">"Index found"</span>)</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if name is null or blank</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexCatalog#findIndexes" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="findIndexes(fileName:String)(implicitspark:org.apache.spark.sql.SparkSession):Seq[String]"></a><a id="findIndexes(String)(SparkSession):Seq[String]"></a>
@@ -537,7 +537,7 @@ directories and orphaned FileLists remain removable recovery artifacts but are n
       <span class="symbol">
         <span class="name">findIndexes</span><span class="params">(<span name="fileName">fileName: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="params">(<span class="implicit">implicit </span><span name="spark">spark: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span><span class="result">: <span class="extype" name="scala.Seq">Seq</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the names of all indexes that track a given file.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the names of all indexes that track a given file.</p><p>Scans every index's file list to check whether <code>fileName</code> is present. This is useful for determining which indexes
 need a <code>deleteFiles</code> call when a source file has been removed from storage.
 </p></div><dl class="paramcmts block"><dt class="param">fileName</dt><dd class="cmt"><p>
@@ -548,7 +548,7 @@ need a <code>deleteFiles</code> call when a source file has been removed from st
 affected.foreach { name <span class="kw">=&gt;</span>
   IndexCatalog.get(name).deleteFiles(<span class="lit">"abfss://data@mystorage.dfs.core.windows.net/file1.parquet"</span>)
 }</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if fileName is null or blank</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexCatalog#get" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="get(name:String)(implicitspark:org.apache.spark.sql.SparkSession):dev.cjfravel.ariadne.Index"></a><a id="get(String)(SparkSession):Index"></a>
@@ -564,7 +564,7 @@ affected.foreach { name <span class="kw">=&gt;</span>
       <span class="symbol">
         <span class="name">get</span><span class="params">(<span name="name">name: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="params">(<span class="implicit">implicit </span><span name="spark">spark: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span><span class="result">: <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Fetches an <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a> instance by reconnecting to an existing index.</p><div class="fullcomment"><div class="comment cmt"><p>Fetches an <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a> instance by reconnecting to an existing index.</p><p>This is equivalent to calling <code>Index(name)</code> directly; it is provided here for API completeness so callers can
 discover and fetch indexes without importing <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a>.
 </p></div><dl class="paramcmts block"><dt class="param">name</dt><dd class="cmt"><p>
@@ -572,8 +572,8 @@ discover and fetch indexes without importing <a href="Index.html" class="extype"
   implicit SparkSession</p></dd><dt>returns</dt><dd class="cmt"><p>
   a fully initialized Index instance</p></dd></dl><dl class="attributes block"> <div class="block">Example:
                <ol><li class="cmt"><p></p><pre><span class="kw">val</span> index: Index = IndexCatalog.get(<span class="lit">"myIndex"</span>)</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if name is null or blank</p></span><span class="cmt"><p><span class="extype" name="IndexNotFoundException"><code>IndexNotFoundException</code></span>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if name is null or blank</p></span><span class="cmt"><p><span class="extype" name="IndexNotFoundException"><code>IndexNotFoundException</code></span> 
   if the index does not exist</p></span></dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -589,12 +589,12 @@ discover and fetch indexes without importing <a href="Index.html" class="extype"
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -610,12 +610,12 @@ discover and fetch indexes without importing <a href="Index.html" class="extype"
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -631,7 +631,7 @@ discover and fetch indexes without importing <a href="Index.html" class="extype"
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexCatalog#list" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="list()(implicitspark:org.apache.spark.sql.SparkSession):Seq[String]"></a><a id="list()(SparkSession):Seq[String]"></a>
@@ -647,7 +647,7 @@ discover and fetch indexes without importing <a href="Index.html" class="extype"
       <span class="symbol">
         <span class="name">list</span><span class="params">()</span><span class="params">(<span class="implicit">implicit </span><span name="spark">spark: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span><span class="result">: <span class="extype" name="scala.Seq">Seq</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Lists the names of all indexes in the configured storage path.</p><div class="fullcomment"><div class="comment cmt"><p>Lists the names of all indexes in the configured storage path.</p><p>Scans the <code>{storagePath}/indexes/</code> directory for subdirectories that contain a <code>metadata.json</code> file — this
 distinguishes real indexes from stale or partially deleted directories.
 </p></div><dl class="paramcmts block"><dt class="param">spark</dt><dd class="cmt"><p>
@@ -669,7 +669,7 @@ distinguishes real indexes from stale or partially deleted directories.
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -685,12 +685,12 @@ distinguishes real indexes from stale or partially deleted directories.
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -706,12 +706,12 @@ distinguishes real indexes from stale or partially deleted directories.
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexCatalog#remove" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="remove(name:String)(implicitspark:org.apache.spark.sql.SparkSession):Boolean"></a><a id="remove(String)(SparkSession):Boolean"></a>
@@ -727,7 +727,7 @@ distinguishes real indexes from stale or partially deleted directories.
       <span class="symbol">
         <span class="name">remove</span><span class="params">(<span name="name">name: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="params">(<span class="implicit">implicit </span><span name="spark">spark: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Removes an index by name.</p><div class="fullcomment"><div class="comment cmt"><p>Removes an index by name.</p><p>Deletes the index storage directory (containing metadata, index tables, staging, and large indexes) and the
 associated file list Delta table. If the file list has already been removed by another process, it is treated as a
 successful no-op for that resource.
@@ -736,8 +736,8 @@ successful no-op for that resource.
   implicit SparkSession</p></dd><dt>returns</dt><dd class="cmt"><p>
   true if any resources were removed</p></dd></dl><dl class="attributes block"> <div class="block">Example:
                <ol><li class="cmt"><p></p><pre>IndexCatalog.remove(<span class="lit">"oldIndex"</span>)</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if name is null or blank</p></span><span class="cmt"><p><span class="extype" name="IndexNotFoundException"><code>IndexNotFoundException</code></span>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if name is null or blank</p></span><span class="cmt"><p><span class="extype" name="IndexNotFoundException"><code>IndexNotFoundException</code></span> 
   if the index does not exist</p></span></dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -753,7 +753,7 @@ successful no-op for that resource.
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexCatalog#toDF" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toDF()(implicitspark:org.apache.spark.sql.SparkSession):org.apache.spark.sql.DataFrame"></a><a id="toDF()(SparkSession):DataFrame"></a>
@@ -769,7 +769,7 @@ successful no-op for that resource.
       <span class="symbol">
         <span class="name">toDF</span><span class="params">()</span><span class="params">(<span class="implicit">implicit </span><span name="spark">spark: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns a DataFrame summarizing all indexes.</p><div class="fullcomment"><div class="comment cmt"><p>Returns a DataFrame summarizing all indexes.</p><p>The returned DataFrame has one row per index with the following columns:</p><pre>name: <span class="std">String</span>
 format: <span class="std">String</span>
 regular_indexes: <span class="std">String</span>   (comma-separated)
@@ -799,7 +799,7 @@ df.show()</pre></li></ol>
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -815,13 +815,13 @@ df.show()</pre></li></ol>
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -837,15 +837,15 @@ df.show()</pre></li></ol>
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -861,19 +861,19 @@ df.show()</pre></li></ol>
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -891,15 +891,15 @@ df.show()</pre></li></ol>
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -911,13 +911,13 @@ df.show()</pre></li></ol>
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/IndexFileOperations.html
+++ b/docs/api/dev/cjfravel/ariadne/IndexFileOperations.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.IndexFileOperations" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.IndexFileOperations" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="catalog/index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -147,7 +147,7 @@
       <span class="symbol">
         <a title="" href="exceptions/index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented3">
                         <span class="separator"></span>
@@ -256,7 +256,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Trait providing file I/O operations for <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a> instances.</p><p>Handles reading data files in supported formats (CSV, Parquet, JSON), applying computed indexes and exploded field
 transformations, and managing column selection for optimized reads.</p><p><b>Read pipeline:</b> <span class="extype" name="readFiles">readFiles</span> orchestrates the full read path:</p><ol class="decimal"><li><a href="#createBaseDataFrame(files:Set[String]):org.apache.spark.sql.DataFrame" class="extmbr" name="dev.cjfravel.ariadne.IndexFileOperations#createBaseDataFrame">createBaseDataFrame</a> — loads files using the stored schema, format, and read options 2.
      <a href="#applyComputedIndexes(df:org.apache.spark.sql.DataFrame):org.apache.spark.sql.DataFrame" class="extmbr" name="dev.cjfravel.ariadne.IndexFileOperations#applyComputedIndexes">applyComputedIndexes</a> — adds derived columns via Spark SQL expressions 3. <a href="#applyExplodedFields(df:org.apache.spark.sql.DataFrame):org.apache.spark.sql.DataFrame" class="extmbr" name="dev.cjfravel.ariadne.IndexFileOperations#applyExplodedFields">applyExplodedFields</a> — explodes
@@ -277,7 +277,7 @@ For single-file reads, a fallback literal is used because Spark may report an em
             </span>
             <div class="subClasses hiddenContent"><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a>, <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a>, <a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a>, <a href="IndexJoinOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexJoinOperations">IndexJoinOperations</a>, <a href="IndexQueryOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexQueryOperations">IndexQueryOperations</a></div>
           </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -292,7 +292,7 @@ For single-file reads, a fallback literal is used because Spark may report an em
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -319,9 +319,9 @@ For single-file reads, a fallback literal is used because Spark may report an em
 
       <div id="template">
         <div id="allMembers">
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Abstract Value Members</h3>
@@ -339,7 +339,7 @@ For single-file reads, a fallback literal is used because Spark may report an em
       <span class="symbol">
         <span class="name">spark</span><span class="result">: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Implicit SparkSession that must be provided by the mixing class.</p><div class="fullcomment"><div class="comment cmt"><p>Implicit SparkSession that must be provided by the mixing class.</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
     </li></ol>
             </div>
@@ -361,7 +361,7 @@ For single-file reads, a fallback literal is used because Spark may report an em
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -377,7 +377,7 @@ For single-file reads, a fallback literal is used because Spark may report an em
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -393,7 +393,7 @@ For single-file reads, a fallback literal is used because Spark may report an em
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexFileOperations#addFilenameColumn" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addFilenameColumn(df:org.apache.spark.sql.DataFrame,files:Set[String]):org.apache.spark.sql.DataFrame"></a><a id="addFilenameColumn(DataFrame,Set[String]):DataFrame"></a>
@@ -409,7 +409,7 @@ For single-file reads, a fallback literal is used because Spark may report an em
       <span class="symbol">
         <span class="name">addFilenameColumn</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="files">files: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Adds a stable filename column to the DataFrame.</p><div class="fullcomment"><div class="comment cmt"><p>Adds a stable filename column to the DataFrame.</p><p>Uses <code>input_file_name()</code> to capture the source file path. For single-file reads where Spark may report an empty
 filename, falls back to the known file path.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
@@ -430,7 +430,7 @@ filename, falls back to the known file path.
       <span class="symbol">
         <span class="name">applyColumnSelection</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Applies column selection if columns have been specified via select().</p><div class="fullcomment"><div class="comment cmt"><p>Applies column selection if columns have been specified via select(). Only reads the explicitly selected columns.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
   The DataFrame to apply column selection to</p></dd><dt>returns</dt><dd class="cmt"><p>
@@ -449,12 +449,12 @@ filename, falls back to the known file path.
       <span class="symbol">
         <span class="name">applyComputedIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Applies computed indexes to a DataFrame by adding computed columns.</p><div class="fullcomment"><div class="comment cmt"><p>Applies computed indexes to a DataFrame by adding computed columns.</p><p>Each computed index is a Spark SQL expression stored in metadata. The expression is evaluated via <code>expr()</code> and
 added as a new column. If no computed indexes are configured, the DataFrame is returned unchanged.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
   The base DataFrame</p></dd><dt>returns</dt><dd class="cmt"><p>
-  DataFrame with computed index columns added</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="org.apache.spark.sql.AnalysisException"><code>org.apache.spark.sql.AnalysisException</code></span>
+  DataFrame with computed index columns added</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="org.apache.spark.sql.AnalysisException"><code>org.apache.spark.sql.AnalysisException</code></span> 
   if a computed index expression is invalid or references non-existent columns</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexFileOperations#applyExplodedFields" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="applyExplodedFields(df:org.apache.spark.sql.DataFrame):org.apache.spark.sql.DataFrame"></a><a id="applyExplodedFields(DataFrame):DataFrame"></a>
@@ -470,7 +470,7 @@ added as a new column. If no computed indexes are configured, the DataFrame is r
       <span class="symbol">
         <span class="name">applyExplodedFields</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Applies exploded field transformations to a DataFrame.</p><div class="fullcomment"><div class="comment cmt"><p>Applies exploded field transformations to a DataFrame.</p><p>For each configured exploded field, extracts the nested field path from the array column and explodes it into a
 top-level column. This is used on the read/join path to prepare data for joining on exploded field values.</p><p>Note that <code>explode()</code> (not <code>explode_outer()</code>) is used intentionally — rows with null or empty arrays are dropped
 because they contain no matchable values for the join. This is consistent with the index build path which also
@@ -492,7 +492,7 @@ excludes null/empty arrays.
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#autoBloomFpr" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="autoBloomFpr:Double"></a>
@@ -508,7 +508,7 @@ excludes null/empty arrays.
       <span class="symbol">
         <span class="name">autoBloomFpr</span><span class="result">: <span class="extype" name="scala.Double">Double</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">False positive rate for auto-bloom filters on large index columns.</p><div class="fullcomment"><div class="comment cmt"><p>False positive rate for auto-bloom filters on large index columns. When a column exceeds largeIndexLimit, an
 auto-bloom filter is built with this FPR to enable file pruning at query time. Reads from
 spark.ariadne.autoBloomFpr configuration (default: 0.01).
@@ -527,7 +527,7 @@ spark.ariadne.autoBloomFpr configuration (default: 0.01).
       <span class="symbol">
         <span class="name">autoCompactThreshold</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Int">Int</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Optional threshold for auto-compaction.</p><div class="fullcomment"><div class="comment cmt"><p>Optional threshold for auto-compaction. When set, the main index Delta table is compacted after an update if the
 number of Delta log JSON files meets or exceeds this value. Reads from spark.ariadne.autoCompactThreshold
 configuration (default: not set).
@@ -546,17 +546,17 @@ configuration (default: not set).
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexFileOperations#createBaseDataFrame" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="createBaseDataFrame(files:Set[String]):org.apache.spark.sql.DataFrame"></a><a id="createBaseDataFrame(Set[String]):DataFrame"></a>
@@ -572,12 +572,12 @@ configuration (default: not set).
       <span class="symbol">
         <span class="name">createBaseDataFrame</span><span class="params">(<span name="files">files: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Creates a base DataFrame from the provided files using the stored format and schema.</p><div class="fullcomment"><div class="comment cmt"><p>Creates a base DataFrame from the provided files using the stored format and schema. Applies any read options
 configured in the index metadata.</p><p>Returns an empty DataFrame (with the stored schema) if all file paths are blank after normalization.
 </p></div><dl class="paramcmts block"><dt class="param">files</dt><dd class="cmt"><p>
   Set of file paths to read</p></dd><dt>returns</dt><dd class="cmt"><p>
-  DataFrame with data from the specified files</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+  DataFrame with data from the specified files</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if the stored format is not csv, parquet, or json</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#debugEnabled" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="debugEnabled:Boolean"></a>
@@ -593,7 +593,7 @@ configured in the index metadata.</p><p>Returns an empty DataFrame (with the sto
       <span class="symbol">
         <span class="name">debugEnabled</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">When true, logs detailed diagnostics during join operations including partition counts, physical plans, and
 per-phase timing.</p><div class="fullcomment"><div class="comment cmt"><p>When true, logs detailed diagnostics during join operations including partition counts, physical plans, and
 per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
@@ -612,12 +612,12 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">delete</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Deletes a path recursively from the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Deletes a path recursively from the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to delete</p></dd><dt>returns</dt><dd class="cmt"><p>
-  true if the path was successfully deleted</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  true if the path was successfully deleted</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the filesystem operation fails</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#delta" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="delta(path:org.apache.hadoop.fs.Path):Option[io.delta.tables.DeltaTable]"></a><a id="delta(Path):Option[DeltaTable]"></a>
@@ -633,7 +633,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">delta</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="io.delta.tables.DeltaTable">DeltaTable</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns a <span class="extype" name="io.delta.tables.DeltaTable">io.delta.tables.DeltaTable</span> if the path exists and contains valid Delta metadata.</p><div class="fullcomment"><div class="comment cmt"><p>Returns a <span class="extype" name="io.delta.tables.DeltaTable">io.delta.tables.DeltaTable</span> if the path exists and contains valid Delta metadata.</p><p>If the path exists but is <i>not</i> a valid Delta table (e.g., leftover partial write), the directory is deleted and
 <code>None</code> is returned so it can be recreated cleanly on the next write.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
@@ -653,7 +653,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -669,7 +669,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#exists" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exists(path:org.apache.hadoop.fs.Path):Boolean"></a><a id="exists(Path):Boolean"></a>
@@ -685,12 +685,12 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">exists</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks if a path exists on the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Checks if a path exists on the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to check</p></dd><dt>returns</dt><dd class="cmt"><p>
-  true if the path exists</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  true if the path exists</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the filesystem operation fails</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadataOperations#format" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="format:String"></a>
@@ -706,7 +706,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">format</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the file format of the indexed data (e.g., &quot;parquet&quot;, &quot;csv&quot;, &quot;json&quot;).</p><div class="fullcomment"><div class="comment cmt"><p>Returns the file format of the indexed data (e.g., &quot;parquet&quot;, &quot;csv&quot;, &quot;json&quot;).</p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   the format string from the stored metadata</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#fs" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -723,7 +723,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">fs</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.FileSystem">FileSystem</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop <code>FileSystem</code> instance resolved from the <a href="AriadneContextUser.html#storagePath:org.apache.hadoop.fs.Path" class="extmbr" name="dev.cjfravel.ariadne.AriadneContextUser#storagePath">storagePath</a> URI and the Spark Hadoop configuration.</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop <code>FileSystem</code> instance resolved from the <a href="AriadneContextUser.html#storagePath:org.apache.hadoop.fs.Path" class="extmbr" name="dev.cjfravel.ariadne.AriadneContextUser#storagePath">storagePath</a> URI and the Spark Hadoop configuration. Used for all
 filesystem operations (existence checks, reads, deletes, lock files).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -741,12 +741,12 @@ filesystem operations (existence checks, reads, deletes, lock files).
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -762,12 +762,12 @@ filesystem operations (existence checks, reads, deletes, lock files).
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#indexRepartitionCount" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="indexRepartitionCount:Option[Int]"></a>
@@ -783,7 +783,7 @@ filesystem operations (existence checks, reads, deletes, lock files).
       <span class="symbol">
         <span class="name">indexRepartitionCount</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Int">Int</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Optional number of partitions to use when repartitioning the index DataFrame during joins.</p><div class="fullcomment"><div class="comment cmt"><p>Optional number of partitions to use when repartitioning the index DataFrame during joins. When set, the index
 DataFrame is repartitioned before expensive operations like explode to reduce per-executor memory pressure and
 avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepartitionCount configuration
@@ -803,7 +803,7 @@ avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepa
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#largeIndexLimit" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="largeIndexLimit:Long"></a>
@@ -819,7 +819,7 @@ avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepa
       <span class="symbol">
         <span class="name">largeIndexLimit</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Maximum number of distinct values per file before an index column is promoted to a &quot;large index&quot; (stored in a
 separate exploded Delta table).</p><div class="fullcomment"><div class="comment cmt"><p>Maximum number of distinct values per file before an index column is promoted to a &quot;large index&quot; (stored in a
 separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</code> (default: 500000).</p><p>If the configured value is not a valid positive number, a warning is logged and the default of 500,000 is used.
@@ -838,7 +838,7 @@ separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</
       <span class="symbol">
         <span class="name">lockMaxWait</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Maximum total time in seconds to wait for lock acquisition before failing.</p><div class="fullcomment"><div class="comment cmt"><p>Maximum total time in seconds to wait for lock acquisition before failing. Reads from spark.ariadne.lockMaxWait
 configuration (default: 3600).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Note</dt><dd><span class="cmt"><p>
@@ -858,7 +858,7 @@ configuration (default: 3600).
       <span class="symbol">
         <span class="name">lockRefreshInterval</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Refresh the update lock every N batches during updateBatched.</p><div class="fullcomment"><div class="comment cmt"><p>Refresh the update lock every N batches during updateBatched. Reads from spark.ariadne.lockRefreshInterval
 configuration (default: 1).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -876,7 +876,7 @@ configuration (default: 1).
       <span class="symbol">
         <span class="name">lockRetryInterval</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Base interval in seconds between lock acquisition retries (exponential backoff applied).</p><div class="fullcomment"><div class="comment cmt"><p>Base interval in seconds between lock acquisition retries (exponential backoff applied). Reads from
 spark.ariadne.lockRetryInterval configuration (default: 60).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -894,7 +894,7 @@ spark.ariadne.lockRetryInterval configuration (default: 60).
       <span class="symbol">
         <span class="name">lockTimeout</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Seconds since <code>lastRefreshedAt</code> before a lock is considered stale and eligible for auto-heal (forcible acquisition
 by another process).</p><div class="fullcomment"><div class="comment cmt"><p>Seconds since <code>lastRefreshedAt</code> before a lock is considered stale and eligible for auto-heal (forcible acquisition
 by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default: 1800).
@@ -913,7 +913,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">logger</span><span class="result">: <span class="extype" name="org.apache.logging.log4j.Logger">Logger</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Log4j logger shared by all Ariadne components.</p><div class="fullcomment"><div class="comment cmt"><p>Log4j logger shared by all Ariadne components. Uses the &quot;ariadne&quot; logger name. Marked <code>@transient lazy</code> so that
 <code>Index</code> (a case class) remains serializable across Spark stages — Log4j loggers are not <code>Serializable</code>.
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a> → <a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -931,7 +931,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">metadataExists</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks if metadata exists in the storage location.</p><div class="fullcomment"><div class="comment cmt"><p>Checks if metadata exists in the storage location.</p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   True if metadata exists, otherwise false.</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadataOperations#metadataFilePath" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -948,7 +948,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">metadataFilePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop path for the metadata file.</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop path for the metadata file.</p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   the path to <code>metadata.json</code> under the index storage directory</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -965,7 +965,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -981,12 +981,12 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -1002,12 +1002,12 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#open" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="open(path:org.apache.hadoop.fs.Path):org.apache.hadoop.fs.FSDataInputStream"></a><a id="open(Path):FSDataInputStream"></a>
@@ -1023,12 +1023,12 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">open</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.FSDataInputStream">FSDataInputStream</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Opens an input stream to read from a path on the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Opens an input stream to read from a path on the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to open for reading</p></dd><dt>returns</dt><dd class="cmt"><p>
-  An FSDataInputStream for reading the file contents</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  An FSDataInputStream for reading the file contents</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the file does not exist or cannot be opened</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadataOperations#refreshMetadata" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="refreshMetadata():Unit"></a>
@@ -1044,10 +1044,10 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">refreshMetadata</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Forces a reload of metadata from the <code>metadata.json</code> file on disk.</p><div class="fullcomment"><div class="comment cmt"><p>Forces a reload of metadata from the <code>metadata.json</code> file on disk.</p><p>Replaces the in-memory cached metadata with a freshly deserialized copy. This is called automatically by
 <span class="extype" name="metadata">metadata</span> on first access; callers may invoke it explicitly to pick up external changes.
-</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="MetadataMissingOrCorruptException"><code>MetadataMissingOrCorruptException</code></span>
+</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="MetadataMissingOrCorruptException"><code>MetadataMissingOrCorruptException</code></span> 
   if the metadata file does not exist, cannot be read, or contains invalid JSON</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#repartitionDataFiles" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="repartitionDataFiles:Boolean"></a>
@@ -1063,7 +1063,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">repartitionDataFiles</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">When true, applies indexRepartitionCount repartitioning to the data files read during joinDf.</p><div class="fullcomment"><div class="comment cmt"><p>When true, applies indexRepartitionCount repartitioning to the data files read during joinDf. When false, data
 files keep their natural parquet partitioning. Disable when column selection significantly reduces data volume,
 making the repartition shuffle more expensive than useful. Reads from spark.ariadne.repartitionDataFiles
@@ -1083,7 +1083,7 @@ configuration (default: false).
       <span class="symbol">
         <span class="name">safeDestroyBroadcast</span><span class="params">(<span name="broadcast">broadcast: <span class="extype" name="org.apache.spark.broadcast.Broadcast">Broadcast</span>[_]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Safely destroys a broadcast variable, logging but swallowing any exception.</p><div class="fullcomment"><div class="comment cmt"><p>Safely destroys a broadcast variable, logging but swallowing any exception.</p><p>Intended for use inside <code>finally</code> blocks where a cleanup failure must not mask the original exception propagating
 out of the <code>try</code> block. Tolerates a null broadcast.
 </p></div><dl class="paramcmts block"><dt class="param">broadcast</dt><dd class="cmt"><p>
@@ -1102,7 +1102,7 @@ out of the <code>try</code> block. Tolerates a null broadcast.
       <span class="symbol">
         <span class="name">stagingConsolidationThreshold</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Number of batches to process before consolidating staged data into the main index.</p><div class="fullcomment"><div class="comment cmt"><p>Number of batches to process before consolidating staged data into the main index. This provides fault tolerance
 for large index builds - if a job fails, work is preserved up to the last consolidation point. Reads from
 spark.ariadne.stagingConsolidationThreshold configuration (default: 50).
@@ -1121,10 +1121,10 @@ spark.ariadne.stagingConsolidationThreshold configuration (default: 50).
       <span class="symbol">
         <span class="name">storagePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Base path on the Hadoop-compatible filesystem where all Ariadne index data is stored.</p><div class="fullcomment"><div class="comment cmt"><p>Base path on the Hadoop-compatible filesystem where all Ariadne index data is stored. Each index creates a
 subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</code> (required — no default).
-</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if the configuration key is not set</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexFileOperations#storedSchema" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="storedSchema:org.apache.spark.sql.types.StructType"></a><a id="storedSchema:StructType"></a>
@@ -1140,14 +1140,14 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name">storedSchema</span><span class="result">: <span class="extype" name="org.apache.spark.sql.types.StructType">StructType</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the stored schema of the index.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the stored schema of the index.</p><p>Parses the JSON schema string from metadata into a Spark StructType.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   The StructType schema parsed from metadata</p></dd></dl><dl class="attributes block"> <div class="block">Example:
                <ol><li class="cmt"><p></p><pre><span class="kw">val</span> schema = index.storedSchema
 schema.printTreeString()</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="SchemaParseException"><code>SchemaParseException</code></span>
-  if the schema string cannot be parsed as a StructType</p></span><span class="cmt"><p><a href="exceptions/MissingSchemaException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.MissingSchemaException"><code>dev.cjfravel.ariadne.exceptions.MissingSchemaException</code></a>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="SchemaParseException"><code>SchemaParseException</code></span> 
+  if the schema string cannot be parsed as a StructType</p></span><span class="cmt"><p><a href="exceptions/MissingSchemaException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.MissingSchemaException"><code>dev.cjfravel.ariadne.exceptions.MissingSchemaException</code></a> 
   if the schema is null in metadata</p></span></dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -1163,7 +1163,7 @@ schema.printTreeString()</pre></li></ol>
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -1179,7 +1179,7 @@ schema.printTreeString()</pre></li></ol>
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -1195,13 +1195,13 @@ schema.printTreeString()</pre></li></ol>
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -1217,15 +1217,15 @@ schema.printTreeString()</pre></li></ol>
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -1241,13 +1241,13 @@ schema.printTreeString()</pre></li></ol>
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadataOperations#writeMetadata" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="writeMetadata(metadata:dev.cjfravel.ariadne.IndexMetadata):Unit"></a><a id="writeMetadata(IndexMetadata):Unit"></a>
@@ -1263,19 +1263,19 @@ schema.printTreeString()</pre></li></ol>
       <span class="symbol">
         <span class="name">writeMetadata</span><span class="params">(<span name="metadata">metadata: <a href="IndexMetadata.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadata">IndexMetadata</a></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Writes metadata to the <code>metadata.json</code> file and updates the in-memory cache.</p><div class="fullcomment"><div class="comment cmt"><p>Writes metadata to the <code>metadata.json</code> file and updates the in-memory cache.</p><p>Creates the parent directory if it does not exist. JSON is written and validated at a unique sibling path, then
 replaced through Hadoop's overwrite rename operation. The replacement is atomic on filesystems with atomic rename
 semantics (such as HDFS); object-store connectors may implement rename as copy/delete and cannot provide the same
 guarantee.
 </p></div><dl class="paramcmts block"><dt class="param">metadata</dt><dd class="cmt"><p>
-  the metadata instance to serialize and persist</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  the metadata instance to serialize and persist</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the write fails (the error is logged before propagating)</p></span></dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -1293,15 +1293,15 @@ guarantee.
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -1317,13 +1317,13 @@ guarantee.
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/IndexJoinOperations.html
+++ b/docs/api/dev/cjfravel/ariadne/IndexJoinOperations.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.IndexJoinOperations" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.IndexJoinOperations" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="catalog/index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -147,7 +147,7 @@
       <span class="symbol">
         <a title="" href="exceptions/index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented3">
                         <span class="separator"></span>
@@ -256,7 +256,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Trait providing join operations between DataFrames and indexed data.</p><p>Orchestrates the join workflow:</p><ol class="decimal"><li>Maps join columns to their storage column names (regular, bloom, range, exploded) 2. Locates relevant files
      using the index (via <a href="IndexQueryOperations.html#locateFilesFromDataFrame(valuesDf:org.apache.spark.sql.DataFrame,columnMappings:Map[String,String],joinColumns:Seq[String]):Set[String]" class="extmbr" name="dev.cjfravel.ariadne.IndexQueryOperations#locateFilesFromDataFrame">IndexQueryOperations.locateFilesFromDataFrame</a>) 3. Reads only the located data files
      (file-level pruning) 4. Applies temporal deduplication if applicable (keeps latest version per value) 5.
@@ -272,7 +272,7 @@
             </span>
             <div class="subClasses hiddenContent"><a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a>, <a href="IndexQueryOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexQueryOperations">IndexQueryOperations</a></div>
           </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -287,7 +287,7 @@
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -314,7 +314,7 @@
 
       <div id="template">
         <div id="allMembers">
-
+        
 
         <div id="types" class="types members">
               <h3>Type Members</h3>
@@ -332,7 +332,7 @@
       <span class="symbol">
         <a title="Case class to hold file analysis results for batching decisions." href="IndexBuildOperations$FileAnalysis.html"><span class="name">FileAnalysis</span></a><span class="params">(<span name="filename">filename: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="distinctCounts">distinctCounts: <span class="extype" name="scala.Predef.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Long">Long</span>]</span>, <span name="maxDistinctCount">maxDistinctCount: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result"> extends <span class="extype" name="scala.Product">Product</span> with <span class="extype" name="scala.Serializable">Serializable</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Case class to hold file analysis results for batching decisions.</p><div class="fullcomment"><div class="comment cmt"><p>Case class to hold file analysis results for batching decisions.
 </p></div><dl class="paramcmts block"><dt class="param">filename</dt><dd class="cmt"><p>
   The name of the file</p></dd><dt class="param">distinctCounts</dt><dd class="cmt"><p>
@@ -357,7 +357,7 @@
       <span class="symbol">
         <span class="name">spark</span><span class="result">: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Implicit SparkSession that must be provided by the mixing class.</p><div class="fullcomment"><div class="comment cmt"><p>Implicit SparkSession that must be provided by the mixing class.</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
     </li></ol>
             </div>
@@ -379,7 +379,7 @@
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -395,7 +395,7 @@
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -411,7 +411,7 @@
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexFileOperations#addFilenameColumn" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addFilenameColumn(df:org.apache.spark.sql.DataFrame,files:Set[String]):org.apache.spark.sql.DataFrame"></a><a id="addFilenameColumn(DataFrame,Set[String]):DataFrame"></a>
@@ -427,7 +427,7 @@
       <span class="symbol">
         <span class="name">addFilenameColumn</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="files">files: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Adds a stable filename column to the DataFrame.</p><div class="fullcomment"><div class="comment cmt"><p>Adds a stable filename column to the DataFrame.</p><p>Uses <code>input_file_name()</code> to capture the source file path. For single-file reads where Spark may report an empty
 filename, falls back to the known file path.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
@@ -448,7 +448,7 @@ filename, falls back to the known file path.
       <span class="symbol">
         <span class="name">analyzeFiles</span><span class="params">(<span name="files">files: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Seq">Seq</span>[<a href="Index.html#FileAnalysisextendsProductwithSerializable" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations.FileAnalysis">Index.FileAnalysis</a>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Performs pre-flight analysis on unindexed files to determine optimal batching strategy.</p><div class="fullcomment"><div class="comment cmt"><p>Performs pre-flight analysis on unindexed files to determine optimal batching strategy.</p><p>Reads the source files, applies computed indexes, and counts distinct values per indexed column per file. The
 resulting <a href="IndexBuildOperations$FileAnalysis.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations.FileAnalysis">FileAnalysis</a> objects are used by <a href="IndexBuildOperations.html#createOptimalBatches(fileAnalyses:Seq[IndexBuildOperations.this.FileAnalysis]):Seq[Set[String]]" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#createOptimalBatches">createOptimalBatches</a> to group files into batches that stay under
 the <code>largeIndexLimit</code>.</p><p>If no storage columns are configured (e.g., only bloom or range indexes), returns trivial analyses with zero
@@ -473,7 +473,7 @@ distinct counts.
       <span class="symbol">
         <span class="name">appendToLargeIndex</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Appends large index data to per-column Delta tables under <code>large_indexes/</code>.</p><div class="fullcomment"><div class="comment cmt"><p>Appends large index data to per-column Delta tables under <code>large_indexes/</code>.</p><p>For each storage column, identifies rows where the array size meets or exceeds <code>largeIndexLimit</code>, explodes those
 arrays into individual rows, and writes them to <code>large_indexes/{column}/</code>. Before appending, any existing rows for
 the same filenames are removed via Delta MERGE to prevent duplicates (important during column backfill or
@@ -498,7 +498,7 @@ re-indexing).
       <span class="symbol">
         <span class="name">appendToStaging</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Appends the processed DataFrame to the staging Delta table.</p><div class="fullcomment"><div class="comment cmt"><p>Appends the processed DataFrame to the staging Delta table.</p><p>Before writing, any column whose array size meets or exceeds <code>largeIndexLimit</code> is nulled out (those values are
 stored separately via <a href="IndexBuildOperations.html#appendToLargeIndex(df:org.apache.spark.sql.DataFrame):Unit" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#appendToLargeIndex">appendToLargeIndex</a>). The DataFrame is written in append mode with schema merge enabled.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
@@ -517,7 +517,7 @@ stored separately via <a href="IndexBuildOperations.html#appendToLargeIndex(df:o
       <span class="symbol">
         <span class="name">applyColumnSelection</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Applies column selection if columns have been specified via select().</p><div class="fullcomment"><div class="comment cmt"><p>Applies column selection if columns have been specified via select(). Only reads the explicitly selected columns.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
   The DataFrame to apply column selection to</p></dd><dt>returns</dt><dd class="cmt"><p>
@@ -536,12 +536,12 @@ stored separately via <a href="IndexBuildOperations.html#appendToLargeIndex(df:o
       <span class="symbol">
         <span class="name">applyComputedIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Applies computed indexes to a DataFrame by adding computed columns.</p><div class="fullcomment"><div class="comment cmt"><p>Applies computed indexes to a DataFrame by adding computed columns.</p><p>Each computed index is a Spark SQL expression stored in metadata. The expression is evaluated via <code>expr()</code> and
 added as a new column. If no computed indexes are configured, the DataFrame is returned unchanged.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
   The base DataFrame</p></dd><dt>returns</dt><dd class="cmt"><p>
-  DataFrame with computed index columns added</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="org.apache.spark.sql.AnalysisException"><code>org.apache.spark.sql.AnalysisException</code></span>
+  DataFrame with computed index columns added</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="org.apache.spark.sql.AnalysisException"><code>org.apache.spark.sql.AnalysisException</code></span> 
   if a computed index expression is invalid or references non-existent columns</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexFileOperations#applyExplodedFields" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="applyExplodedFields(df:org.apache.spark.sql.DataFrame):org.apache.spark.sql.DataFrame"></a><a id="applyExplodedFields(DataFrame):DataFrame"></a>
@@ -557,7 +557,7 @@ added as a new column. If no computed indexes are configured, the DataFrame is r
       <span class="symbol">
         <span class="name">applyExplodedFields</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Applies exploded field transformations to a DataFrame.</p><div class="fullcomment"><div class="comment cmt"><p>Applies exploded field transformations to a DataFrame.</p><p>For each configured exploded field, extracts the nested field path from the array column and explodes it into a
 top-level column. This is used on the read/join path to prepare data for joining on exploded field values.</p><p>Note that <code>explode()</code> (not <code>explode_outer()</code>) is used intentionally — rows with null or empty arrays are dropped
 because they contain no matchable values for the join. This is consistent with the index build path which also
@@ -579,7 +579,7 @@ excludes null/empty arrays.
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#autoBloomColumnPrefix" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="autoBloomColumnPrefix:String"></a>
@@ -595,7 +595,7 @@ excludes null/empty arrays.
       <span class="symbol">
         <span class="name">autoBloomColumnPrefix</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Column name prefix for auto-bloom filter storage in the main index table.</p><div class="fullcomment"><div class="comment cmt"><p>Column name prefix for auto-bloom filter storage in the main index table.
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#autoBloomFpr" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -612,7 +612,7 @@ excludes null/empty arrays.
       <span class="symbol">
         <span class="name">autoBloomFpr</span><span class="result">: <span class="extype" name="scala.Double">Double</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">False positive rate for auto-bloom filters on large index columns.</p><div class="fullcomment"><div class="comment cmt"><p>False positive rate for auto-bloom filters on large index columns. When a column exceeds largeIndexLimit, an
 auto-bloom filter is built with this FPR to enable file pruning at query time. Reads from
 spark.ariadne.autoBloomFpr configuration (default: 0.01).
@@ -631,7 +631,7 @@ spark.ariadne.autoBloomFpr configuration (default: 0.01).
       <span class="symbol">
         <span class="name">autoBloomStorageColumns</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the set of auto-bloom storage column names (each prefixed with <code>auto_bloom_</code>).</p><div class="fullcomment"><div class="comment cmt"><p>Returns the set of auto-bloom storage column names (each prefixed with <code>auto_bloom_</code>).
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   set of prefixed column names (e.g., <code>auto_bloom_user_id</code>)</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
@@ -649,7 +649,7 @@ spark.ariadne.autoBloomFpr configuration (default: 0.01).
       <span class="symbol">
         <span class="name">autoCompactThreshold</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Int">Int</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Optional threshold for auto-compaction.</p><div class="fullcomment"><div class="comment cmt"><p>Optional threshold for auto-compaction. When set, the main index Delta table is compacted after an update if the
 number of Delta log JSON files meets or exceeds this value. Reads from spark.ariadne.autoCompactThreshold
 configuration (default: not set).
@@ -668,7 +668,7 @@ configuration (default: not set).
       <span class="symbol">
         <span class="name">batchesSinceCompact</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Counter tracking batches processed since the last auto-compaction.</p><div class="fullcomment"><div class="comment cmt"><p>Counter tracking batches processed since the last auto-compaction.</p><p>Incremented after each batch in <code>updateBatched</code> and reset to zero after each compaction cycle or at the start of
 each <a href="Index.html#update:Unit" class="extmbr" name="dev.cjfravel.ariadne.Index#update">update</a> call to prevent stale counts from a previous <code>update</code> from triggering premature
 compaction.
@@ -687,7 +687,7 @@ compaction.
       <span class="symbol">
         <span class="name">bloomColumnPrefix</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Column name prefix used when storing bloom filter binary data in the index Delta table.</p><div class="fullcomment"><div class="comment cmt"><p>Column name prefix used when storing bloom filter binary data in the index Delta table.
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.BloomFilterOperations#bloomColumns" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -704,7 +704,7 @@ compaction.
       <span class="symbol">
         <span class="name">bloomColumns</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the set of source column names that have bloom indexes configured.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the set of source column names that have bloom indexes configured.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   set of column names (without the <code>bloom_</code> prefix)</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd></dl></div>
@@ -722,7 +722,7 @@ compaction.
       <span class="symbol">
         <span class="name">bloomContainsUdf</span><span class="result">: <span class="extype" name="org.apache.spark.sql.expressions.UserDefinedFunction">UserDefinedFunction</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Creates a Spark UDF for checking bloom filter membership at query time.</p><div class="fullcomment"><div class="comment cmt"><p>Creates a Spark UDF for checking bloom filter membership at query time.</p><p>The returned UDF accepts a serialized bloom filter (<code>Array[Byte]</code>) and a candidate value (<code>String</code>), and returns
 <code>true</code> if the bloom filter indicates the value might be present.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
@@ -741,7 +741,7 @@ compaction.
       <span class="symbol">
         <span class="name">bloomIndexConfigs</span><span class="result">: <span class="extype" name="scala.Seq">Seq</span>[<a href="BloomIndexConfig.html" class="extype" name="dev.cjfravel.ariadne.BloomIndexConfig">BloomIndexConfig</a>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the bloom index configurations from the current index metadata.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the bloom index configurations from the current index metadata.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   sequence of <a href="BloomIndexConfig.html" class="extype" name="dev.cjfravel.ariadne.BloomIndexConfig">BloomIndexConfig</a> objects, one per bloom-indexed column</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd></dl></div>
@@ -759,7 +759,7 @@ compaction.
       <span class="symbol">
         <span class="name">bloomMightContain</span><span class="params">(<span name="bloomBytes">bloomBytes: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Byte">Byte</span>]</span>, <span name="value">value: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks if a value might be contained in a serialized bloom filter.</p><div class="fullcomment"><div class="comment cmt"><p>Checks if a value might be contained in a serialized bloom filter.</p><p>Deserializes the bloom filter and performs a <code>mightContain</code> check. Returns <code>false</code> if either argument is <code>null</code>.
 </p></div><dl class="paramcmts block"><dt class="param">bloomBytes</dt><dd class="cmt"><p>
   serialized bloom filter bytes</p></dd><dt class="param">value</dt><dd class="cmt"><p>
@@ -779,7 +779,7 @@ compaction.
       <span class="symbol">
         <span class="name">bloomStorageColumns</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the set of storage column names used for bloom filter binary data.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the set of storage column names used for bloom filter binary data.</p><p>Each name is the source column name prefixed with <a href="BloomFilterOperations.html#bloomColumnPrefix:String" class="extmbr" name="dev.cjfravel.ariadne.BloomFilterOperations#bloomColumnPrefix">bloomColumnPrefix</a>.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   set of prefixed column names (e.g., <code>bloom_user_id</code>)</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd></dl></div>
@@ -797,7 +797,7 @@ compaction.
       <span class="symbol">
         <span class="name">buildAutoBloomIndexes</span><span class="params">(<span name="combinedDf">combinedDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds auto-bloom filters for columns that exceed the large index limit.</p><div class="fullcomment"><div class="comment cmt"><p>Builds auto-bloom filters for columns that exceed the large index limit.</p><p>Scans the combined DataFrame to identify columns with any file whose array size meets or exceeds <code>largeIndexLimit</code>.
 For each such column, a bloom filter is built from the full array and stored in the main index with the
 <code>auto_bloom_</code> prefix. At query time, these bloom filters enable fast pre-filtering to determine which files need to
@@ -822,7 +822,7 @@ unpersisted before the exception is rethrown.
       <span class="symbol">
         <span class="name">buildBloomFilterIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds bloom filter indexes for all configured bloom columns.</p><div class="fullcomment"><div class="comment cmt"><p>Builds bloom filter indexes for all configured bloom columns.</p><p>For each <a href="BloomIndexConfig.html" class="extype" name="dev.cjfravel.ariadne.BloomIndexConfig">BloomIndexConfig</a>, this method:</p><ol class="decimal"><li>Groups the input data by filename 2. Collects distinct values per file into a set 3. Creates a bloom filter
      from the collected values using <a href="BloomFilterOperations.html#createBloomFilterUdf(fprValue:Double):org.apache.spark.sql.expressions.UserDefinedFunction" class="extmbr" name="dev.cjfravel.ariadne.BloomFilterOperations#createBloomFilterUdf">createBloomFilterUdf</a> 4. Joins the resulting bloom column back onto the
      accumulating DataFrame</li></ol><p>If no bloom indexes are configured, returns a distinct filename-only DataFrame.
@@ -843,7 +843,7 @@ unpersisted before the exception is rethrown.
       <span class="symbol">
         <span class="name">buildExplodedFieldIndexes</span><span class="params">(<span name="baseData">baseData: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="resultDf">resultDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds exploded field indexes and joins them onto the result DataFrame.</p><div class="fullcomment"><div class="comment cmt"><p>Builds exploded field indexes and joins them onto the result DataFrame.</p><p>For each configured exploded field index, extracts the nested field path from the array column, explodes it,
 collects distinct values back into an array per file, and joins the result onto <code>resultDf</code>.
 </p></div><dl class="paramcmts block"><dt class="param">baseData</dt><dd class="cmt"><p>
@@ -864,7 +864,7 @@ collects distinct values back into an array per file, and joins the result onto 
       <span class="symbol">
         <span class="name">buildRangeIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds range indexes storing <code>Struct(min, max)</code> per file.</p><div class="fullcomment"><div class="comment cmt"><p>Builds range indexes storing <code>Struct(min, max)</code> per file.</p><p>For each range index configuration, groups by <code>filename</code> and computes the <code>min</code> and <code>max</code> of the column per file.
 The result is a struct column named <code>range_{column}</code>.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
@@ -885,7 +885,7 @@ The result is a struct column named <code>range_{column}</code>.
       <span class="symbol">
         <span class="name">buildRegularIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds regular (array-aggregated) indexes for all configured regular and computed columns.</p><div class="fullcomment"><div class="comment cmt"><p>Builds regular (array-aggregated) indexes for all configured regular and computed columns.</p><p>Groups the input data by filename and collects distinct values into arrays via <code>collect_set</code>. If no regular or
 computed indexes are configured, returns a distinct filename-only DataFrame.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
@@ -905,7 +905,7 @@ computed indexes are configured, returns a distinct filename-only DataFrame.
       <span class="symbol">
         <span class="name">buildTemporalIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds temporal indexes storing <code>Array[Struct(value, max_ts)]</code> per file.</p><div class="fullcomment"><div class="comment cmt"><p>Builds temporal indexes storing <code>Array[Struct(value, max_ts)]</code> per file.</p><p>For each temporal index configuration, groups by <code>(filename, value_column)</code> to find the maximum timestamp per value
 per file, then collects the <code>(value, max_ts)</code> structs into an array per file. This enables temporal deduplication
 at query time.
@@ -927,17 +927,17 @@ at query time.
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#compactDeltaTables" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="compactDeltaTables():Unit"></a>
@@ -953,7 +953,7 @@ at query time.
       <span class="symbol">
         <span class="name">compactDeltaTables</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Compacts all Delta tables (main index and large index tables) using Delta OPTIMIZE.</p><div class="fullcomment"><div class="comment cmt"><p>Compacts all Delta tables (main index and large index tables) using Delta OPTIMIZE.</p><p>Runs Delta Lake's OPTIMIZE command to consolidate small files into larger ones, improving read performance.
 Processes the main index table first, then each large index column table.
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
@@ -971,7 +971,7 @@ Processes the main index table first, then each large index column table.
       <span class="symbol">
         <span class="name">consolidateStaging</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Consolidates staged data into the main index table.</p><div class="fullcomment"><div class="comment cmt"><p>Consolidates staged data into the main index table.</p><p>Delegates to <span class="extype" name="consolidateMainStaging">consolidateMainStaging</span> which performs a Delta MERGE (upsert) of all staged rows into the main
 index, then deletes the staging table. Logs the total time taken.
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
@@ -989,12 +989,12 @@ index, then deletes the staging table. Logs the total time taken.
       <span class="symbol">
         <span class="name">createBaseDataFrame</span><span class="params">(<span name="files">files: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Creates a base DataFrame from the provided files using the stored format and schema.</p><div class="fullcomment"><div class="comment cmt"><p>Creates a base DataFrame from the provided files using the stored format and schema. Applies any read options
 configured in the index metadata.</p><p>Returns an empty DataFrame (with the stored schema) if all file paths are blank after normalization.
 </p></div><dl class="paramcmts block"><dt class="param">files</dt><dd class="cmt"><p>
   Set of file paths to read</p></dd><dt>returns</dt><dd class="cmt"><p>
-  DataFrame with data from the specified files</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+  DataFrame with data from the specified files</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if the stored format is not csv, parquet, or json</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.BloomFilterOperations#createBloomFilterUdf" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="createBloomFilterUdf(fprValue:Double):org.apache.spark.sql.expressions.UserDefinedFunction"></a><a id="createBloomFilterUdf(Double):UserDefinedFunction"></a>
@@ -1010,7 +1010,7 @@ configured in the index metadata.</p><p>Returns an empty DataFrame (with the sto
       <span class="symbol">
         <span class="name">createBloomFilterUdf</span><span class="params">(<span name="fprValue">fprValue: <span class="extype" name="scala.Double">Double</span></span>)</span><span class="result">: <span class="extype" name="org.apache.spark.sql.expressions.UserDefinedFunction">UserDefinedFunction</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Creates a Spark UDF that converts a collected set of values into a serialized bloom filter.</p><div class="fullcomment"><div class="comment cmt"><p>Creates a Spark UDF that converts a collected set of values into a serialized bloom filter.</p><p>The UDF is designed for use inside <code>agg(bloomUdf(collect_set(...)))</code>. It:</p><ol class="decimal"><li>Filters out null values from the input sequence 2. Creates a Guava <code>BloomFilter</code> sized for the actual number
      of non-null elements 3. Inserts each value (converted to <code>String</code>) into the filter 4. Serializes the filter to
      <code>Array[Byte]</code> via <code>ByteArrayOutputStream</code></li></ol><p>The <code>fprValue</code> parameter is captured as a local <code>val</code> to ensure it is serializable when the UDF closure is shipped
@@ -1018,7 +1018,7 @@ to Spark executors.
 </p></div><dl class="paramcmts block"><dt class="param">fprValue</dt><dd class="cmt"><p>
   the desired false positive rate (e.g., 0.01 for 1%); must be strictly between 0 and 1 (exclusive)</p></dd><dt>returns</dt><dd class="cmt"><p>
   a UDF that accepts <code>Seq[Any]</code> (from <code>collect_set</code>) and returns <code>Array[Byte]</code>, or <code>null</code> if the input is null or
-  contains only nulls</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+  contains only nulls</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if <code>fprValue</code> is not in the range (0, 1)</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#createOptimalBatches" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="createOptimalBatches(fileAnalyses:Seq[IndexBuildOperations.this.FileAnalysis]):Seq[Set[String]]"></a><a id="createOptimalBatches(Seq[Index.FileAnalysis]):Seq[Set[String]]"></a>
@@ -1034,7 +1034,7 @@ to Spark executors.
       <span class="symbol">
         <span class="name">createOptimalBatches</span><span class="params">(<span name="fileAnalyses">fileAnalyses: <span class="extype" name="scala.Seq">Seq</span>[<a href="Index.html#FileAnalysisextendsProductwithSerializable" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations.FileAnalysis">Index.FileAnalysis</a>]</span>)</span><span class="result">: <span class="extype" name="scala.Seq">Seq</span>[<span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Groups files into batches whose aggregate <code>maxDistinctCount</code> stays at or below <code>largeIndexLimit</code>.</p><div class="fullcomment"><div class="comment cmt"><p>Groups files into batches whose aggregate <code>maxDistinctCount</code> stays at or below <code>largeIndexLimit</code>.</p><p>The algorithm sorts files by <code>maxDistinctCount</code> (largest first) and packs them sequentially into batches. When
 adding a file would push the batch total past the limit, a new batch is started. Files that individually exceed the
 limit are placed into single-file batches to guarantee progress.
@@ -1055,7 +1055,7 @@ limit are placed into single-file batches to guarantee progress.
       <span class="symbol">
         <span class="name">debugEnabled</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">When true, logs detailed diagnostics during join operations including partition counts, physical plans, and
 per-phase timing.</p><div class="fullcomment"><div class="comment cmt"><p>When true, logs detailed diagnostics during join operations including partition counts, physical plans, and
 per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
@@ -1074,12 +1074,12 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">delete</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Deletes a path recursively from the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Deletes a path recursively from the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to delete</p></dd><dt>returns</dt><dd class="cmt"><p>
-  true if the path was successfully deleted</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  true if the path was successfully deleted</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the filesystem operation fails</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#delta" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="delta(path:org.apache.hadoop.fs.Path):Option[io.delta.tables.DeltaTable]"></a><a id="delta(Path):Option[DeltaTable]"></a>
@@ -1095,7 +1095,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">delta</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="io.delta.tables.DeltaTable">DeltaTable</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns a <span class="extype" name="io.delta.tables.DeltaTable">io.delta.tables.DeltaTable</span> if the path exists and contains valid Delta metadata.</p><div class="fullcomment"><div class="comment cmt"><p>Returns a <span class="extype" name="io.delta.tables.DeltaTable">io.delta.tables.DeltaTable</span> if the path exists and contains valid Delta metadata.</p><p>If the path exists but is <i>not</i> a valid Delta table (e.g., leftover partial write), the directory is deleted and
 <code>None</code> is returned so it can be recreated cleanly on the next write.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
@@ -1115,12 +1115,12 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">deserializeBloomFilter</span><span class="params">(<span name="bytes">bytes: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Byte">Byte</span>]</span>)</span><span class="result">: <span class="extype" name="com.google.common.hash.BloomFilter">BloomFilter</span>[<span class="extype" name="java.lang.CharSequence">CharSequence</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Deserializes a Guava bloom filter from its byte representation.</p><div class="fullcomment"><div class="comment cmt"><p>Deserializes a Guava bloom filter from its byte representation.</p><p>Uses <code>BloomFilter.readFrom</code> with a UTF-8 <code>StringFunnel</code>, which must match the funnel used during creation in
 <a href="BloomFilterOperations.html#createBloomFilterUdf(fprValue:Double):org.apache.spark.sql.expressions.UserDefinedFunction" class="extmbr" name="dev.cjfravel.ariadne.BloomFilterOperations#createBloomFilterUdf">createBloomFilterUdf</a>.
 </p></div><dl class="paramcmts block"><dt class="param">bytes</dt><dd class="cmt"><p>
   serialized bloom filter bytes (produced by <code>BloomFilter.writeTo</code>)</p></dd><dt>returns</dt><dd class="cmt"><p>
-  a <code>BloomFilter[CharSequence]</code> instance ready for membership queries</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  a <code>BloomFilter[CharSequence]</code> instance ready for membership queries</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the byte array is malformed or corrupted</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#ensureStorageReadyUnderLock" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ensureStorageReadyUnderLock(lock:dev.cjfravel.ariadne.IndexLock,correlationId:String,refresh:Boolean):Unit"></a><a id="ensureStorageReadyUnderLock(IndexLock,String,Boolean):Unit"></a>
@@ -1136,7 +1136,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">ensureStorageReadyUnderLock</span><span class="params">(<span name="lock">lock: <a href="IndexLock.html" class="extype" name="dev.cjfravel.ariadne.IndexLock">IndexLock</a></span>, <span name="correlationId">correlationId: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="refresh">refresh: <span class="extype" name="scala.Boolean">Boolean</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Runs migration preflight while the caller holds the update lock.</p><div class="fullcomment"><div class="comment cmt"><p>Runs migration preflight while the caller holds the update lock.
 </p></div><dl class="paramcmts block"><dt class="param">refresh</dt><dd class="cmt"><p>
   whether to reload metadata after lock acquisition</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
@@ -1154,7 +1154,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -1170,7 +1170,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#exists" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exists(path:org.apache.hadoop.fs.Path):Boolean"></a><a id="exists(Path):Boolean"></a>
@@ -1186,12 +1186,12 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">exists</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks if a path exists on the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Checks if a path exists on the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to check</p></dd><dt>returns</dt><dd class="cmt"><p>
-  true if the path exists</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  true if the path exists</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the filesystem operation fails</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadataOperations#format" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="format:String"></a>
@@ -1207,7 +1207,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">format</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the file format of the indexed data (e.g., &quot;parquet&quot;, &quot;csv&quot;, &quot;json&quot;).</p><div class="fullcomment"><div class="comment cmt"><p>Returns the file format of the indexed data (e.g., &quot;parquet&quot;, &quot;csv&quot;, &quot;json&quot;).</p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   the format string from the stored metadata</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#fs" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -1224,7 +1224,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">fs</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.FileSystem">FileSystem</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop <code>FileSystem</code> instance resolved from the <a href="AriadneContextUser.html#storagePath:org.apache.hadoop.fs.Path" class="extmbr" name="dev.cjfravel.ariadne.AriadneContextUser#storagePath">storagePath</a> URI and the Spark Hadoop configuration.</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop <code>FileSystem</code> instance resolved from the <a href="AriadneContextUser.html#storagePath:org.apache.hadoop.fs.Path" class="extmbr" name="dev.cjfravel.ariadne.AriadneContextUser#storagePath">storagePath</a> URI and the Spark Hadoop configuration. Used for all
 filesystem operations (existence checks, reads, deletes, lock files).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -1242,12 +1242,12 @@ filesystem operations (existence checks, reads, deletes, lock files).
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#getFileSizes" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getFileSizes(files:Set[String]):Map[String,Long]"></a><a id="getFileSizes(Set[String]):Map[String,Long]"></a>
@@ -1263,7 +1263,7 @@ filesystem operations (existence checks, reads, deletes, lock files).
       <span class="symbol">
         <span class="name">getFileSizes</span><span class="params">(<span name="files">files: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Predef.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Long">Long</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Computes file sizes in bytes for the given files using the Hadoop FileSystem.</p><div class="fullcomment"><div class="comment cmt"><p>Computes file sizes in bytes for the given files using the Hadoop FileSystem.</p><p>Files that cannot be found or read are silently skipped with a warning log.
 </p></div><dl class="paramcmts block"><dt class="param">files</dt><dd class="cmt"><p>
   set of fully-qualified file paths to measure</p></dd><dt>returns</dt><dd class="cmt"><p>
@@ -1282,7 +1282,7 @@ filesystem operations (existence checks, reads, deletes, lock files).
       <span class="symbol">
         <span class="name">handleLargeIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks all storage columns for arrays exceeding <code>largeIndexLimit</code> and delegates to <a href="IndexBuildOperations.html#appendToLargeIndex(df:org.apache.spark.sql.DataFrame):Unit" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#appendToLargeIndex">appendToLargeIndex</a> for
 separation.</p><div class="fullcomment"><div class="comment cmt"><p>Checks all storage columns for arrays exceeding <code>largeIndexLimit</code> and delegates to <a href="IndexBuildOperations.html#appendToLargeIndex(df:org.apache.spark.sql.DataFrame):Unit" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#appendToLargeIndex">appendToLargeIndex</a> for
 separation.
@@ -1302,12 +1302,12 @@ separation.
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#indexFilePath" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="indexFilePath:org.apache.hadoop.fs.Path"></a><a id="indexFilePath:Path"></a>
@@ -1323,7 +1323,7 @@ separation.
       <span class="symbol">
         <span class="name">indexFilePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop path for the main index Delta table (<code>{storagePath}/index/</code>).</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop path for the main index Delta table (<code>{storagePath}/index/</code>).</p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#indexRepartitionCount" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="indexRepartitionCount:Option[Int]"></a>
@@ -1339,7 +1339,7 @@ separation.
       <span class="symbol">
         <span class="name">indexRepartitionCount</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Int">Int</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Optional number of partitions to use when repartitioning the index DataFrame during joins.</p><div class="fullcomment"><div class="comment cmt"><p>Optional number of partitions to use when repartitioning the index DataFrame during joins. When set, the index
 DataFrame is repartitioned before expensive operations like explode to reduce per-executor memory pressure and
 avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepartitionCount configuration
@@ -1359,7 +1359,7 @@ avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepa
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexJoinOperations#join" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="join(df:org.apache.spark.sql.DataFrame,usingColumns:Seq[String],joinType:String):org.apache.spark.sql.DataFrame"></a><a id="join(DataFrame,Seq[String],String):DataFrame"></a>
@@ -1375,7 +1375,7 @@ avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepa
       <span class="symbol">
         <span class="name">join</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="usingColumns">usingColumns: <span class="extype" name="scala.Seq">Seq</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="joinType">joinType: <span class="extype" name="scala.Predef.String">String</span> = <span class="symbol">&quot;inner&quot;</span></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Joins a DataFrame with indexed data files.</p><div class="fullcomment"><div class="comment cmt"><p>Joins a DataFrame with indexed data files.</p><p>This is the primary public API for index-based joins. The index locates which files contain matching values, reads
 only those files, applies temporal deduplication if applicable, then performs the Spark DataFrame join.</p><p>The join direction is <code>indexedData.join(df)</code> — the index-located data is on the left. For the reverse direction,
 use <a href="Index$$DataFrameOps.html#join(index:dev.cjfravel.ariadne.Index,usingColumns:Seq[String],joinType:String):org.apache.spark.sql.DataFrame" class="extmbr" name="dev.cjfravel.ariadne.Index.DataFrameOps#join">Index.DataFrameOps.join</a>.
@@ -1392,8 +1392,8 @@ index.update
 <span class="kw">val</span> result = index.join(lookupDf, <span class="std">Seq</span>(<span class="lit">"customer_id"</span>))
 <span class="cmt">// Left join variant:</span>
 <span class="kw">val</span> leftResult = index.join(lookupDf, <span class="std">Seq</span>(<span class="lit">"customer_id"</span>), <span class="lit">"left"</span>)</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if none of the join columns have indexes</p></span><span class="cmt"><p><a href="exceptions/ColumnNotFoundException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.ColumnNotFoundException"><code>dev.cjfravel.ariadne.exceptions.ColumnNotFoundException</code></a>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if none of the join columns have indexes</p></span><span class="cmt"><p><a href="exceptions/ColumnNotFoundException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.ColumnNotFoundException"><code>dev.cjfravel.ariadne.exceptions.ColumnNotFoundException</code></a> 
   if join columns are not in the schema or indexes</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexJoinOperations#joinDf" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="joinDf(df:org.apache.spark.sql.DataFrame,usingColumns:Seq[String]):org.apache.spark.sql.DataFrame"></a><a id="joinDf(DataFrame,Seq[String]):DataFrame"></a>
@@ -1409,7 +1409,7 @@ index.update
       <span class="symbol">
         <span class="name">joinDf</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="usingColumns">usingColumns: <span class="extype" name="scala.Seq">Seq</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Locates and reads indexed data files relevant to the given DataFrame.</p><div class="fullcomment"><div class="comment cmt"><p>Locates and reads indexed data files relevant to the given DataFrame.</p><p>Uses the index to identify which files contain matching values, then reads those files into a lazy DataFrame. If no
 matching files are found, returns an empty DataFrame with the stored schema. The actual row-level filtering happens
 in the subsequent join in <a href="#join(df:org.apache.spark.sql.DataFrame,usingColumns:Seq[String],joinType:String):org.apache.spark.sql.DataFrame" class="extmbr" name="dev.cjfravel.ariadne.IndexJoinOperations#join">join</a>.</p><p>Logs data pruning metrics (file count, data size saved) when available, and includes detailed file-level debug
@@ -1417,8 +1417,8 @@ information when debug mode is enabled.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
   The DataFrame to match against the index.</p></dd><dt class="param">usingColumns</dt><dd class="cmt"><p>
   The columns used for the join.</p></dd><dt>returns</dt><dd class="cmt"><p>
-  A lazy DataFrame containing data from indexed files, or an empty DataFrame if no files match.</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if none of the join columns have indexes, or if df/usingColumns are null/empty</p></span><span class="cmt"><p><a href="exceptions/ColumnNotFoundException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.ColumnNotFoundException"><code>dev.cjfravel.ariadne.exceptions.ColumnNotFoundException</code></a>
+  A lazy DataFrame containing data from indexed files, or an empty DataFrame if no files match.</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if none of the join columns have indexes, or if df/usingColumns are null/empty</p></span><span class="cmt"><p><a href="exceptions/ColumnNotFoundException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.ColumnNotFoundException"><code>dev.cjfravel.ariadne.exceptions.ColumnNotFoundException</code></a> 
   if join columns are not in the selected columns, schema, or indexes</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#largeIndexLimit" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="largeIndexLimit:Long"></a>
@@ -1434,7 +1434,7 @@ information when debug mode is enabled.
       <span class="symbol">
         <span class="name">largeIndexLimit</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Maximum number of distinct values per file before an index column is promoted to a &quot;large index&quot; (stored in a
 separate exploded Delta table).</p><div class="fullcomment"><div class="comment cmt"><p>Maximum number of distinct values per file before an index column is promoted to a &quot;large index&quot; (stored in a
 separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</code> (default: 500000).</p><p>If the configured value is not a valid positive number, a warning is logged and the default of 500,000 is used.
@@ -1453,7 +1453,7 @@ separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</
       <span class="symbol">
         <span class="name">largeIndexesFilePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop root path for large index Delta tables (<code>{storagePath}/large_indexes/</code>).</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop root path for large index Delta tables (<code>{storagePath}/large_indexes/</code>).
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#lastAutoBloomCache" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -1470,11 +1470,11 @@ separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</
       <span class="symbol">
         <span class="name">lastAutoBloomCache</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Tracks the cached DataFrame from <a href="IndexBuildOperations.html#buildAutoBloomIndexes(combinedDf:org.apache.spark.sql.DataFrame):org.apache.spark.sql.DataFrame" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#buildAutoBloomIndexes">buildAutoBloomIndexes</a> for deferred cleanup.</p><div class="fullcomment"><div class="comment cmt"><p>Tracks the cached DataFrame from <a href="IndexBuildOperations.html#buildAutoBloomIndexes(combinedDf:org.apache.spark.sql.DataFrame):org.apache.spark.sql.DataFrame" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#buildAutoBloomIndexes">buildAutoBloomIndexes</a> for deferred cleanup.</p><p>Set during auto-bloom processing and unpersisted after staging is complete.
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd><dt>Annotations</dt><dd>
                 <span class="name">@transient</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.BloomFilterOperations#locateFilesWithBloom" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="locateFilesWithBloom(column:String,values:Array[Any],indexDf:org.apache.spark.sql.DataFrame):Set[String]"></a><a id="locateFilesWithBloom(String,Array[Any],DataFrame):Set[String]"></a>
@@ -1490,7 +1490,7 @@ separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</
       <span class="symbol">
         <span class="name">locateFilesWithBloom</span><span class="params">(<span name="column">column: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="values">values: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Any">Any</span>]</span>, <span name="indexDf">indexDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Locates files that might contain any of the given values using bloom filters.</p><div class="fullcomment"><div class="comment cmt"><p>Locates files that might contain any of the given values using bloom filters.</p><p>Collects all rows from the index, deserializes each file's bloom filter for the specified column, and tests every
 candidate value. A file is included in the result if any value passes the <code>mightContain</code> check.
 </p></div><dl class="paramcmts block"><dt class="param">column</dt><dd class="cmt"><p>
@@ -1516,7 +1516,7 @@ candidate value. A file is included in the result if any value passes the <code>
       <span class="symbol">
         <span class="name">locateFilesWithBloomFromDataFrame</span><span class="params">(<span name="column">column: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="valuesDf">valuesDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="indexDf">indexDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Locates files that might contain values from a DataFrame using bloom filters.</p><div class="fullcomment"><div class="comment cmt"><p>Locates files that might contain values from a DataFrame using bloom filters.</p><p>Collects distinct non-null values from the specified column of <code>valuesDf</code>, then delegates to
 <a href="BloomFilterOperations.html#locateFilesWithBloom(column:String,values:Array[Any],indexDf:org.apache.spark.sql.DataFrame):Set[String]" class="extmbr" name="dev.cjfravel.ariadne.BloomFilterOperations#locateFilesWithBloom">locateFilesWithBloom</a> for the actual bloom filter check.
 </p></div><dl class="paramcmts block"><dt class="param">column</dt><dd class="cmt"><p>
@@ -1542,7 +1542,7 @@ candidate value. A file is included in the result if any value passes the <code>
       <span class="symbol">
         <span class="name">lockMaxWait</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Maximum total time in seconds to wait for lock acquisition before failing.</p><div class="fullcomment"><div class="comment cmt"><p>Maximum total time in seconds to wait for lock acquisition before failing. Reads from spark.ariadne.lockMaxWait
 configuration (default: 3600).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Note</dt><dd><span class="cmt"><p>
@@ -1562,7 +1562,7 @@ configuration (default: 3600).
       <span class="symbol">
         <span class="name">lockRefreshInterval</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Refresh the update lock every N batches during updateBatched.</p><div class="fullcomment"><div class="comment cmt"><p>Refresh the update lock every N batches during updateBatched. Reads from spark.ariadne.lockRefreshInterval
 configuration (default: 1).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -1580,7 +1580,7 @@ configuration (default: 1).
       <span class="symbol">
         <span class="name">lockRetryInterval</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Base interval in seconds between lock acquisition retries (exponential backoff applied).</p><div class="fullcomment"><div class="comment cmt"><p>Base interval in seconds between lock acquisition retries (exponential backoff applied). Reads from
 spark.ariadne.lockRetryInterval configuration (default: 60).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -1598,7 +1598,7 @@ spark.ariadne.lockRetryInterval configuration (default: 60).
       <span class="symbol">
         <span class="name">lockTimeout</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Seconds since <code>lastRefreshedAt</code> before a lock is considered stale and eligible for auto-heal (forcible acquisition
 by another process).</p><div class="fullcomment"><div class="comment cmt"><p>Seconds since <code>lastRefreshedAt</code> before a lock is considered stale and eligible for auto-heal (forcible acquisition
 by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default: 1800).
@@ -1617,7 +1617,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">logger</span><span class="result">: <span class="extype" name="org.apache.logging.log4j.Logger">Logger</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Log4j logger shared by all Ariadne components.</p><div class="fullcomment"><div class="comment cmt"><p>Log4j logger shared by all Ariadne components. Uses the &quot;ariadne&quot; logger name. Marked <code>@transient lazy</code> so that
 <code>Index</code> (a case class) remains serializable across Spark stages — Log4j loggers are not <code>Serializable</code>.
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a> → <a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -1635,7 +1635,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">mapJoinColumnsToStorage</span><span class="params">(<span name="joinColumns">joinColumns: <span class="extype" name="scala.Seq">Seq</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Predef.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Maps join column names to their corresponding storage column names.</p><div class="fullcomment"><div class="comment cmt"><p>Maps join column names to their corresponding storage column names.</p><p>Bloom filter columns are prefixed with the bloom prefix, range columns are prefixed with &quot;range_&quot;, exploded field
 columns are mapped to their backing array column, and all other columns map to themselves.
 </p></div><dl class="paramcmts block"><dt class="param">joinColumns</dt><dd class="cmt"><p>
@@ -1655,7 +1655,7 @@ columns are mapped to their backing array column, and all other columns map to t
       <span class="symbol">
         <span class="name">maybeAutoCompact</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Triggers compaction if the auto-compact threshold has been reached.</p><div class="fullcomment"><div class="comment cmt"><p>Triggers compaction if the auto-compact threshold has been reached.</p><p>Checks the <a href="IndexBuildOperations.html#batchesSinceCompact:Int" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#batchesSinceCompact">batchesSinceCompact</a> counter against the configured <code>autoCompactThreshold</code>. If the threshold is met,
 compacts all Delta tables and resets the counter to zero. The counter is persisted to metadata so it survives
 across Spark jobs.
@@ -1674,7 +1674,7 @@ across Spark jobs.
       <span class="symbol">
         <span class="name">metadataExists</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks if metadata exists in the storage location.</p><div class="fullcomment"><div class="comment cmt"><p>Checks if metadata exists in the storage location.</p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   True if metadata exists, otherwise false.</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadataOperations#metadataFilePath" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -1691,7 +1691,7 @@ across Spark jobs.
       <span class="symbol">
         <span class="name">metadataFilePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop path for the metadata file.</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop path for the metadata file.</p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   the path to <code>metadata.json</code> under the index storage directory</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#migrateExplodedFieldColumns" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -1708,7 +1708,7 @@ across Spark jobs.
       <span class="symbol">
         <span class="name">migrateExplodedFieldColumns</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Migrates pre-0.1.1 indexes that stored exploded field columns under <code>array_column</code> names to the current <code>as_column</code>
 naming convention.</p><div class="fullcomment"><div class="comment cmt"><p>Migrates pre-0.1.1 indexes that stored exploded field columns under <code>array_column</code> names to the current <code>as_column</code>
 naming convention.</p><p>Detection: reads the main and staging Delta table schemas and checks whether any
@@ -1730,7 +1730,7 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -1746,12 +1746,12 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -1767,12 +1767,12 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#open" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="open(path:org.apache.hadoop.fs.Path):org.apache.hadoop.fs.FSDataInputStream"></a><a id="open(Path):FSDataInputStream"></a>
@@ -1788,12 +1788,12 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">open</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.FSDataInputStream">FSDataInputStream</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Opens an input stream to read from a path on the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Opens an input stream to read from a path on the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to open for reading</p></dd><dt>returns</dt><dd class="cmt"><p>
-  An FSDataInputStream for reading the file contents</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  An FSDataInputStream for reading the file contents</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the file does not exist or cannot be opened</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#rangeStorageColumns" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="rangeStorageColumns:Set[String]"></a>
@@ -1809,7 +1809,7 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">rangeStorageColumns</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the set of range index storage column names (each prefixed with <code>range_</code>).</p><div class="fullcomment"><div class="comment cmt"><p>Returns the set of range index storage column names (each prefixed with <code>range_</code>).
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   set of prefixed column names (e.g., <code>range_event_date</code>)</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
@@ -1827,10 +1827,10 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">refreshMetadata</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Forces a reload of metadata from the <code>metadata.json</code> file on disk.</p><div class="fullcomment"><div class="comment cmt"><p>Forces a reload of metadata from the <code>metadata.json</code> file on disk.</p><p>Replaces the in-memory cached metadata with a freshly deserialized copy. This is called automatically by
 <span class="extype" name="metadata">metadata</span> on first access; callers may invoke it explicitly to pick up external changes.
-</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="MetadataMissingOrCorruptException"><code>MetadataMissingOrCorruptException</code></span>
+</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="MetadataMissingOrCorruptException"><code>MetadataMissingOrCorruptException</code></span> 
   if the metadata file does not exist, cannot be read, or contains invalid JSON</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#repartitionDataFiles" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="repartitionDataFiles:Boolean"></a>
@@ -1846,7 +1846,7 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">repartitionDataFiles</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">When true, applies indexRepartitionCount repartitioning to the data files read during joinDf.</p><div class="fullcomment"><div class="comment cmt"><p>When true, applies indexRepartitionCount repartitioning to the data files read during joinDf. When false, data
 files keep their natural parquet partitioning. Disable when column selection significantly reduces data volume,
 making the repartition shuffle more expensive than useful. Reads from spark.ariadne.repartitionDataFiles
@@ -1866,7 +1866,7 @@ configuration (default: false).
       <span class="symbol">
         <span class="name">requireNonReservedStagingColumn</span><span class="params">(<span name="column">column: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#safeDestroyBroadcast" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="safeDestroyBroadcast(broadcast:org.apache.spark.broadcast.Broadcast[_]):Unit"></a><a id="safeDestroyBroadcast(Broadcast[_]):Unit"></a>
@@ -1882,7 +1882,7 @@ configuration (default: false).
       <span class="symbol">
         <span class="name">safeDestroyBroadcast</span><span class="params">(<span name="broadcast">broadcast: <span class="extype" name="org.apache.spark.broadcast.Broadcast">Broadcast</span>[_]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Safely destroys a broadcast variable, logging but swallowing any exception.</p><div class="fullcomment"><div class="comment cmt"><p>Safely destroys a broadcast variable, logging but swallowing any exception.</p><p>Intended for use inside <code>finally</code> blocks where a cleanup failure must not mask the original exception propagating
 out of the <code>try</code> block. Tolerates a null broadcast.
 </p></div><dl class="paramcmts block"><dt class="param">broadcast</dt><dd class="cmt"><p>
@@ -1901,7 +1901,7 @@ out of the <code>try</code> block. Tolerates a null broadcast.
       <span class="symbol">
         <span class="name">stagingConsolidationThreshold</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Number of batches to process before consolidating staged data into the main index.</p><div class="fullcomment"><div class="comment cmt"><p>Number of batches to process before consolidating staged data into the main index. This provides fault tolerance
 for large index builds - if a job fails, work is preserved up to the last consolidation point. Reads from
 spark.ariadne.stagingConsolidationThreshold configuration (default: 50).
@@ -1920,7 +1920,7 @@ spark.ariadne.stagingConsolidationThreshold configuration (default: 50).
       <span class="symbol">
         <span class="name">stagingFilePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop path for the staging Delta table (<code>{storagePath}/staging/</code>).</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop path for the staging Delta table (<code>{storagePath}/staging/</code>).</p><p>The staging table accumulates batch results during <a href="Index.html#update:Unit" class="extmbr" name="dev.cjfravel.ariadne.Index#update">update</a> and is merged into the main index by
 <a href="IndexBuildOperations.html#consolidateStaging():Unit" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#consolidateStaging">consolidateStaging</a>.
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
@@ -1938,7 +1938,7 @@ spark.ariadne.stagingConsolidationThreshold configuration (default: 50).
       <span class="symbol">
         <span class="name">storageColumns</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the set of all storage column names across regular, computed, exploded-field, and temporal index types.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the set of all storage column names across regular, computed, exploded-field, and temporal index types.</p><p>This is used internally to determine which columns to check for large-index separation and to build aggregation
 expressions.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
@@ -1957,10 +1957,10 @@ expressions.
       <span class="symbol">
         <span class="name">storagePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Base path on the Hadoop-compatible filesystem where all Ariadne index data is stored.</p><div class="fullcomment"><div class="comment cmt"><p>Base path on the Hadoop-compatible filesystem where all Ariadne index data is stored. Each index creates a
 subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</code> (required — no default).
-</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if the configuration key is not set</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexFileOperations#storedSchema" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="storedSchema:org.apache.spark.sql.types.StructType"></a><a id="storedSchema:StructType"></a>
@@ -1976,14 +1976,14 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name">storedSchema</span><span class="result">: <span class="extype" name="org.apache.spark.sql.types.StructType">StructType</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the stored schema of the index.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the stored schema of the index.</p><p>Parses the JSON schema string from metadata into a Spark StructType.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   The StructType schema parsed from metadata</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a></dd><div class="block">Example:
                <ol><li class="cmt"><p></p><pre><span class="kw">val</span> schema = index.storedSchema
 schema.printTreeString()</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="SchemaParseException"><code>SchemaParseException</code></span>
-  if the schema string cannot be parsed as a StructType</p></span><span class="cmt"><p><a href="exceptions/MissingSchemaException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.MissingSchemaException"><code>dev.cjfravel.ariadne.exceptions.MissingSchemaException</code></a>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="SchemaParseException"><code>SchemaParseException</code></span> 
+  if the schema string cannot be parsed as a StructType</p></span><span class="cmt"><p><a href="exceptions/MissingSchemaException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.MissingSchemaException"><code>dev.cjfravel.ariadne.exceptions.MissingSchemaException</code></a> 
   if the schema is null in metadata</p></span></dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -1999,7 +1999,7 @@ schema.printTreeString()</pre></li></ol>
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -2015,7 +2015,7 @@ schema.printTreeString()</pre></li></ol>
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#vacuumDeltaTables" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="vacuumDeltaTables(retentionHours:Int):Unit"></a><a id="vacuumDeltaTables(Int):Unit"></a>
@@ -2031,7 +2031,7 @@ schema.printTreeString()</pre></li></ol>
       <span class="symbol">
         <span class="name">vacuumDeltaTables</span><span class="params">(<span name="retentionHours">retentionHours: <span class="extype" name="scala.Int">Int</span> = <span class="symbol">168</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Vacuums all Delta tables (main index and large index tables) to remove old files.</p><div class="fullcomment"><div class="comment cmt"><p>Vacuums all Delta tables (main index and large index tables) to remove old files.</p><p>Uses Delta Lake's VACUUM command to delete data files no longer referenced by the transaction log. Temporarily
 disables the retention duration safety check when <code>retentionHours</code> is zero or negative.
 </p></div><dl class="paramcmts block"><dt class="param">retentionHours</dt><dd class="cmt"><p>
@@ -2053,13 +2053,13 @@ disables the retention duration safety check when <code>retentionHours</code> is
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -2075,15 +2075,15 @@ disables the retention duration safety check when <code>retentionHours</code> is
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -2099,13 +2099,13 @@ disables the retention duration safety check when <code>retentionHours</code> is
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadataOperations#writeMetadata" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="writeMetadata(metadata:dev.cjfravel.ariadne.IndexMetadata):Unit"></a><a id="writeMetadata(IndexMetadata):Unit"></a>
@@ -2121,19 +2121,19 @@ disables the retention duration safety check when <code>retentionHours</code> is
       <span class="symbol">
         <span class="name">writeMetadata</span><span class="params">(<span name="metadata">metadata: <a href="IndexMetadata.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadata">IndexMetadata</a></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Writes metadata to the <code>metadata.json</code> file and updates the in-memory cache.</p><div class="fullcomment"><div class="comment cmt"><p>Writes metadata to the <code>metadata.json</code> file and updates the in-memory cache.</p><p>Creates the parent directory if it does not exist. JSON is written and validated at a unique sibling path, then
 replaced through Hadoop's overwrite rename operation. The replacement is atomic on filesystems with atomic rename
 semantics (such as HDFS); object-store connectors may implement rename as copy/delete and cannot provide the same
 guarantee.
 </p></div><dl class="paramcmts block"><dt class="param">metadata</dt><dd class="cmt"><p>
-  the metadata instance to serialize and persist</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  the metadata instance to serialize and persist</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the write fails (the error is logged before propagating)</p></span></dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -2151,15 +2151,15 @@ guarantee.
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -2181,13 +2181,13 @@ guarantee.
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/IndexLock.html
+++ b/docs/api/dev/cjfravel/ariadne/IndexLock.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.IndexLock" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.IndexLock" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="catalog/index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -147,7 +147,7 @@
       <span class="symbol">
         <a title="" href="exceptions/index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented3">
                         <span class="separator"></span>
@@ -256,7 +256,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>File-based distributed lock for index operations.</p><p>Provides mutual exclusion for index operations (update, compact, vacuum) using lock files on HDFS or cloud-compatible
 filesystems. Lock files are JSON documents containing a <a href="LockInfo.html" class="extype" name="dev.cjfravel.ariadne.LockInfo">LockInfo</a> payload.</p><h4>Concurrency semantics</h4><p>Lock acquisition is atomic at the filesystem level: the lock file is created with <code>overwrite = false</code>, so only one
 writer can succeed. If another process already holds the lock, acquisition enters a retry loop with exponential
@@ -274,7 +274,7 @@ instance or coordinate externally.
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="scala.Serializable">Serializable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.Product">Product</span>, <span class="extype" name="scala.Equals">Equals</span>, <a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -289,7 +289,7 @@ instance or coordinate externally.
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -332,7 +332,7 @@ instance or coordinate externally.
       <span class="symbol">
         <span class="name">IndexLock</span><span class="params">(<span name="lockPath">lockPath: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>, <span name="indexName">indexName: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="params">(<span class="implicit">implicit </span><span name="spark">spark: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">lockPath</dt><dd class="cmt"><p>
   Path to the lock file on the filesystem</p></dd><dt class="param">indexName</dt><dd class="cmt"><p>
   Name of the index being locked (used in log messages)</p></dd><dt class="param">spark</dt><dd class="cmt"><p>
@@ -340,9 +340,9 @@ instance or coordinate externally.
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -361,7 +361,7 @@ instance or coordinate externally.
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -377,7 +377,7 @@ instance or coordinate externally.
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -393,7 +393,7 @@ instance or coordinate externally.
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexLock#acquire" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="acquire(correlationId:String):Unit"></a><a id="acquire(String):Unit"></a>
@@ -409,12 +409,12 @@ instance or coordinate externally.
       <span class="symbol">
         <span class="name">acquire</span><span class="params">(<span name="correlationId">correlationId: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Acquires the lock for the given correlation ID.</p><div class="fullcomment"><div class="comment cmt"><p>Acquires the lock for the given correlation ID.</p><p>If the lock file already exists, this method will either heal a stale or corrupt lock, or enter a retry loop until
 the lock becomes available or <code>lockMaxWait</code> is exceeded.
 </p></div><dl class="paramcmts block"><dt class="param">correlationId</dt><dd class="cmt"><p>
-  unique identifier to associate with this lock hold</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if correlationId is null or blank</p></span><span class="cmt"><p><span class="extype" name="IndexLockException"><code>IndexLockException</code></span>
+  unique identifier to associate with this lock hold</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if correlationId is null or blank</p></span><span class="cmt"><p><span class="extype" name="IndexLockException"><code>IndexLockException</code></span> 
   if the lock cannot be acquired within the configured timeout or after max retry attempts</p></span></dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -430,7 +430,7 @@ the lock becomes available or <code>lockMaxWait</code> is exceeded.
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#autoBloomFpr" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="autoBloomFpr:Double"></a>
@@ -446,7 +446,7 @@ the lock becomes available or <code>lockMaxWait</code> is exceeded.
       <span class="symbol">
         <span class="name">autoBloomFpr</span><span class="result">: <span class="extype" name="scala.Double">Double</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">False positive rate for auto-bloom filters on large index columns.</p><div class="fullcomment"><div class="comment cmt"><p>False positive rate for auto-bloom filters on large index columns. When a column exceeds largeIndexLimit, an
 auto-bloom filter is built with this FPR to enable file pruning at query time. Reads from
 spark.ariadne.autoBloomFpr configuration (default: 0.01).
@@ -465,7 +465,7 @@ spark.ariadne.autoBloomFpr configuration (default: 0.01).
       <span class="symbol">
         <span class="name">autoCompactThreshold</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Int">Int</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Optional threshold for auto-compaction.</p><div class="fullcomment"><div class="comment cmt"><p>Optional threshold for auto-compaction. When set, the main index Delta table is compacted after an update if the
 number of Delta log JSON files meets or exceeds this value. Reads from spark.ariadne.autoCompactThreshold
 configuration (default: not set).
@@ -484,17 +484,17 @@ configuration (default: not set).
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#debugEnabled" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="debugEnabled:Boolean"></a>
@@ -510,7 +510,7 @@ configuration (default: not set).
       <span class="symbol">
         <span class="name">debugEnabled</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">When true, logs detailed diagnostics during join operations including partition counts, physical plans, and
 per-phase timing.</p><div class="fullcomment"><div class="comment cmt"><p>When true, logs detailed diagnostics during join operations including partition counts, physical plans, and
 per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
@@ -529,12 +529,12 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">delete</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Deletes a path recursively from the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Deletes a path recursively from the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to delete</p></dd><dt>returns</dt><dd class="cmt"><p>
-  true if the path was successfully deleted</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  true if the path was successfully deleted</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the filesystem operation fails</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#delta" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="delta(path:org.apache.hadoop.fs.Path):Option[io.delta.tables.DeltaTable]"></a><a id="delta(Path):Option[DeltaTable]"></a>
@@ -550,7 +550,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">delta</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="io.delta.tables.DeltaTable">DeltaTable</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns a <span class="extype" name="io.delta.tables.DeltaTable">io.delta.tables.DeltaTable</span> if the path exists and contains valid Delta metadata.</p><div class="fullcomment"><div class="comment cmt"><p>Returns a <span class="extype" name="io.delta.tables.DeltaTable">io.delta.tables.DeltaTable</span> if the path exists and contains valid Delta metadata.</p><p>If the path exists but is <i>not</i> a valid Delta table (e.g., leftover partial write), the directory is deleted and
 <code>None</code> is returned so it can be recreated cleanly on the next write.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
@@ -570,7 +570,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#exists" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exists(path:org.apache.hadoop.fs.Path):Boolean"></a><a id="exists(Path):Boolean"></a>
@@ -586,12 +586,12 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">exists</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks if a path exists on the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Checks if a path exists on the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to check</p></dd><dt>returns</dt><dd class="cmt"><p>
-  true if the path exists</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  true if the path exists</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the filesystem operation fails</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#fs" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="fs:org.apache.hadoop.fs.FileSystem"></a><a id="fs:FileSystem"></a>
@@ -607,7 +607,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">fs</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.FileSystem">FileSystem</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop <code>FileSystem</code> instance resolved from the <a href="AriadneContextUser.html#storagePath:org.apache.hadoop.fs.Path" class="extmbr" name="dev.cjfravel.ariadne.AriadneContextUser#storagePath">storagePath</a> URI and the Spark Hadoop configuration.</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop <code>FileSystem</code> instance resolved from the <a href="AriadneContextUser.html#storagePath:org.apache.hadoop.fs.Path" class="extmbr" name="dev.cjfravel.ariadne.AriadneContextUser#storagePath">storagePath</a> URI and the Spark Hadoop configuration. Used for all
 filesystem operations (existence checks, reads, deletes, lock files).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -625,12 +625,12 @@ filesystem operations (existence checks, reads, deletes, lock files).
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexLock#indexName" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="indexName:String"></a>
@@ -646,8 +646,8 @@ filesystem operations (existence checks, reads, deletes, lock files).
       <span class="symbol">
         <span class="name">indexName</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#indexRepartitionCount" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="indexRepartitionCount:Option[Int]"></a>
       <span class="permalink">
@@ -662,7 +662,7 @@ filesystem operations (existence checks, reads, deletes, lock files).
       <span class="symbol">
         <span class="name">indexRepartitionCount</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Int">Int</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Optional number of partitions to use when repartitioning the index DataFrame during joins.</p><div class="fullcomment"><div class="comment cmt"><p>Optional number of partitions to use when repartitioning the index DataFrame during joins. When set, the index
 DataFrame is repartitioned before expensive operations like explode to reduce per-executor memory pressure and
 avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepartitionCount configuration
@@ -682,7 +682,7 @@ avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepa
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#largeIndexLimit" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="largeIndexLimit:Long"></a>
@@ -698,7 +698,7 @@ avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepa
       <span class="symbol">
         <span class="name">largeIndexLimit</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Maximum number of distinct values per file before an index column is promoted to a &quot;large index&quot; (stored in a
 separate exploded Delta table).</p><div class="fullcomment"><div class="comment cmt"><p>Maximum number of distinct values per file before an index column is promoted to a &quot;large index&quot; (stored in a
 separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</code> (default: 500000).</p><p>If the configured value is not a valid positive number, a warning is logged and the default of 500,000 is used.
@@ -717,7 +717,7 @@ separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</
       <span class="symbol">
         <span class="name">lockMaxWait</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Maximum total time in seconds to wait for lock acquisition before failing.</p><div class="fullcomment"><div class="comment cmt"><p>Maximum total time in seconds to wait for lock acquisition before failing. Reads from spark.ariadne.lockMaxWait
 configuration (default: 3600).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Note</dt><dd><span class="cmt"><p>
@@ -737,8 +737,8 @@ configuration (default: 3600).
       <span class="symbol">
         <span class="name">lockPath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
-
+      
+      
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#lockRefreshInterval" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="lockRefreshInterval:Int"></a>
       <span class="permalink">
@@ -753,7 +753,7 @@ configuration (default: 3600).
       <span class="symbol">
         <span class="name">lockRefreshInterval</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Refresh the update lock every N batches during updateBatched.</p><div class="fullcomment"><div class="comment cmt"><p>Refresh the update lock every N batches during updateBatched. Reads from spark.ariadne.lockRefreshInterval
 configuration (default: 1).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -771,7 +771,7 @@ configuration (default: 1).
       <span class="symbol">
         <span class="name">lockRetryInterval</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Base interval in seconds between lock acquisition retries (exponential backoff applied).</p><div class="fullcomment"><div class="comment cmt"><p>Base interval in seconds between lock acquisition retries (exponential backoff applied). Reads from
 spark.ariadne.lockRetryInterval configuration (default: 60).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -789,7 +789,7 @@ spark.ariadne.lockRetryInterval configuration (default: 60).
       <span class="symbol">
         <span class="name">lockTimeout</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Seconds since <code>lastRefreshedAt</code> before a lock is considered stale and eligible for auto-heal (forcible acquisition
 by another process).</p><div class="fullcomment"><div class="comment cmt"><p>Seconds since <code>lastRefreshedAt</code> before a lock is considered stale and eligible for auto-heal (forcible acquisition
 by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default: 1800).
@@ -808,12 +808,12 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">logger</span><span class="result">: <span class="extype" name="org.apache.logging.log4j.Logger">Logger</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Log4j logger shared by all Ariadne components.</p><div class="fullcomment"><div class="comment cmt"><p>Log4j logger shared by all Ariadne components. Uses the &quot;ariadne&quot; logger name. Marked <code>@transient lazy</code> so that
 <code>Index</code> (a case class) remains serializable across Spark stages — Log4j loggers are not <code>Serializable</code>.
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Annotations</dt><dd>
                 <span class="name">@transient</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -829,7 +829,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -845,12 +845,12 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -866,12 +866,12 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#open" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="open(path:org.apache.hadoop.fs.Path):org.apache.hadoop.fs.FSDataInputStream"></a><a id="open(Path):FSDataInputStream"></a>
@@ -887,12 +887,12 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">open</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.FSDataInputStream">FSDataInputStream</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Opens an input stream to read from a path on the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Opens an input stream to read from a path on the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to open for reading</p></dd><dt>returns</dt><dd class="cmt"><p>
-  An FSDataInputStream for reading the file contents</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  An FSDataInputStream for reading the file contents</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the file does not exist or cannot be opened</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexLock#refresh" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="refresh(correlationId:String):Unit"></a><a id="refresh(String):Unit"></a>
@@ -908,11 +908,11 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">refresh</span><span class="params">(<span name="correlationId">correlationId: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Refreshes the lock's <code>lastRefreshedAt</code> timestamp to prevent stale-lock healing.</p><div class="fullcomment"><div class="comment cmt"><p>Refreshes the lock's <code>lastRefreshedAt</code> timestamp to prevent stale-lock healing.</p><p>Long-running operations should call this periodically (more frequently than <code>lockTimeout</code>) to signal that the lock
 holder is still active.
 </p></div><dl class="paramcmts block"><dt class="param">correlationId</dt><dd class="cmt"><p>
-  the correlation ID that should currently hold the lock</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+  the correlation ID that should currently hold the lock</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if correlationId is null or blank</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexLock#release" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="release(correlationId:String):Unit"></a><a id="release(String):Unit"></a>
@@ -928,11 +928,11 @@ holder is still active.
       <span class="symbol">
         <span class="name">release</span><span class="params">(<span name="correlationId">correlationId: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Releases the lock if it is held by the given correlation ID.</p><div class="fullcomment"><div class="comment cmt"><p>Releases the lock if it is held by the given correlation ID.</p><p>If the lock file does not exist or belongs to a different correlation ID, a warning is logged and no action is
 taken.
 </p></div><dl class="paramcmts block"><dt class="param">correlationId</dt><dd class="cmt"><p>
-  the correlation ID that should currently hold the lock</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+  the correlation ID that should currently hold the lock</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if correlationId is null or blank</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#repartitionDataFiles" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="repartitionDataFiles:Boolean"></a>
@@ -948,7 +948,7 @@ taken.
       <span class="symbol">
         <span class="name">repartitionDataFiles</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">When true, applies indexRepartitionCount repartitioning to the data files read during joinDf.</p><div class="fullcomment"><div class="comment cmt"><p>When true, applies indexRepartitionCount repartitioning to the data files read during joinDf. When false, data
 files keep their natural parquet partitioning. Disable when column selection significantly reduces data volume,
 making the repartition shuffle more expensive than useful. Reads from spark.ariadne.repartitionDataFiles
@@ -968,7 +968,7 @@ configuration (default: false).
       <span class="symbol">
         <span class="name">safeDestroyBroadcast</span><span class="params">(<span name="broadcast">broadcast: <span class="extype" name="org.apache.spark.broadcast.Broadcast">Broadcast</span>[_]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Safely destroys a broadcast variable, logging but swallowing any exception.</p><div class="fullcomment"><div class="comment cmt"><p>Safely destroys a broadcast variable, logging but swallowing any exception.</p><p>Intended for use inside <code>finally</code> blocks where a cleanup failure must not mask the original exception propagating
 out of the <code>try</code> block. Tolerates a null broadcast.
 </p></div><dl class="paramcmts block"><dt class="param">broadcast</dt><dd class="cmt"><p>
@@ -987,7 +987,7 @@ out of the <code>try</code> block. Tolerates a null broadcast.
       <span class="symbol">
         <span class="name">spark</span><span class="result">: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Implicit SparkSession that must be provided by the mixing class.</p><div class="fullcomment"><div class="comment cmt"><p>Implicit SparkSession that must be provided by the mixing class.</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.IndexLock">IndexLock</a> → <a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#stagingConsolidationThreshold" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="stagingConsolidationThreshold:Int"></a>
@@ -1003,7 +1003,7 @@ out of the <code>try</code> block. Tolerates a null broadcast.
       <span class="symbol">
         <span class="name">stagingConsolidationThreshold</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Number of batches to process before consolidating staged data into the main index.</p><div class="fullcomment"><div class="comment cmt"><p>Number of batches to process before consolidating staged data into the main index. This provides fault tolerance
 for large index builds - if a job fails, work is preserved up to the last consolidation point. Reads from
 spark.ariadne.stagingConsolidationThreshold configuration (default: 50).
@@ -1022,10 +1022,10 @@ spark.ariadne.stagingConsolidationThreshold configuration (default: 50).
       <span class="symbol">
         <span class="name">storagePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Base path on the Hadoop-compatible filesystem where all Ariadne index data is stored.</p><div class="fullcomment"><div class="comment cmt"><p>Base path on the Hadoop-compatible filesystem where all Ariadne index data is stored. Each index creates a
 subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</code> (required — no default).
-</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if the configuration key is not set</p></span></dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -1041,7 +1041,7 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -1057,13 +1057,13 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -1079,15 +1079,15 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -1103,19 +1103,19 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -1133,15 +1133,15 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -1163,13 +1163,13 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/IndexMetadata$.html
+++ b/docs/api/dev/cjfravel/ariadne/IndexMetadata$.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.IndexMetadata" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.IndexMetadata" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="catalog/index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -147,7 +147,7 @@
       <span class="symbol">
         <a title="" href="exceptions/index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented3">
                         <span class="separator"></span>
@@ -258,7 +258,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Factory object for creating IndexMetadata instances from JSON.</p><p>Provides deserialization capabilities with automatic version migration to ensure backward compatibility across
 different metadata formats.
 </p></div><div class="toggleContainer block">
@@ -267,7 +267,7 @@ different metadata formats.
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="scala.Serializable">Serializable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -282,7 +282,7 @@ different metadata formats.
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -309,11 +309,11 @@ different metadata formats.
 
       <div id="template">
         <div id="allMembers">
+        
 
+        
 
-
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -332,7 +332,7 @@ different metadata formats.
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -348,7 +348,7 @@ different metadata formats.
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -364,7 +364,7 @@ different metadata formats.
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadata#apply" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="apply(jsonString:String):dev.cjfravel.ariadne.IndexMetadata"></a><a id="apply(String):IndexMetadata"></a>
@@ -380,7 +380,7 @@ different metadata formats.
       <span class="symbol">
         <span class="name">apply</span><span class="params">(<span name="jsonString">jsonString: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <a href="IndexMetadata.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadata">IndexMetadata</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Creates an IndexMetadata instance from a JSON string.</p><div class="fullcomment"><div class="comment cmt"><p>Creates an IndexMetadata instance from a JSON string.</p><p>This method deserializes JSON metadata and automatically handles version migration to ensure compatibility with
 older index formats:</p><ul><li>v1 → v2: Adds computed_indexes field if missing</li><li>v2 → v3: Adds exploded_field_indexes field if missing</li><li>v3 → v4: Adds read_options field if missing</li><li>v4 → v5: Adds bloom_indexes field if missing</li><li>v5 → v6: Adds temporal_indexes field if missing</li><li>v6 → v7: Adds range_indexes field if missing</li><li>v7 → v8: Adds auto_bloom_indexes field if missing</li><li>v8 → v9: Adds total_indexed_file_size field if missing</li><li>v9 → v10: Adds batches_since_compact field if missing
 </li></ul></div><dl class="paramcmts block"><dt class="param">jsonString</dt><dd class="cmt"><p>
@@ -389,7 +389,7 @@ older index formats:</p><ul><li>v1 → v2: Adds computed_indexes field if missin
                <ol><li class="cmt"><p></p><pre><span class="kw">val</span> jsonString = <span class="lit">""</span><span class="lit">"{"</span>format<span class="lit">":"</span>parquet<span class="lit">","</span>schema<span class="lit">":"</span>...<span class="lit">","</span>indexes<span class="lit">":["</span>id<span class="lit">"]}"</span><span class="lit">""</span>
 <span class="kw">val</span> metadata = IndexMetadata(jsonString)
 <span class="cmt">// Returns metadata with all fields properly initialized</span></pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="MetadataMissingOrCorruptException"><code>MetadataMissingOrCorruptException</code></span>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="MetadataMissingOrCorruptException"><code>MetadataMissingOrCorruptException</code></span> 
   if <code>jsonString</code> is null, empty, or cannot be deserialized</p></span></dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -405,7 +405,7 @@ older index formats:</p><ul><li>v1 → v2: Adds computed_indexes field if missin
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -421,17 +421,17 @@ older index formats:</p><ul><li>v1 → v2: Adds computed_indexes field if missin
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -447,7 +447,7 @@ older index formats:</p><ul><li>v1 → v2: Adds computed_indexes field if missin
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -463,7 +463,7 @@ older index formats:</p><ul><li>v1 → v2: Adds computed_indexes field if missin
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -479,12 +479,12 @@ older index formats:</p><ul><li>v1 → v2: Adds computed_indexes field if missin
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -500,12 +500,12 @@ older index formats:</p><ul><li>v1 → v2: Adds computed_indexes field if missin
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -521,7 +521,7 @@ older index formats:</p><ul><li>v1 → v2: Adds computed_indexes field if missin
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -537,7 +537,7 @@ older index formats:</p><ul><li>v1 → v2: Adds computed_indexes field if missin
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -553,12 +553,12 @@ older index formats:</p><ul><li>v1 → v2: Adds computed_indexes field if missin
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -574,12 +574,12 @@ older index formats:</p><ul><li>v1 → v2: Adds computed_indexes field if missin
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -595,7 +595,7 @@ older index formats:</p><ul><li>v1 → v2: Adds computed_indexes field if missin
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -611,7 +611,7 @@ older index formats:</p><ul><li>v1 → v2: Adds computed_indexes field if missin
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -627,13 +627,13 @@ older index formats:</p><ul><li>v1 → v2: Adds computed_indexes field if missin
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -649,15 +649,15 @@ older index formats:</p><ul><li>v1 → v2: Adds computed_indexes field if missin
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -673,19 +673,19 @@ older index formats:</p><ul><li>v1 → v2: Adds computed_indexes field if missin
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -703,15 +703,15 @@ older index formats:</p><ul><li>v1 → v2: Adds computed_indexes field if missin
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -727,13 +727,13 @@ older index formats:</p><ul><li>v1 → v2: Adds computed_indexes field if missin
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/IndexMetadata.html
+++ b/docs/api/dev/cjfravel/ariadne/IndexMetadata.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.IndexMetadata" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.IndexMetadata" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="catalog/index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -147,7 +147,7 @@
       <span class="symbol">
         <a title="" href="exceptions/index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented3">
                         <span class="separator"></span>
@@ -258,7 +258,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Metadata container for Ariadne index configuration and state.</p><p>This case class stores all metadata required to manage an Ariadne index, including schema information, indexed
 columns, and format details. It supports multiple versions for backward compatibility.
 </p></div><dl class="paramcmts block"><dt class="param">format</dt><dd class="cmt"><p>
@@ -284,7 +284,7 @@ columns, and format details. It supports multiple versions for backward compatib
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="scala.Serializable">Serializable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.Product">Product</span>, <span class="extype" name="scala.Equals">Equals</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -299,7 +299,7 @@ columns, and format details. It supports multiple versions for backward compatib
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -342,7 +342,7 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">IndexMetadata</span><span class="params">(<span name="format">format: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="schema">schema: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="indexes">indexes: <span class="extype" name="java.util.List">List</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="computed_indexes">computed_indexes: <span class="extype" name="java.util.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="exploded_field_indexes">exploded_field_indexes: <span class="extype" name="java.util.List">List</span>[<a href="ExplodedFieldMapping.html" class="extype" name="dev.cjfravel.ariadne.ExplodedFieldMapping">ExplodedFieldMapping</a>]</span>, <span name="bloom_indexes">bloom_indexes: <span class="extype" name="java.util.List">List</span>[<a href="BloomIndexConfig.html" class="extype" name="dev.cjfravel.ariadne.BloomIndexConfig">BloomIndexConfig</a>]</span>, <span name="temporal_indexes">temporal_indexes: <span class="extype" name="java.util.List">List</span>[<a href="TemporalIndexConfig.html" class="extype" name="dev.cjfravel.ariadne.TemporalIndexConfig">TemporalIndexConfig</a>]</span>, <span name="read_options">read_options: <span class="extype" name="java.util.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="range_indexes">range_indexes: <span class="extype" name="java.util.List">List</span>[<a href="RangeIndexConfig.html" class="extype" name="dev.cjfravel.ariadne.RangeIndexConfig">RangeIndexConfig</a>]</span>, <span name="auto_bloom_indexes">auto_bloom_indexes: <span class="extype" name="java.util.List">List</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="total_indexed_file_size">total_indexed_file_size: <span class="extype" name="java.lang.Long">Long</span></span>, <span name="batches_since_compact">batches_since_compact: <span class="extype" name="java.lang.Integer">Integer</span></span>, <span name="metadata_version">metadata_version: <span class="extype" name="java.lang.Integer">Integer</span></span>, <span name="storage_format_version">storage_format_version: <span class="extype" name="java.lang.Integer">Integer</span></span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">format</dt><dd class="cmt"><p>
   The file format of the indexed data (e.g., &quot;parquet&quot;, &quot;csv&quot;, &quot;json&quot;)</p></dd><dt class="param">schema</dt><dd class="cmt"><p>
   The JSON representation of the DataFrame schema</p></dd><dt class="param">indexes</dt><dd class="cmt"><p>
@@ -360,9 +360,9 @@ columns, and format details. It supports multiple versions for backward compatib
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -381,7 +381,7 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -397,7 +397,7 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -413,7 +413,7 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -429,7 +429,7 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadata#auto_bloom_indexes" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="auto_bloom_indexes:java.util.List[String]"></a><a id="auto_bloom_indexes:List[String]"></a>
@@ -445,8 +445,8 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">auto_bloom_indexes</span><span class="result">: <span class="extype" name="java.util.List">List</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
-
+      
+      
     </li><li name="dev.cjfravel.ariadne.IndexMetadata#batches_since_compact" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="batches_since_compact:Integer"></a>
       <span class="permalink">
@@ -461,8 +461,8 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">batches_since_compact</span><span class="result">: <span class="extype" name="java.lang.Integer">Integer</span></span>
       </span>
-
-
+      
+      
     </li><li name="dev.cjfravel.ariadne.IndexMetadata#bloom_indexes" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="bloom_indexes:java.util.List[dev.cjfravel.ariadne.BloomIndexConfig]"></a><a id="bloom_indexes:List[BloomIndexConfig]"></a>
       <span class="permalink">
@@ -477,8 +477,8 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">bloom_indexes</span><span class="result">: <span class="extype" name="java.util.List">List</span>[<a href="BloomIndexConfig.html" class="extype" name="dev.cjfravel.ariadne.BloomIndexConfig">BloomIndexConfig</a>]</span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
       <span class="permalink">
@@ -493,17 +493,17 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadata#computed_indexes" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="computed_indexes:java.util.Map[String,String]"></a><a id="computed_indexes:Map[String,String]"></a>
@@ -519,8 +519,8 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">computed_indexes</span><span class="result">: <span class="extype" name="java.util.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
       <span class="permalink">
@@ -535,7 +535,7 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadata#exploded_field_indexes" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="exploded_field_indexes:java.util.List[dev.cjfravel.ariadne.ExplodedFieldMapping]"></a><a id="exploded_field_indexes:List[ExplodedFieldMapping]"></a>
@@ -551,8 +551,8 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">exploded_field_indexes</span><span class="result">: <span class="extype" name="java.util.List">List</span>[<a href="ExplodedFieldMapping.html" class="extype" name="dev.cjfravel.ariadne.ExplodedFieldMapping">ExplodedFieldMapping</a>]</span>
       </span>
-
-
+      
+      
     </li><li name="dev.cjfravel.ariadne.IndexMetadata#format" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="format:String"></a>
       <span class="permalink">
@@ -567,8 +567,8 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">format</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
       <span class="permalink">
@@ -583,12 +583,12 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadata#indexes" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="indexes:java.util.List[String]"></a><a id="indexes:List[String]"></a>
@@ -604,8 +604,8 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">indexes</span><span class="result">: <span class="extype" name="java.util.List">List</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
-
+      
+      
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
       <span class="permalink">
@@ -620,7 +620,7 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadata#metadata_version" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="metadata_version:Integer"></a>
@@ -636,8 +636,8 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">metadata_version</span><span class="result">: <span class="extype" name="java.lang.Integer">Integer</span></span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
       <span class="permalink">
@@ -652,7 +652,7 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -668,12 +668,12 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -689,12 +689,12 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadata#range_indexes" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="range_indexes:java.util.List[dev.cjfravel.ariadne.RangeIndexConfig]"></a><a id="range_indexes:List[RangeIndexConfig]"></a>
@@ -710,8 +710,8 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">range_indexes</span><span class="result">: <span class="extype" name="java.util.List">List</span>[<a href="RangeIndexConfig.html" class="extype" name="dev.cjfravel.ariadne.RangeIndexConfig">RangeIndexConfig</a>]</span>
       </span>
-
-
+      
+      
     </li><li name="dev.cjfravel.ariadne.IndexMetadata#read_options" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="read_options:java.util.Map[String,String]"></a><a id="read_options:Map[String,String]"></a>
       <span class="permalink">
@@ -726,8 +726,8 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">read_options</span><span class="result">: <span class="extype" name="java.util.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
-
+      
+      
     </li><li name="dev.cjfravel.ariadne.IndexMetadata#schema" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="schema:String"></a>
       <span class="permalink">
@@ -742,8 +742,8 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">schema</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="dev.cjfravel.ariadne.IndexMetadata#storage_format_version" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="storage_format_version:Integer"></a>
       <span class="permalink">
@@ -758,8 +758,8 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">storage_format_version</span><span class="result">: <span class="extype" name="java.lang.Integer">Integer</span></span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
       <span class="permalink">
@@ -774,7 +774,7 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadata#temporal_indexes" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="temporal_indexes:java.util.List[dev.cjfravel.ariadne.TemporalIndexConfig]"></a><a id="temporal_indexes:List[TemporalIndexConfig]"></a>
@@ -790,8 +790,8 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">temporal_indexes</span><span class="result">: <span class="extype" name="java.util.List">List</span>[<a href="TemporalIndexConfig.html" class="extype" name="dev.cjfravel.ariadne.TemporalIndexConfig">TemporalIndexConfig</a>]</span>
       </span>
-
-
+      
+      
     </li><li name="dev.cjfravel.ariadne.IndexMetadata#total_indexed_file_size" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="total_indexed_file_size:Long"></a>
       <span class="permalink">
@@ -806,8 +806,8 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">total_indexed_file_size</span><span class="result">: <span class="extype" name="java.lang.Long">Long</span></span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
       <span class="permalink">
@@ -822,13 +822,13 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -844,15 +844,15 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -868,19 +868,19 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -898,15 +898,15 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -926,13 +926,13 @@ columns, and format details. It supports multiple versions for backward compatib
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/IndexMetadataOperations.html
+++ b/docs/api/dev/cjfravel/ariadne/IndexMetadataOperations.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.IndexMetadataOperations" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.IndexMetadataOperations" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="catalog/index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -147,7 +147,7 @@
       <span class="symbol">
         <a title="" href="exceptions/index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented3">
                         <span class="separator"></span>
@@ -256,7 +256,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Trait providing metadata read/write operations for <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a> instances.</p><p>Manages the lifecycle of <a href="IndexMetadata.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadata">IndexMetadata</a> — reading from and writing to the <code>metadata.json</code> file on the
 Hadoop-compatible filesystem. Metadata is cached in memory after the first load; call <a href="#refreshMetadata():Unit" class="extmbr" name="dev.cjfravel.ariadne.IndexMetadataOperations#refreshMetadata">refreshMetadata</a> to force a
 reload.</p><p><b>Storage:</b> Metadata is persisted as a single JSON file at <code>{storagePath}/metadata.json</code>, serialized and
@@ -277,7 +277,7 @@ External synchronization is required for concurrent access.
             </span>
             <div class="subClasses hiddenContent"><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a>, <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a>, <a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a>, <a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a>, <a href="IndexJoinOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexJoinOperations">IndexJoinOperations</a>, <a href="IndexQueryOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexQueryOperations">IndexQueryOperations</a></div>
           </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -292,7 +292,7 @@ External synchronization is required for concurrent access.
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -319,9 +319,9 @@ External synchronization is required for concurrent access.
 
       <div id="template">
         <div id="allMembers">
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Abstract Value Members</h3>
@@ -339,7 +339,7 @@ External synchronization is required for concurrent access.
       <span class="symbol">
         <span class="name">spark</span><span class="result">: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Implicit SparkSession that must be provided by the mixing class.</p><div class="fullcomment"><div class="comment cmt"><p>Implicit SparkSession that must be provided by the mixing class.</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
     </li></ol>
             </div>
@@ -361,7 +361,7 @@ External synchronization is required for concurrent access.
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -377,7 +377,7 @@ External synchronization is required for concurrent access.
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -393,7 +393,7 @@ External synchronization is required for concurrent access.
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -409,7 +409,7 @@ External synchronization is required for concurrent access.
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#autoBloomFpr" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="autoBloomFpr:Double"></a>
@@ -425,7 +425,7 @@ External synchronization is required for concurrent access.
       <span class="symbol">
         <span class="name">autoBloomFpr</span><span class="result">: <span class="extype" name="scala.Double">Double</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">False positive rate for auto-bloom filters on large index columns.</p><div class="fullcomment"><div class="comment cmt"><p>False positive rate for auto-bloom filters on large index columns. When a column exceeds largeIndexLimit, an
 auto-bloom filter is built with this FPR to enable file pruning at query time. Reads from
 spark.ariadne.autoBloomFpr configuration (default: 0.01).
@@ -444,7 +444,7 @@ spark.ariadne.autoBloomFpr configuration (default: 0.01).
       <span class="symbol">
         <span class="name">autoCompactThreshold</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Int">Int</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Optional threshold for auto-compaction.</p><div class="fullcomment"><div class="comment cmt"><p>Optional threshold for auto-compaction. When set, the main index Delta table is compacted after an update if the
 number of Delta log JSON files meets or exceeds this value. Reads from spark.ariadne.autoCompactThreshold
 configuration (default: not set).
@@ -463,17 +463,17 @@ configuration (default: not set).
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#debugEnabled" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="debugEnabled:Boolean"></a>
@@ -489,7 +489,7 @@ configuration (default: not set).
       <span class="symbol">
         <span class="name">debugEnabled</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">When true, logs detailed diagnostics during join operations including partition counts, physical plans, and
 per-phase timing.</p><div class="fullcomment"><div class="comment cmt"><p>When true, logs detailed diagnostics during join operations including partition counts, physical plans, and
 per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
@@ -508,12 +508,12 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">delete</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Deletes a path recursively from the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Deletes a path recursively from the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to delete</p></dd><dt>returns</dt><dd class="cmt"><p>
-  true if the path was successfully deleted</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  true if the path was successfully deleted</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the filesystem operation fails</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#delta" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="delta(path:org.apache.hadoop.fs.Path):Option[io.delta.tables.DeltaTable]"></a><a id="delta(Path):Option[DeltaTable]"></a>
@@ -529,7 +529,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">delta</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="io.delta.tables.DeltaTable">DeltaTable</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns a <span class="extype" name="io.delta.tables.DeltaTable">io.delta.tables.DeltaTable</span> if the path exists and contains valid Delta metadata.</p><div class="fullcomment"><div class="comment cmt"><p>Returns a <span class="extype" name="io.delta.tables.DeltaTable">io.delta.tables.DeltaTable</span> if the path exists and contains valid Delta metadata.</p><p>If the path exists but is <i>not</i> a valid Delta table (e.g., leftover partial write), the directory is deleted and
 <code>None</code> is returned so it can be recreated cleanly on the next write.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
@@ -549,7 +549,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -565,7 +565,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#exists" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exists(path:org.apache.hadoop.fs.Path):Boolean"></a><a id="exists(Path):Boolean"></a>
@@ -581,12 +581,12 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">exists</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks if a path exists on the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Checks if a path exists on the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to check</p></dd><dt>returns</dt><dd class="cmt"><p>
-  true if the path exists</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  true if the path exists</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the filesystem operation fails</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadataOperations#format" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="format:String"></a>
@@ -602,7 +602,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">format</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the file format of the indexed data (e.g., &quot;parquet&quot;, &quot;csv&quot;, &quot;json&quot;).</p><div class="fullcomment"><div class="comment cmt"><p>Returns the file format of the indexed data (e.g., &quot;parquet&quot;, &quot;csv&quot;, &quot;json&quot;).</p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   the format string from the stored metadata</p></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#fs" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -619,7 +619,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">fs</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.FileSystem">FileSystem</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop <code>FileSystem</code> instance resolved from the <a href="AriadneContextUser.html#storagePath:org.apache.hadoop.fs.Path" class="extmbr" name="dev.cjfravel.ariadne.AriadneContextUser#storagePath">storagePath</a> URI and the Spark Hadoop configuration.</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop <code>FileSystem</code> instance resolved from the <a href="AriadneContextUser.html#storagePath:org.apache.hadoop.fs.Path" class="extmbr" name="dev.cjfravel.ariadne.AriadneContextUser#storagePath">storagePath</a> URI and the Spark Hadoop configuration. Used for all
 filesystem operations (existence checks, reads, deletes, lock files).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -637,12 +637,12 @@ filesystem operations (existence checks, reads, deletes, lock files).
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -658,12 +658,12 @@ filesystem operations (existence checks, reads, deletes, lock files).
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#indexRepartitionCount" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="indexRepartitionCount:Option[Int]"></a>
@@ -679,7 +679,7 @@ filesystem operations (existence checks, reads, deletes, lock files).
       <span class="symbol">
         <span class="name">indexRepartitionCount</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Int">Int</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Optional number of partitions to use when repartitioning the index DataFrame during joins.</p><div class="fullcomment"><div class="comment cmt"><p>Optional number of partitions to use when repartitioning the index DataFrame during joins. When set, the index
 DataFrame is repartitioned before expensive operations like explode to reduce per-executor memory pressure and
 avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepartitionCount configuration
@@ -699,7 +699,7 @@ avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepa
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#largeIndexLimit" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="largeIndexLimit:Long"></a>
@@ -715,7 +715,7 @@ avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepa
       <span class="symbol">
         <span class="name">largeIndexLimit</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Maximum number of distinct values per file before an index column is promoted to a &quot;large index&quot; (stored in a
 separate exploded Delta table).</p><div class="fullcomment"><div class="comment cmt"><p>Maximum number of distinct values per file before an index column is promoted to a &quot;large index&quot; (stored in a
 separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</code> (default: 500000).</p><p>If the configured value is not a valid positive number, a warning is logged and the default of 500,000 is used.
@@ -734,7 +734,7 @@ separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</
       <span class="symbol">
         <span class="name">lockMaxWait</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Maximum total time in seconds to wait for lock acquisition before failing.</p><div class="fullcomment"><div class="comment cmt"><p>Maximum total time in seconds to wait for lock acquisition before failing. Reads from spark.ariadne.lockMaxWait
 configuration (default: 3600).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Note</dt><dd><span class="cmt"><p>
@@ -754,7 +754,7 @@ configuration (default: 3600).
       <span class="symbol">
         <span class="name">lockRefreshInterval</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Refresh the update lock every N batches during updateBatched.</p><div class="fullcomment"><div class="comment cmt"><p>Refresh the update lock every N batches during updateBatched. Reads from spark.ariadne.lockRefreshInterval
 configuration (default: 1).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -772,7 +772,7 @@ configuration (default: 1).
       <span class="symbol">
         <span class="name">lockRetryInterval</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Base interval in seconds between lock acquisition retries (exponential backoff applied).</p><div class="fullcomment"><div class="comment cmt"><p>Base interval in seconds between lock acquisition retries (exponential backoff applied). Reads from
 spark.ariadne.lockRetryInterval configuration (default: 60).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -790,7 +790,7 @@ spark.ariadne.lockRetryInterval configuration (default: 60).
       <span class="symbol">
         <span class="name">lockTimeout</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Seconds since <code>lastRefreshedAt</code> before a lock is considered stale and eligible for auto-heal (forcible acquisition
 by another process).</p><div class="fullcomment"><div class="comment cmt"><p>Seconds since <code>lastRefreshedAt</code> before a lock is considered stale and eligible for auto-heal (forcible acquisition
 by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default: 1800).
@@ -809,7 +809,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">logger</span><span class="result">: <span class="extype" name="org.apache.logging.log4j.Logger">Logger</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Log4j logger shared by all Ariadne components.</p><div class="fullcomment"><div class="comment cmt"><p>Log4j logger shared by all Ariadne components. Uses the &quot;ariadne&quot; logger name. Marked <code>@transient lazy</code> so that
 <code>Index</code> (a case class) remains serializable across Spark stages — Log4j loggers are not <code>Serializable</code>.
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a> → <a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -827,7 +827,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">metadataExists</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks if metadata exists in the storage location.</p><div class="fullcomment"><div class="comment cmt"><p>Checks if metadata exists in the storage location.</p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   True if metadata exists, otherwise false.</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadataOperations#metadataFilePath" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -844,7 +844,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">metadataFilePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop path for the metadata file.</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop path for the metadata file.</p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   the path to <code>metadata.json</code> under the index storage directory</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -861,7 +861,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -877,12 +877,12 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -898,12 +898,12 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#open" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="open(path:org.apache.hadoop.fs.Path):org.apache.hadoop.fs.FSDataInputStream"></a><a id="open(Path):FSDataInputStream"></a>
@@ -919,12 +919,12 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">open</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.FSDataInputStream">FSDataInputStream</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Opens an input stream to read from a path on the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Opens an input stream to read from a path on the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to open for reading</p></dd><dt>returns</dt><dd class="cmt"><p>
-  An FSDataInputStream for reading the file contents</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  An FSDataInputStream for reading the file contents</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the file does not exist or cannot be opened</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadataOperations#refreshMetadata" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="refreshMetadata():Unit"></a>
@@ -940,10 +940,10 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">refreshMetadata</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Forces a reload of metadata from the <code>metadata.json</code> file on disk.</p><div class="fullcomment"><div class="comment cmt"><p>Forces a reload of metadata from the <code>metadata.json</code> file on disk.</p><p>Replaces the in-memory cached metadata with a freshly deserialized copy. This is called automatically by
 <span class="extype" name="metadata">metadata</span> on first access; callers may invoke it explicitly to pick up external changes.
-</p></div><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="MetadataMissingOrCorruptException"><code>MetadataMissingOrCorruptException</code></span>
+</p></div><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="MetadataMissingOrCorruptException"><code>MetadataMissingOrCorruptException</code></span> 
   if the metadata file does not exist, cannot be read, or contains invalid JSON</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#repartitionDataFiles" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="repartitionDataFiles:Boolean"></a>
@@ -959,7 +959,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">repartitionDataFiles</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">When true, applies indexRepartitionCount repartitioning to the data files read during joinDf.</p><div class="fullcomment"><div class="comment cmt"><p>When true, applies indexRepartitionCount repartitioning to the data files read during joinDf. When false, data
 files keep their natural parquet partitioning. Disable when column selection significantly reduces data volume,
 making the repartition shuffle more expensive than useful. Reads from spark.ariadne.repartitionDataFiles
@@ -979,7 +979,7 @@ configuration (default: false).
       <span class="symbol">
         <span class="name">safeDestroyBroadcast</span><span class="params">(<span name="broadcast">broadcast: <span class="extype" name="org.apache.spark.broadcast.Broadcast">Broadcast</span>[_]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Safely destroys a broadcast variable, logging but swallowing any exception.</p><div class="fullcomment"><div class="comment cmt"><p>Safely destroys a broadcast variable, logging but swallowing any exception.</p><p>Intended for use inside <code>finally</code> blocks where a cleanup failure must not mask the original exception propagating
 out of the <code>try</code> block. Tolerates a null broadcast.
 </p></div><dl class="paramcmts block"><dt class="param">broadcast</dt><dd class="cmt"><p>
@@ -998,7 +998,7 @@ out of the <code>try</code> block. Tolerates a null broadcast.
       <span class="symbol">
         <span class="name">stagingConsolidationThreshold</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Number of batches to process before consolidating staged data into the main index.</p><div class="fullcomment"><div class="comment cmt"><p>Number of batches to process before consolidating staged data into the main index. This provides fault tolerance
 for large index builds - if a job fails, work is preserved up to the last consolidation point. Reads from
 spark.ariadne.stagingConsolidationThreshold configuration (default: 50).
@@ -1017,10 +1017,10 @@ spark.ariadne.stagingConsolidationThreshold configuration (default: 50).
       <span class="symbol">
         <span class="name">storagePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Base path on the Hadoop-compatible filesystem where all Ariadne index data is stored.</p><div class="fullcomment"><div class="comment cmt"><p>Base path on the Hadoop-compatible filesystem where all Ariadne index data is stored. Each index creates a
 subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</code> (required — no default).
-</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if the configuration key is not set</p></span></dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -1036,7 +1036,7 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -1052,7 +1052,7 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -1068,13 +1068,13 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -1090,15 +1090,15 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -1114,13 +1114,13 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadataOperations#writeMetadata" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="writeMetadata(metadata:dev.cjfravel.ariadne.IndexMetadata):Unit"></a><a id="writeMetadata(IndexMetadata):Unit"></a>
@@ -1136,19 +1136,19 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name">writeMetadata</span><span class="params">(<span name="metadata">metadata: <a href="IndexMetadata.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadata">IndexMetadata</a></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Writes metadata to the <code>metadata.json</code> file and updates the in-memory cache.</p><div class="fullcomment"><div class="comment cmt"><p>Writes metadata to the <code>metadata.json</code> file and updates the in-memory cache.</p><p>Creates the parent directory if it does not exist. JSON is written and validated at a unique sibling path, then
 replaced through Hadoop's overwrite rename operation. The replacement is atomic on filesystems with atomic rename
 semantics (such as HDFS); object-store connectors may implement rename as copy/delete and cannot provide the same
 guarantee.
 </p></div><dl class="paramcmts block"><dt class="param">metadata</dt><dd class="cmt"><p>
-  the metadata instance to serialize and persist</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  the metadata instance to serialize and persist</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the write fails (the error is logged before propagating)</p></span></dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -1166,15 +1166,15 @@ guarantee.
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -1188,13 +1188,13 @@ guarantee.
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/IndexPathUtils$.html
+++ b/docs/api/dev/cjfravel/ariadne/IndexPathUtils$.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.IndexPathUtils" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.IndexPathUtils" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="catalog/index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -147,7 +147,7 @@
       <span class="symbol">
         <a title="" href="exceptions/index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented3">
                         <span class="separator"></span>
@@ -256,7 +256,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Utility object providing path resolution and lifecycle operations for indexes.</p><p>All paths are resolved relative to the configured <code>spark.ariadne.storagePath</code>. This object is stateless; filesystem
 access is performed through temporary <a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a> instances created from the implicit <code>SparkSession</code>.
 </p></div><div class="toggleContainer block">
@@ -265,7 +265,7 @@ access is performed through temporary <a href="AriadneContextUser.html" class="e
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -280,7 +280,7 @@ access is performed through temporary <a href="AriadneContextUser.html" class="e
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -307,11 +307,11 @@ access is performed through temporary <a href="AriadneContextUser.html" class="e
 
       <div id="template">
         <div id="allMembers">
+        
 
+        
 
-
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -330,7 +330,7 @@ access is performed through temporary <a href="AriadneContextUser.html" class="e
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -346,7 +346,7 @@ access is performed through temporary <a href="AriadneContextUser.html" class="e
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -362,7 +362,7 @@ access is performed through temporary <a href="AriadneContextUser.html" class="e
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -378,7 +378,7 @@ access is performed through temporary <a href="AriadneContextUser.html" class="e
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexPathUtils#cleanFileName" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cleanFileName(fileName:String):String"></a><a id="cleanFileName(String):String"></a>
@@ -394,13 +394,13 @@ access is performed through temporary <a href="AriadneContextUser.html" class="e
       <span class="symbol">
         <span class="name">cleanFileName</span><span class="params">(<span name="fileName">fileName: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Cleans a filename for safe storage by replacing non-alphanumeric characters with underscores, collapsing
 consecutive underscores, and trimming leading/trailing underscores.</p><div class="fullcomment"><div class="comment cmt"><p>Cleans a filename for safe storage by replacing non-alphanumeric characters with underscores, collapsing
 consecutive underscores, and trimming leading/trailing underscores.
 </p></div><dl class="paramcmts block"><dt class="param">fileName</dt><dd class="cmt"><p>
   the raw filename to clean; must not be null</p></dd><dt>returns</dt><dd class="cmt"><p>
-  the sanitized filename, or an empty string if input is empty</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+  the sanitized filename, or an empty string if input is empty</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if <code>fileName</code> is null</p></span></dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -416,17 +416,17 @@ consecutive underscores, and trimming leading/trailing underscores.
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -442,7 +442,7 @@ consecutive underscores, and trimming leading/trailing underscores.
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -458,7 +458,7 @@ consecutive underscores, and trimming leading/trailing underscores.
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexPathUtils#exists" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exists(name:String)(implicitsparkSession:org.apache.spark.sql.SparkSession):Boolean"></a><a id="exists(String)(SparkSession):Boolean"></a>
@@ -474,12 +474,12 @@ consecutive underscores, and trimming leading/trailing underscores.
       <span class="symbol">
         <span class="name">exists</span><span class="params">(<span name="name">name: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="params">(<span class="implicit">implicit </span><span name="sparkSession">sparkSession: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks whether an index with the given name exists.</p><div class="fullcomment"><div class="comment cmt"><p>Checks whether an index with the given name exists.</p><p>An index is considered to exist if either its file list entry or its storage directory is present.
 </p></div><dl class="paramcmts block"><dt class="param">name</dt><dd class="cmt"><p>
   The index name to check</p></dd><dt class="param">sparkSession</dt><dd class="cmt"><p>
   The implicit SparkSession</p></dd><dt>returns</dt><dd class="cmt"><p>
-  true if the index exists</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+  true if the index exists</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if name is null, blank, or contains unsafe path characters</p></span></dd><dt>Note</dt><dd><span class="cmt"><p>
   This check is subject to a TOCTOU (time-of-check/time-of-use) race condition — the index may be created or
   removed between this call and a subsequent operation. Callers must not rely on this result for correctness in
@@ -498,11 +498,11 @@ consecutive underscores, and trimming leading/trailing underscores.
       <span class="symbol">
         <span class="name">fileListName</span><span class="params">(<span name="name">name: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the file list name for a given index name.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the file list name for a given index name.
 </p></div><dl class="paramcmts block"><dt class="param">name</dt><dd class="cmt"><p>
   The index name</p></dd><dt>returns</dt><dd class="cmt"><p>
-  The prefixed file list identifier</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+  The prefixed file list identifier</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if name is null, blank, or contains unsafe path characters</p></span></dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -518,12 +518,12 @@ consecutive underscores, and trimming leading/trailing underscores.
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -539,12 +539,12 @@ consecutive underscores, and trimming leading/trailing underscores.
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -560,7 +560,7 @@ consecutive underscores, and trimming leading/trailing underscores.
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -576,7 +576,7 @@ consecutive underscores, and trimming leading/trailing underscores.
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -592,12 +592,12 @@ consecutive underscores, and trimming leading/trailing underscores.
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -613,12 +613,12 @@ consecutive underscores, and trimming leading/trailing underscores.
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexPathUtils#remove" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="remove(name:String)(implicitsparkSession:org.apache.spark.sql.SparkSession):Boolean"></a><a id="remove(String)(SparkSession):Boolean"></a>
@@ -634,14 +634,14 @@ consecutive underscores, and trimming leading/trailing underscores.
       <span class="symbol">
         <span class="name">remove</span><span class="params">(<span name="name">name: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="params">(<span class="implicit">implicit </span><span name="sparkSession">sparkSession: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Removes an index by deleting its file list entry and storage directory.</p><div class="fullcomment"><div class="comment cmt"><p>Removes an index by deleting its file list entry and storage directory.</p><p>Both the file list Delta table and the index storage directory are removed. The method returns <code>true</code> if at least
 one resource was successfully deleted.
 </p></div><dl class="paramcmts block"><dt class="param">name</dt><dd class="cmt"><p>
   the index name to remove</p></dd><dt class="param">sparkSession</dt><dd class="cmt"><p>
   the implicit SparkSession</p></dd><dt>returns</dt><dd class="cmt"><p>
-  true if any resources were successfully removed</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if name is null, blank, or contains unsafe path characters</p></span><span class="cmt"><p><span class="extype" name="IndexNotFoundException"><code>IndexNotFoundException</code></span>
+  true if any resources were successfully removed</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if name is null, blank, or contains unsafe path characters</p></span><span class="cmt"><p><span class="extype" name="IndexNotFoundException"><code>IndexNotFoundException</code></span> 
   if the index does not exist</p></span></dd><dt>Note</dt><dd><span class="cmt"><p>
   The <a href="#exists(name:String)(implicitsparkSession:org.apache.spark.sql.SparkSession):Boolean" class="extmbr" name="dev.cjfravel.ariadne.IndexPathUtils#exists">exists</a> guard is subject to a TOCTOU (time-of-check/time-of-use) race — another process may remove the
   index between the existence check and the actual deletion, or create a new index with the same name concurrently.
@@ -660,7 +660,7 @@ one resource was successfully deleted.
       <span class="symbol">
         <span class="name">storagePath</span><span class="params">(<span class="implicit">implicit </span><span name="sparkSession">sparkSession: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the base storage path for indexes under the configured Ariadne storage path.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the base storage path for indexes under the configured Ariadne storage path.
 </p></div><dl class="paramcmts block"><dt class="param">sparkSession</dt><dd class="cmt"><p>
   the implicit SparkSession providing configuration</p></dd><dt>returns</dt><dd class="cmt"><p>
@@ -679,7 +679,7 @@ one resource was successfully deleted.
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexPathUtils#tempPath" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="tempPath(implicitsparkSession:org.apache.spark.sql.SparkSession):org.apache.hadoop.fs.Path"></a><a id="tempPath(SparkSession):Path"></a>
@@ -695,7 +695,7 @@ one resource was successfully deleted.
       <span class="symbol">
         <span class="name">tempPath</span><span class="params">(<span class="implicit">implicit </span><span name="sparkSession">sparkSession: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns a temporary directory path for query staging operations.</p><div class="fullcomment"><div class="comment cmt"><p>Returns a temporary directory path for query staging operations.</p><p>The <code>_temp</code> directory is located under the Ariadne storage path and is used for transient data during query
 execution.
 </p></div><dl class="paramcmts block"><dt class="param">sparkSession</dt><dd class="cmt"><p>
@@ -715,7 +715,7 @@ execution.
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexPathUtils#validateIndexName" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="validateIndexName(name:String):Unit"></a><a id="validateIndexName(String):Unit"></a>
@@ -731,13 +731,13 @@ execution.
       <span class="symbol">
         <span class="name">validateIndexName</span><span class="params">(<span name="name">name: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Validates that an index name is safe to use as a path component.</p><div class="fullcomment"><div class="comment cmt"><p>Validates that an index name is safe to use as a path component.</p><p>Rejects names that are null, blank, contain path separators (<code>/</code>, <code>\</code>), contain the parent-directory segment <code>..</code>,
 contain null bytes, or begin with <code>.</code> (to avoid colliding with hidden files). Valid index names are used directly
 as subdirectory names under the Ariadne storage root, so unchecked input would permit path traversal (e.g.,
 <code>../foo</code>) or collisions with internal control files.
 </p></div><dl class="paramcmts block"><dt class="param">name</dt><dd class="cmt"><p>
-  the index name to validate</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+  the index name to validate</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if the name is null, blank, or contains unsafe characters</p></span></dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -753,13 +753,13 @@ as subdirectory names under the Ariadne storage root, so unchecked input would p
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -775,15 +775,15 @@ as subdirectory names under the Ariadne storage root, so unchecked input would p
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -799,19 +799,19 @@ as subdirectory names under the Ariadne storage root, so unchecked input would p
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -829,15 +829,15 @@ as subdirectory names under the Ariadne storage root, so unchecked input would p
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -849,13 +849,13 @@ as subdirectory names under the Ariadne storage root, so unchecked input would p
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/IndexQueryOperations.html
+++ b/docs/api/dev/cjfravel/ariadne/IndexQueryOperations.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.IndexQueryOperations" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.IndexQueryOperations" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="catalog/index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -147,7 +147,7 @@
       <span class="symbol">
         <a title="" href="exceptions/index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented3">
                         <span class="separator"></span>
@@ -256,7 +256,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Trait providing query and file location operations for Index instances.</p><p>This is the top-level trait in the Index trait hierarchy, providing:</p><ul><li>File location via regular, bloom, temporal, range, and auto-bloom indexes</li><li>Multi-column intersection with AND semantics across index types</li><li>Index statistics and diagnostics</li><li>Delta table management (repartitioning, large index loading)</li></ul><p>File location uses a staged collection strategy: distinct filenames are written to temporary CSV storage before
 collection to avoid executor memory pressure on large result sets.
 </p></div><dl class="attributes block"> <dt>Self Type</dt><dd><a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a></dd></dl><div class="toggleContainer block">
@@ -270,7 +270,7 @@ collection to avoid executor memory pressure on large result sets.
             </span>
             <div class="subClasses hiddenContent"><a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a></div>
           </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -285,7 +285,7 @@ collection to avoid executor memory pressure on large result sets.
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -312,7 +312,7 @@ collection to avoid executor memory pressure on large result sets.
 
       <div id="template">
         <div id="allMembers">
-
+        
 
         <div id="types" class="types members">
               <h3>Type Members</h3>
@@ -330,7 +330,7 @@ collection to avoid executor memory pressure on large result sets.
       <span class="symbol">
         <a title="Case class to hold file analysis results for batching decisions." href="IndexBuildOperations$FileAnalysis.html"><span class="name">FileAnalysis</span></a><span class="params">(<span name="filename">filename: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="distinctCounts">distinctCounts: <span class="extype" name="scala.Predef.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Long">Long</span>]</span>, <span name="maxDistinctCount">maxDistinctCount: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result"> extends <span class="extype" name="scala.Product">Product</span> with <span class="extype" name="scala.Serializable">Serializable</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Case class to hold file analysis results for batching decisions.</p><div class="fullcomment"><div class="comment cmt"><p>Case class to hold file analysis results for batching decisions.
 </p></div><dl class="paramcmts block"><dt class="param">filename</dt><dd class="cmt"><p>
   The name of the file</p></dd><dt class="param">distinctCounts</dt><dd class="cmt"><p>
@@ -355,7 +355,7 @@ collection to avoid executor memory pressure on large result sets.
       <span class="symbol">
         <span class="name">spark</span><span class="result">: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Implicit SparkSession that must be provided by the mixing class.</p><div class="fullcomment"><div class="comment cmt"><p>Implicit SparkSession that must be provided by the mixing class.</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
     </li></ol>
             </div>
@@ -377,7 +377,7 @@ collection to avoid executor memory pressure on large result sets.
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -393,7 +393,7 @@ collection to avoid executor memory pressure on large result sets.
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -409,7 +409,7 @@ collection to avoid executor memory pressure on large result sets.
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexFileOperations#addFilenameColumn" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addFilenameColumn(df:org.apache.spark.sql.DataFrame,files:Set[String]):org.apache.spark.sql.DataFrame"></a><a id="addFilenameColumn(DataFrame,Set[String]):DataFrame"></a>
@@ -425,7 +425,7 @@ collection to avoid executor memory pressure on large result sets.
       <span class="symbol">
         <span class="name">addFilenameColumn</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="files">files: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Adds a stable filename column to the DataFrame.</p><div class="fullcomment"><div class="comment cmt"><p>Adds a stable filename column to the DataFrame.</p><p>Uses <code>input_file_name()</code> to capture the source file path. For single-file reads where Spark may report an empty
 filename, falls back to the known file path.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
@@ -446,7 +446,7 @@ filename, falls back to the known file path.
       <span class="symbol">
         <span class="name">analyzeFiles</span><span class="params">(<span name="files">files: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Seq">Seq</span>[<a href="Index.html#FileAnalysisextendsProductwithSerializable" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations.FileAnalysis">Index.FileAnalysis</a>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Performs pre-flight analysis on unindexed files to determine optimal batching strategy.</p><div class="fullcomment"><div class="comment cmt"><p>Performs pre-flight analysis on unindexed files to determine optimal batching strategy.</p><p>Reads the source files, applies computed indexes, and counts distinct values per indexed column per file. The
 resulting <a href="IndexBuildOperations$FileAnalysis.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations.FileAnalysis">FileAnalysis</a> objects are used by <a href="IndexBuildOperations.html#createOptimalBatches(fileAnalyses:Seq[IndexBuildOperations.this.FileAnalysis]):Seq[Set[String]]" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#createOptimalBatches">createOptimalBatches</a> to group files into batches that stay under
 the <code>largeIndexLimit</code>.</p><p>If no storage columns are configured (e.g., only bloom or range indexes), returns trivial analyses with zero
@@ -471,7 +471,7 @@ distinct counts.
       <span class="symbol">
         <span class="name">appendToLargeIndex</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Appends large index data to per-column Delta tables under <code>large_indexes/</code>.</p><div class="fullcomment"><div class="comment cmt"><p>Appends large index data to per-column Delta tables under <code>large_indexes/</code>.</p><p>For each storage column, identifies rows where the array size meets or exceeds <code>largeIndexLimit</code>, explodes those
 arrays into individual rows, and writes them to <code>large_indexes/{column}/</code>. Before appending, any existing rows for
 the same filenames are removed via Delta MERGE to prevent duplicates (important during column backfill or
@@ -496,7 +496,7 @@ re-indexing).
       <span class="symbol">
         <span class="name">appendToStaging</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Appends the processed DataFrame to the staging Delta table.</p><div class="fullcomment"><div class="comment cmt"><p>Appends the processed DataFrame to the staging Delta table.</p><p>Before writing, any column whose array size meets or exceeds <code>largeIndexLimit</code> is nulled out (those values are
 stored separately via <a href="IndexBuildOperations.html#appendToLargeIndex(df:org.apache.spark.sql.DataFrame):Unit" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#appendToLargeIndex">appendToLargeIndex</a>). The DataFrame is written in append mode with schema merge enabled.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
@@ -515,7 +515,7 @@ stored separately via <a href="IndexBuildOperations.html#appendToLargeIndex(df:o
       <span class="symbol">
         <span class="name">applyColumnSelection</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Applies column selection if columns have been specified via select().</p><div class="fullcomment"><div class="comment cmt"><p>Applies column selection if columns have been specified via select(). Only reads the explicitly selected columns.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
   The DataFrame to apply column selection to</p></dd><dt>returns</dt><dd class="cmt"><p>
@@ -534,12 +534,12 @@ stored separately via <a href="IndexBuildOperations.html#appendToLargeIndex(df:o
       <span class="symbol">
         <span class="name">applyComputedIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Applies computed indexes to a DataFrame by adding computed columns.</p><div class="fullcomment"><div class="comment cmt"><p>Applies computed indexes to a DataFrame by adding computed columns.</p><p>Each computed index is a Spark SQL expression stored in metadata. The expression is evaluated via <code>expr()</code> and
 added as a new column. If no computed indexes are configured, the DataFrame is returned unchanged.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
   The base DataFrame</p></dd><dt>returns</dt><dd class="cmt"><p>
-  DataFrame with computed index columns added</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="org.apache.spark.sql.AnalysisException"><code>org.apache.spark.sql.AnalysisException</code></span>
+  DataFrame with computed index columns added</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="org.apache.spark.sql.AnalysisException"><code>org.apache.spark.sql.AnalysisException</code></span> 
   if a computed index expression is invalid or references non-existent columns</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexFileOperations#applyExplodedFields" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="applyExplodedFields(df:org.apache.spark.sql.DataFrame):org.apache.spark.sql.DataFrame"></a><a id="applyExplodedFields(DataFrame):DataFrame"></a>
@@ -555,7 +555,7 @@ added as a new column. If no computed indexes are configured, the DataFrame is r
       <span class="symbol">
         <span class="name">applyExplodedFields</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Applies exploded field transformations to a DataFrame.</p><div class="fullcomment"><div class="comment cmt"><p>Applies exploded field transformations to a DataFrame.</p><p>For each configured exploded field, extracts the nested field path from the array column and explodes it into a
 top-level column. This is used on the read/join path to prepare data for joining on exploded field values.</p><p>Note that <code>explode()</code> (not <code>explode_outer()</code>) is used intentionally — rows with null or empty arrays are dropped
 because they contain no matchable values for the join. This is consistent with the index build path which also
@@ -577,7 +577,7 @@ excludes null/empty arrays.
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#autoBloomColumnPrefix" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="autoBloomColumnPrefix:String"></a>
@@ -593,7 +593,7 @@ excludes null/empty arrays.
       <span class="symbol">
         <span class="name">autoBloomColumnPrefix</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Column name prefix for auto-bloom filter storage in the main index table.</p><div class="fullcomment"><div class="comment cmt"><p>Column name prefix for auto-bloom filter storage in the main index table.
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#autoBloomFpr" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -610,7 +610,7 @@ excludes null/empty arrays.
       <span class="symbol">
         <span class="name">autoBloomFpr</span><span class="result">: <span class="extype" name="scala.Double">Double</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">False positive rate for auto-bloom filters on large index columns.</p><div class="fullcomment"><div class="comment cmt"><p>False positive rate for auto-bloom filters on large index columns. When a column exceeds largeIndexLimit, an
 auto-bloom filter is built with this FPR to enable file pruning at query time. Reads from
 spark.ariadne.autoBloomFpr configuration (default: 0.01).
@@ -629,7 +629,7 @@ spark.ariadne.autoBloomFpr configuration (default: 0.01).
       <span class="symbol">
         <span class="name">autoBloomStorageColumns</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the set of auto-bloom storage column names (each prefixed with <code>auto_bloom_</code>).</p><div class="fullcomment"><div class="comment cmt"><p>Returns the set of auto-bloom storage column names (each prefixed with <code>auto_bloom_</code>).
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   set of prefixed column names (e.g., <code>auto_bloom_user_id</code>)</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
@@ -647,7 +647,7 @@ spark.ariadne.autoBloomFpr configuration (default: 0.01).
       <span class="symbol">
         <span class="name">autoCompactThreshold</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Int">Int</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Optional threshold for auto-compaction.</p><div class="fullcomment"><div class="comment cmt"><p>Optional threshold for auto-compaction. When set, the main index Delta table is compacted after an update if the
 number of Delta log JSON files meets or exceeds this value. Reads from spark.ariadne.autoCompactThreshold
 configuration (default: not set).
@@ -666,7 +666,7 @@ configuration (default: not set).
       <span class="symbol">
         <span class="name">batchesSinceCompact</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Counter tracking batches processed since the last auto-compaction.</p><div class="fullcomment"><div class="comment cmt"><p>Counter tracking batches processed since the last auto-compaction.</p><p>Incremented after each batch in <code>updateBatched</code> and reset to zero after each compaction cycle or at the start of
 each <a href="Index.html#update:Unit" class="extmbr" name="dev.cjfravel.ariadne.Index#update">update</a> call to prevent stale counts from a previous <code>update</code> from triggering premature
 compaction.
@@ -685,7 +685,7 @@ compaction.
       <span class="symbol">
         <span class="name">bloomColumnPrefix</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Column name prefix used when storing bloom filter binary data in the index Delta table.</p><div class="fullcomment"><div class="comment cmt"><p>Column name prefix used when storing bloom filter binary data in the index Delta table.
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.BloomFilterOperations#bloomColumns" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -702,7 +702,7 @@ compaction.
       <span class="symbol">
         <span class="name">bloomColumns</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the set of source column names that have bloom indexes configured.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the set of source column names that have bloom indexes configured.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   set of column names (without the <code>bloom_</code> prefix)</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd></dl></div>
@@ -720,7 +720,7 @@ compaction.
       <span class="symbol">
         <span class="name">bloomContainsUdf</span><span class="result">: <span class="extype" name="org.apache.spark.sql.expressions.UserDefinedFunction">UserDefinedFunction</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Creates a Spark UDF for checking bloom filter membership at query time.</p><div class="fullcomment"><div class="comment cmt"><p>Creates a Spark UDF for checking bloom filter membership at query time.</p><p>The returned UDF accepts a serialized bloom filter (<code>Array[Byte]</code>) and a candidate value (<code>String</code>), and returns
 <code>true</code> if the bloom filter indicates the value might be present.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
@@ -739,7 +739,7 @@ compaction.
       <span class="symbol">
         <span class="name">bloomIndexConfigs</span><span class="result">: <span class="extype" name="scala.Seq">Seq</span>[<a href="BloomIndexConfig.html" class="extype" name="dev.cjfravel.ariadne.BloomIndexConfig">BloomIndexConfig</a>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the bloom index configurations from the current index metadata.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the bloom index configurations from the current index metadata.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   sequence of <a href="BloomIndexConfig.html" class="extype" name="dev.cjfravel.ariadne.BloomIndexConfig">BloomIndexConfig</a> objects, one per bloom-indexed column</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd></dl></div>
@@ -757,7 +757,7 @@ compaction.
       <span class="symbol">
         <span class="name">bloomMightContain</span><span class="params">(<span name="bloomBytes">bloomBytes: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Byte">Byte</span>]</span>, <span name="value">value: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks if a value might be contained in a serialized bloom filter.</p><div class="fullcomment"><div class="comment cmt"><p>Checks if a value might be contained in a serialized bloom filter.</p><p>Deserializes the bloom filter and performs a <code>mightContain</code> check. Returns <code>false</code> if either argument is <code>null</code>.
 </p></div><dl class="paramcmts block"><dt class="param">bloomBytes</dt><dd class="cmt"><p>
   serialized bloom filter bytes</p></dd><dt class="param">value</dt><dd class="cmt"><p>
@@ -777,7 +777,7 @@ compaction.
       <span class="symbol">
         <span class="name">bloomStorageColumns</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the set of storage column names used for bloom filter binary data.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the set of storage column names used for bloom filter binary data.</p><p>Each name is the source column name prefixed with <a href="BloomFilterOperations.html#bloomColumnPrefix:String" class="extmbr" name="dev.cjfravel.ariadne.BloomFilterOperations#bloomColumnPrefix">bloomColumnPrefix</a>.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   set of prefixed column names (e.g., <code>bloom_user_id</code>)</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd></dl></div>
@@ -795,7 +795,7 @@ compaction.
       <span class="symbol">
         <span class="name">buildAutoBloomIndexes</span><span class="params">(<span name="combinedDf">combinedDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds auto-bloom filters for columns that exceed the large index limit.</p><div class="fullcomment"><div class="comment cmt"><p>Builds auto-bloom filters for columns that exceed the large index limit.</p><p>Scans the combined DataFrame to identify columns with any file whose array size meets or exceeds <code>largeIndexLimit</code>.
 For each such column, a bloom filter is built from the full array and stored in the main index with the
 <code>auto_bloom_</code> prefix. At query time, these bloom filters enable fast pre-filtering to determine which files need to
@@ -820,7 +820,7 @@ unpersisted before the exception is rethrown.
       <span class="symbol">
         <span class="name">buildBloomFilterIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds bloom filter indexes for all configured bloom columns.</p><div class="fullcomment"><div class="comment cmt"><p>Builds bloom filter indexes for all configured bloom columns.</p><p>For each <a href="BloomIndexConfig.html" class="extype" name="dev.cjfravel.ariadne.BloomIndexConfig">BloomIndexConfig</a>, this method:</p><ol class="decimal"><li>Groups the input data by filename 2. Collects distinct values per file into a set 3. Creates a bloom filter
      from the collected values using <a href="BloomFilterOperations.html#createBloomFilterUdf(fprValue:Double):org.apache.spark.sql.expressions.UserDefinedFunction" class="extmbr" name="dev.cjfravel.ariadne.BloomFilterOperations#createBloomFilterUdf">createBloomFilterUdf</a> 4. Joins the resulting bloom column back onto the
      accumulating DataFrame</li></ol><p>If no bloom indexes are configured, returns a distinct filename-only DataFrame.
@@ -841,7 +841,7 @@ unpersisted before the exception is rethrown.
       <span class="symbol">
         <span class="name">buildExplodedFieldIndexes</span><span class="params">(<span name="baseData">baseData: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="resultDf">resultDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds exploded field indexes and joins them onto the result DataFrame.</p><div class="fullcomment"><div class="comment cmt"><p>Builds exploded field indexes and joins them onto the result DataFrame.</p><p>For each configured exploded field index, extracts the nested field path from the array column, explodes it,
 collects distinct values back into an array per file, and joins the result onto <code>resultDf</code>.
 </p></div><dl class="paramcmts block"><dt class="param">baseData</dt><dd class="cmt"><p>
@@ -862,7 +862,7 @@ collects distinct values back into an array per file, and joins the result onto 
       <span class="symbol">
         <span class="name">buildRangeIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds range indexes storing <code>Struct(min, max)</code> per file.</p><div class="fullcomment"><div class="comment cmt"><p>Builds range indexes storing <code>Struct(min, max)</code> per file.</p><p>For each range index configuration, groups by <code>filename</code> and computes the <code>min</code> and <code>max</code> of the column per file.
 The result is a struct column named <code>range_{column}</code>.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
@@ -883,7 +883,7 @@ The result is a struct column named <code>range_{column}</code>.
       <span class="symbol">
         <span class="name">buildRegularIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds regular (array-aggregated) indexes for all configured regular and computed columns.</p><div class="fullcomment"><div class="comment cmt"><p>Builds regular (array-aggregated) indexes for all configured regular and computed columns.</p><p>Groups the input data by filename and collects distinct values into arrays via <code>collect_set</code>. If no regular or
 computed indexes are configured, returns a distinct filename-only DataFrame.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
@@ -903,7 +903,7 @@ computed indexes are configured, returns a distinct filename-only DataFrame.
       <span class="symbol">
         <span class="name">buildTemporalIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds temporal indexes storing <code>Array[Struct(value, max_ts)]</code> per file.</p><div class="fullcomment"><div class="comment cmt"><p>Builds temporal indexes storing <code>Array[Struct(value, max_ts)]</code> per file.</p><p>For each temporal index configuration, groups by <code>(filename, value_column)</code> to find the maximum timestamp per value
 per file, then collects the <code>(value, max_ts)</code> structs into an array per file. This enables temporal deduplication
 at query time.
@@ -925,17 +925,17 @@ at query time.
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#compactDeltaTables" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="compactDeltaTables():Unit"></a>
@@ -951,7 +951,7 @@ at query time.
       <span class="symbol">
         <span class="name">compactDeltaTables</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Compacts all Delta tables (main index and large index tables) using Delta OPTIMIZE.</p><div class="fullcomment"><div class="comment cmt"><p>Compacts all Delta tables (main index and large index tables) using Delta OPTIMIZE.</p><p>Runs Delta Lake's OPTIMIZE command to consolidate small files into larger ones, improving read performance.
 Processes the main index table first, then each large index column table.
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
@@ -969,7 +969,7 @@ Processes the main index table first, then each large index column table.
       <span class="symbol">
         <span class="name">consolidateStaging</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Consolidates staged data into the main index table.</p><div class="fullcomment"><div class="comment cmt"><p>Consolidates staged data into the main index table.</p><p>Delegates to <span class="extype" name="consolidateMainStaging">consolidateMainStaging</span> which performs a Delta MERGE (upsert) of all staged rows into the main
 index, then deletes the staging table. Logs the total time taken.
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
@@ -987,12 +987,12 @@ index, then deletes the staging table. Logs the total time taken.
       <span class="symbol">
         <span class="name">createBaseDataFrame</span><span class="params">(<span name="files">files: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Creates a base DataFrame from the provided files using the stored format and schema.</p><div class="fullcomment"><div class="comment cmt"><p>Creates a base DataFrame from the provided files using the stored format and schema. Applies any read options
 configured in the index metadata.</p><p>Returns an empty DataFrame (with the stored schema) if all file paths are blank after normalization.
 </p></div><dl class="paramcmts block"><dt class="param">files</dt><dd class="cmt"><p>
   Set of file paths to read</p></dd><dt>returns</dt><dd class="cmt"><p>
-  DataFrame with data from the specified files</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+  DataFrame with data from the specified files</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if the stored format is not csv, parquet, or json</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.BloomFilterOperations#createBloomFilterUdf" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="createBloomFilterUdf(fprValue:Double):org.apache.spark.sql.expressions.UserDefinedFunction"></a><a id="createBloomFilterUdf(Double):UserDefinedFunction"></a>
@@ -1008,7 +1008,7 @@ configured in the index metadata.</p><p>Returns an empty DataFrame (with the sto
       <span class="symbol">
         <span class="name">createBloomFilterUdf</span><span class="params">(<span name="fprValue">fprValue: <span class="extype" name="scala.Double">Double</span></span>)</span><span class="result">: <span class="extype" name="org.apache.spark.sql.expressions.UserDefinedFunction">UserDefinedFunction</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Creates a Spark UDF that converts a collected set of values into a serialized bloom filter.</p><div class="fullcomment"><div class="comment cmt"><p>Creates a Spark UDF that converts a collected set of values into a serialized bloom filter.</p><p>The UDF is designed for use inside <code>agg(bloomUdf(collect_set(...)))</code>. It:</p><ol class="decimal"><li>Filters out null values from the input sequence 2. Creates a Guava <code>BloomFilter</code> sized for the actual number
      of non-null elements 3. Inserts each value (converted to <code>String</code>) into the filter 4. Serializes the filter to
      <code>Array[Byte]</code> via <code>ByteArrayOutputStream</code></li></ol><p>The <code>fprValue</code> parameter is captured as a local <code>val</code> to ensure it is serializable when the UDF closure is shipped
@@ -1016,7 +1016,7 @@ to Spark executors.
 </p></div><dl class="paramcmts block"><dt class="param">fprValue</dt><dd class="cmt"><p>
   the desired false positive rate (e.g., 0.01 for 1%); must be strictly between 0 and 1 (exclusive)</p></dd><dt>returns</dt><dd class="cmt"><p>
   a UDF that accepts <code>Seq[Any]</code> (from <code>collect_set</code>) and returns <code>Array[Byte]</code>, or <code>null</code> if the input is null or
-  contains only nulls</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+  contains only nulls</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if <code>fprValue</code> is not in the range (0, 1)</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#createOptimalBatches" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="createOptimalBatches(fileAnalyses:Seq[IndexBuildOperations.this.FileAnalysis]):Seq[Set[String]]"></a><a id="createOptimalBatches(Seq[Index.FileAnalysis]):Seq[Set[String]]"></a>
@@ -1032,7 +1032,7 @@ to Spark executors.
       <span class="symbol">
         <span class="name">createOptimalBatches</span><span class="params">(<span name="fileAnalyses">fileAnalyses: <span class="extype" name="scala.Seq">Seq</span>[<a href="Index.html#FileAnalysisextendsProductwithSerializable" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations.FileAnalysis">Index.FileAnalysis</a>]</span>)</span><span class="result">: <span class="extype" name="scala.Seq">Seq</span>[<span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Groups files into batches whose aggregate <code>maxDistinctCount</code> stays at or below <code>largeIndexLimit</code>.</p><div class="fullcomment"><div class="comment cmt"><p>Groups files into batches whose aggregate <code>maxDistinctCount</code> stays at or below <code>largeIndexLimit</code>.</p><p>The algorithm sorts files by <code>maxDistinctCount</code> (largest first) and packs them sequentially into batches. When
 adding a file would push the batch total past the limit, a new batch is started. Files that individually exceed the
 limit are placed into single-file batches to guarantee progress.
@@ -1053,7 +1053,7 @@ limit are placed into single-file batches to guarantee progress.
       <span class="symbol">
         <span class="name">debugEnabled</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">When true, logs detailed diagnostics during join operations including partition counts, physical plans, and
 per-phase timing.</p><div class="fullcomment"><div class="comment cmt"><p>When true, logs detailed diagnostics during join operations including partition counts, physical plans, and
 per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
@@ -1072,12 +1072,12 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">delete</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Deletes a path recursively from the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Deletes a path recursively from the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to delete</p></dd><dt>returns</dt><dd class="cmt"><p>
-  true if the path was successfully deleted</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  true if the path was successfully deleted</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the filesystem operation fails</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#delta" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="delta(path:org.apache.hadoop.fs.Path):Option[io.delta.tables.DeltaTable]"></a><a id="delta(Path):Option[DeltaTable]"></a>
@@ -1093,7 +1093,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">delta</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="io.delta.tables.DeltaTable">DeltaTable</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns a <span class="extype" name="io.delta.tables.DeltaTable">io.delta.tables.DeltaTable</span> if the path exists and contains valid Delta metadata.</p><div class="fullcomment"><div class="comment cmt"><p>Returns a <span class="extype" name="io.delta.tables.DeltaTable">io.delta.tables.DeltaTable</span> if the path exists and contains valid Delta metadata.</p><p>If the path exists but is <i>not</i> a valid Delta table (e.g., leftover partial write), the directory is deleted and
 <code>None</code> is returned so it can be recreated cleanly on the next write.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
@@ -1113,12 +1113,12 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">deserializeBloomFilter</span><span class="params">(<span name="bytes">bytes: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Byte">Byte</span>]</span>)</span><span class="result">: <span class="extype" name="com.google.common.hash.BloomFilter">BloomFilter</span>[<span class="extype" name="java.lang.CharSequence">CharSequence</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Deserializes a Guava bloom filter from its byte representation.</p><div class="fullcomment"><div class="comment cmt"><p>Deserializes a Guava bloom filter from its byte representation.</p><p>Uses <code>BloomFilter.readFrom</code> with a UTF-8 <code>StringFunnel</code>, which must match the funnel used during creation in
 <a href="BloomFilterOperations.html#createBloomFilterUdf(fprValue:Double):org.apache.spark.sql.expressions.UserDefinedFunction" class="extmbr" name="dev.cjfravel.ariadne.BloomFilterOperations#createBloomFilterUdf">createBloomFilterUdf</a>.
 </p></div><dl class="paramcmts block"><dt class="param">bytes</dt><dd class="cmt"><p>
   serialized bloom filter bytes (produced by <code>BloomFilter.writeTo</code>)</p></dd><dt>returns</dt><dd class="cmt"><p>
-  a <code>BloomFilter[CharSequence]</code> instance ready for membership queries</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  a <code>BloomFilter[CharSequence]</code> instance ready for membership queries</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the byte array is malformed or corrupted</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#ensureStorageReadyUnderLock" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ensureStorageReadyUnderLock(lock:dev.cjfravel.ariadne.IndexLock,correlationId:String,refresh:Boolean):Unit"></a><a id="ensureStorageReadyUnderLock(IndexLock,String,Boolean):Unit"></a>
@@ -1134,7 +1134,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">ensureStorageReadyUnderLock</span><span class="params">(<span name="lock">lock: <a href="IndexLock.html" class="extype" name="dev.cjfravel.ariadne.IndexLock">IndexLock</a></span>, <span name="correlationId">correlationId: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="refresh">refresh: <span class="extype" name="scala.Boolean">Boolean</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Runs migration preflight while the caller holds the update lock.</p><div class="fullcomment"><div class="comment cmt"><p>Runs migration preflight while the caller holds the update lock.
 </p></div><dl class="paramcmts block"><dt class="param">refresh</dt><dd class="cmt"><p>
   whether to reload metadata after lock acquisition</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
@@ -1152,7 +1152,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -1168,7 +1168,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#exists" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exists(path:org.apache.hadoop.fs.Path):Boolean"></a><a id="exists(Path):Boolean"></a>
@@ -1184,12 +1184,12 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">exists</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks if a path exists on the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Checks if a path exists on the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to check</p></dd><dt>returns</dt><dd class="cmt"><p>
-  true if the path exists</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  true if the path exists</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the filesystem operation fails</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadataOperations#format" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="format:String"></a>
@@ -1205,7 +1205,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">format</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the file format of the indexed data (e.g., &quot;parquet&quot;, &quot;csv&quot;, &quot;json&quot;).</p><div class="fullcomment"><div class="comment cmt"><p>Returns the file format of the indexed data (e.g., &quot;parquet&quot;, &quot;csv&quot;, &quot;json&quot;).</p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   the format string from the stored metadata</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#fs" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -1222,7 +1222,7 @@ per-phase timing. Reads from spark.ariadne.debug configuration (default: false).
       <span class="symbol">
         <span class="name">fs</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.FileSystem">FileSystem</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop <code>FileSystem</code> instance resolved from the <a href="AriadneContextUser.html#storagePath:org.apache.hadoop.fs.Path" class="extmbr" name="dev.cjfravel.ariadne.AriadneContextUser#storagePath">storagePath</a> URI and the Spark Hadoop configuration.</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop <code>FileSystem</code> instance resolved from the <a href="AriadneContextUser.html#storagePath:org.apache.hadoop.fs.Path" class="extmbr" name="dev.cjfravel.ariadne.AriadneContextUser#storagePath">storagePath</a> URI and the Spark Hadoop configuration. Used for all
 filesystem operations (existence checks, reads, deletes, lock files).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -1240,7 +1240,7 @@ filesystem operations (existence checks, reads, deletes, lock files).
       <span class="symbol">
         <span class="name">getAutoBloomCandidates</span><span class="params">(<span name="column">column: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="values">values: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Any">Any</span>]</span>, <span name="indexDf">indexDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Gets candidate files from the auto-bloom filter for a specific column.</p><div class="fullcomment"><div class="comment cmt"><p>Gets candidate files from the auto-bloom filter for a specific column.</p><p>Collects all bloom filter byte arrays from the index to the driver and tests each value against them. Files whose
 bloom filter is null are included as candidates for backward compatibility with indexes built before auto-bloom was
 added.
@@ -1265,7 +1265,7 @@ added.
       <span class="symbol">
         <span class="name">getAutoBloomCandidatesFromDf</span><span class="params">(<span name="storageColumn">storageColumn: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="joinColumn">joinColumn: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="valuesDf">valuesDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="indexDf">indexDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Gets candidate files from the auto-bloom filter using values extracted from a DataFrame.</p><div class="fullcomment"><div class="comment cmt"><p>Gets candidate files from the auto-bloom filter using values extracted from a DataFrame.</p><p>Collects distinct non-null values from the given DataFrame column, then delegates to <a href="#getAutoBloomCandidates(column:String,values:Array[Any],indexDf:org.apache.spark.sql.DataFrame):Option[Set[String]]" class="extmbr" name="dev.cjfravel.ariadne.IndexQueryOperations#getAutoBloomCandidates">getAutoBloomCandidates</a> for
 the actual bloom filter probing.
 </p></div><dl class="paramcmts block"><dt class="param">storageColumn</dt><dd class="cmt"><p>
@@ -1291,12 +1291,12 @@ the actual bloom filter probing.
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#getFileSizes" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getFileSizes(files:Set[String]):Map[String,Long]"></a><a id="getFileSizes(Set[String]):Map[String,Long]"></a>
@@ -1312,7 +1312,7 @@ the actual bloom filter probing.
       <span class="symbol">
         <span class="name">getFileSizes</span><span class="params">(<span name="files">files: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Predef.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Long">Long</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Computes file sizes in bytes for the given files using the Hadoop FileSystem.</p><div class="fullcomment"><div class="comment cmt"><p>Computes file sizes in bytes for the given files using the Hadoop FileSystem.</p><p>Files that cannot be found or read are silently skipped with a warning log.
 </p></div><dl class="paramcmts block"><dt class="param">files</dt><dd class="cmt"><p>
   set of fully-qualified file paths to measure</p></dd><dt>returns</dt><dd class="cmt"><p>
@@ -1331,7 +1331,7 @@ the actual bloom filter probing.
       <span class="symbol">
         <span class="name">handleLargeIndexes</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks all storage columns for arrays exceeding <code>largeIndexLimit</code> and delegates to <a href="IndexBuildOperations.html#appendToLargeIndex(df:org.apache.spark.sql.DataFrame):Unit" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#appendToLargeIndex">appendToLargeIndex</a> for
 separation.</p><div class="fullcomment"><div class="comment cmt"><p>Checks all storage columns for arrays exceeding <code>largeIndexLimit</code> and delegates to <a href="IndexBuildOperations.html#appendToLargeIndex(df:org.apache.spark.sql.DataFrame):Unit" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#appendToLargeIndex">appendToLargeIndex</a> for
 separation.
@@ -1351,12 +1351,12 @@ separation.
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexQueryOperations#index" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="index:Option[org.apache.spark.sql.DataFrame]"></a><a id="index:Option[DataFrame]"></a>
@@ -1372,7 +1372,7 @@ separation.
       <span class="symbol">
         <span class="name">index</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Helper function to load the index.</p><div class="fullcomment"><div class="comment cmt"><p>Helper function to load the index.</p><p>On first call, checks for and performs any needed exploded field column migration (pre-0.1.1 indexes stored columns
 under <code>array_column</code> names).
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
@@ -1392,7 +1392,7 @@ under <code>array_column</code> names).
       <span class="symbol">
         <span class="name">indexFilePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop path for the main index Delta table (<code>{storagePath}/index/</code>).</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop path for the main index Delta table (<code>{storagePath}/index/</code>).</p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#indexRepartitionCount" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="indexRepartitionCount:Option[Int]"></a>
@@ -1408,7 +1408,7 @@ under <code>array_column</code> names).
       <span class="symbol">
         <span class="name">indexRepartitionCount</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Int">Int</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Optional number of partitions to use when repartitioning the index DataFrame during joins.</p><div class="fullcomment"><div class="comment cmt"><p>Optional number of partitions to use when repartitioning the index DataFrame during joins. When set, the index
 DataFrame is repartitioned before expensive operations like explode to reduce per-executor memory pressure and
 avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepartitionCount configuration
@@ -1428,7 +1428,7 @@ avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepa
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexJoinOperations#join" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="join(df:org.apache.spark.sql.DataFrame,usingColumns:Seq[String],joinType:String):org.apache.spark.sql.DataFrame"></a><a id="join(DataFrame,Seq[String],String):DataFrame"></a>
@@ -1444,7 +1444,7 @@ avoid FetchFailedExceptions on large indexes. Reads from spark.ariadne.indexRepa
       <span class="symbol">
         <span class="name">join</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="usingColumns">usingColumns: <span class="extype" name="scala.Seq">Seq</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="joinType">joinType: <span class="extype" name="scala.Predef.String">String</span> = <span class="symbol">&quot;inner&quot;</span></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Joins a DataFrame with indexed data files.</p><div class="fullcomment"><div class="comment cmt"><p>Joins a DataFrame with indexed data files.</p><p>This is the primary public API for index-based joins. The index locates which files contain matching values, reads
 only those files, applies temporal deduplication if applicable, then performs the Spark DataFrame join.</p><p>The join direction is <code>indexedData.join(df)</code> — the index-located data is on the left. For the reverse direction,
 use <a href="Index$$DataFrameOps.html#join(index:dev.cjfravel.ariadne.Index,usingColumns:Seq[String],joinType:String):org.apache.spark.sql.DataFrame" class="extmbr" name="dev.cjfravel.ariadne.Index.DataFrameOps#join">Index.DataFrameOps.join</a>.
@@ -1461,8 +1461,8 @@ index.update
 <span class="kw">val</span> result = index.join(lookupDf, <span class="std">Seq</span>(<span class="lit">"customer_id"</span>))
 <span class="cmt">// Left join variant:</span>
 <span class="kw">val</span> leftResult = index.join(lookupDf, <span class="std">Seq</span>(<span class="lit">"customer_id"</span>), <span class="lit">"left"</span>)</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if none of the join columns have indexes</p></span><span class="cmt"><p><a href="exceptions/ColumnNotFoundException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.ColumnNotFoundException"><code>dev.cjfravel.ariadne.exceptions.ColumnNotFoundException</code></a>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if none of the join columns have indexes</p></span><span class="cmt"><p><a href="exceptions/ColumnNotFoundException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.ColumnNotFoundException"><code>dev.cjfravel.ariadne.exceptions.ColumnNotFoundException</code></a> 
   if join columns are not in the schema or indexes</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexJoinOperations#joinDf" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="joinDf(df:org.apache.spark.sql.DataFrame,usingColumns:Seq[String]):org.apache.spark.sql.DataFrame"></a><a id="joinDf(DataFrame,Seq[String]):DataFrame"></a>
@@ -1478,7 +1478,7 @@ index.update
       <span class="symbol">
         <span class="name">joinDf</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="usingColumns">usingColumns: <span class="extype" name="scala.Seq">Seq</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Locates and reads indexed data files relevant to the given DataFrame.</p><div class="fullcomment"><div class="comment cmt"><p>Locates and reads indexed data files relevant to the given DataFrame.</p><p>Uses the index to identify which files contain matching values, then reads those files into a lazy DataFrame. If no
 matching files are found, returns an empty DataFrame with the stored schema. The actual row-level filtering happens
 in the subsequent join in <a href="IndexJoinOperations.html#join(df:org.apache.spark.sql.DataFrame,usingColumns:Seq[String],joinType:String):org.apache.spark.sql.DataFrame" class="extmbr" name="dev.cjfravel.ariadne.IndexJoinOperations#join">join</a>.</p><p>Logs data pruning metrics (file count, data size saved) when available, and includes detailed file-level debug
@@ -1486,8 +1486,8 @@ information when debug mode is enabled.
 </p></div><dl class="paramcmts block"><dt class="param">df</dt><dd class="cmt"><p>
   The DataFrame to match against the index.</p></dd><dt class="param">usingColumns</dt><dd class="cmt"><p>
   The columns used for the join.</p></dd><dt>returns</dt><dd class="cmt"><p>
-  A lazy DataFrame containing data from indexed files, or an empty DataFrame if no files match.</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexJoinOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexJoinOperations">IndexJoinOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if none of the join columns have indexes, or if df/usingColumns are null/empty</p></span><span class="cmt"><p><a href="exceptions/ColumnNotFoundException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.ColumnNotFoundException"><code>dev.cjfravel.ariadne.exceptions.ColumnNotFoundException</code></a>
+  A lazy DataFrame containing data from indexed files, or an empty DataFrame if no files match.</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexJoinOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexJoinOperations">IndexJoinOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if none of the join columns have indexes, or if df/usingColumns are null/empty</p></span><span class="cmt"><p><a href="exceptions/ColumnNotFoundException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.ColumnNotFoundException"><code>dev.cjfravel.ariadne.exceptions.ColumnNotFoundException</code></a> 
   if join columns are not in the selected columns, schema, or indexes</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexQueryOperations#largeIndexColumns" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="largeIndexColumns:Set[String]"></a>
@@ -1503,7 +1503,7 @@ information when debug mode is enabled.
       <span class="symbol">
         <span class="name">largeIndexColumns</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the set of column names that have large index Delta tables.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the set of column names that have large index Delta tables.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   Set of column names with large index storage</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd></dl></div>
@@ -1521,7 +1521,7 @@ information when debug mode is enabled.
       <span class="symbol">
         <span class="name">largeIndexLimit</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Maximum number of distinct values per file before an index column is promoted to a &quot;large index&quot; (stored in a
 separate exploded Delta table).</p><div class="fullcomment"><div class="comment cmt"><p>Maximum number of distinct values per file before an index column is promoted to a &quot;large index&quot; (stored in a
 separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</code> (default: 500000).</p><p>If the configured value is not a valid positive number, a warning is logged and the default of 500,000 is used.
@@ -1540,7 +1540,7 @@ separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</
       <span class="symbol">
         <span class="name">largeIndexesFilePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop root path for large index Delta tables (<code>{storagePath}/large_indexes/</code>).</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop root path for large index Delta tables (<code>{storagePath}/large_indexes/</code>).
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#lastAutoBloomCache" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -1557,11 +1557,11 @@ separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</
       <span class="symbol">
         <span class="name">lastAutoBloomCache</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Tracks the cached DataFrame from <a href="IndexBuildOperations.html#buildAutoBloomIndexes(combinedDf:org.apache.spark.sql.DataFrame):org.apache.spark.sql.DataFrame" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#buildAutoBloomIndexes">buildAutoBloomIndexes</a> for deferred cleanup.</p><div class="fullcomment"><div class="comment cmt"><p>Tracks the cached DataFrame from <a href="IndexBuildOperations.html#buildAutoBloomIndexes(combinedDf:org.apache.spark.sql.DataFrame):org.apache.spark.sql.DataFrame" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#buildAutoBloomIndexes">buildAutoBloomIndexes</a> for deferred cleanup.</p><p>Set during auto-bloom processing and unpersisted after staging is complete.
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd><dt>Annotations</dt><dd>
                 <span class="name">@transient</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexQueryOperations#loadColumnIndex" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="loadColumnIndex(indexDf:org.apache.spark.sql.DataFrame,colName:String,bloomCandidateFiles:Option[Set[String]]):org.apache.spark.sql.DataFrame"></a><a id="loadColumnIndex(DataFrame,String,Option[Set[String]]):DataFrame"></a>
@@ -1577,7 +1577,7 @@ separate exploded Delta table). Reads from <code>spark.ariadne.largeIndexLimit</
       <span class="symbol">
         <span class="name">loadColumnIndex</span><span class="params">(<span name="indexDf">indexDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="colName">colName: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="bloomCandidateFiles">bloomCandidateFiles: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]] = <span class="symbol">None</span></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns a unified (filename, colName) DataFrame for a regular index column by exploding the main index arrays and
 unioning with any large index rows that exist for that column.</p><div class="fullcomment"><div class="comment cmt"><p>Returns a unified (filename, colName) DataFrame for a regular index column by exploding the main index arrays and
 unioning with any large index rows that exist for that column.
@@ -1601,7 +1601,7 @@ unioning with any large index rows that exist for that column.
       <span class="symbol">
         <span class="name">loadLargeIndex</span><span class="params">(<span name="colName">colName: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Loads a large index Delta table for a specific column.</p><div class="fullcomment"><div class="comment cmt"><p>Loads a large index Delta table for a specific column. Large indexes store data in exploded (filename, value) row
 form rather than as arrays.
 </p></div><dl class="paramcmts block"><dt class="param">colName</dt><dd class="cmt"><p>
@@ -1621,7 +1621,7 @@ form rather than as arrays.
       <span class="symbol">
         <span class="name">loadTemporalColumnIndex</span><span class="params">(<span name="indexDf">indexDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="colName">colName: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns a unified (filename, _value, _max_ts) DataFrame for a temporal index column by exploding the main index
 struct arrays and unioning with any large index rows that exist for that column.</p><div class="fullcomment"><div class="comment cmt"><p>Returns a unified (filename, _value, _max_ts) DataFrame for a temporal index column by exploding the main index
 struct arrays and unioning with any large index rows that exist for that column.
@@ -1643,7 +1643,7 @@ struct arrays and unioning with any large index rows that exist for that column.
       <span class="symbol">
         <span class="name">locateFiles</span><span class="params">(<span name="indexes">indexes: <span class="extype" name="scala.Predef.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Any">Any</span>]]</span>)</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Locates files matching the given index values across all index types.</p><div class="fullcomment"><div class="comment cmt"><p>Locates files matching the given index values across all index types.</p><p>Queries regular, bloom, temporal, range, and auto-bloom indexes in parallel and intersects results with AND
 semantics. Each index type independently returns candidate files, and only files present in all queried categories
 are included in the final result.
@@ -1652,7 +1652,7 @@ are included in the final result.
   appropriate index type (bloom, temporal, range, or regular).</p></dd><dt>returns</dt><dd class="cmt"><p>
   A set of file paths matching all query criteria, or an empty set if no matches are found or no index exists</p></dd></dl><dl class="attributes block"> <div class="block">Example:
                <ol><li class="cmt"><p></p><pre><span class="kw">val</span> matchingFiles = index.locateFiles(<span class="std">Map</span>(<span class="lit">"userId"</span> -&gt; <span class="std">Array</span>(<span class="lit">"u1"</span>, <span class="lit">"u2"</span>)))</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if <code>indexes</code> is null</p></span></dd><dt>Note</dt><dd><span class="cmt"><p>
   If a staging table exists, its contents are collected to the driver for merging. This may cause driver OOM for
   very large staging tables.</p></span></dd></dl></div>
@@ -1670,7 +1670,7 @@ are included in the final result.
       <span class="symbol">
         <span class="name">locateFilesFromDataFrame</span><span class="params">(<span name="valuesDf">valuesDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="columnMappings">columnMappings: <span class="extype" name="scala.Predef.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="joinColumns">joinColumns: <span class="extype" name="scala.Seq">Seq</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Locates files based on a DataFrame containing join column values.</p><div class="fullcomment"><div class="comment cmt"><p>Locates files based on a DataFrame containing join column values. Handles both regular indexes and bloom filter
 indexes.
 </p></div><dl class="paramcmts block"><dt class="param">valuesDf</dt><dd class="cmt"><p>
@@ -1680,7 +1680,7 @@ indexes.
   A set of file names matching the criteria.</p></dd></dl><dl class="attributes block"> <div class="block">Example:
                <ol><li class="cmt"><p></p><pre><span class="kw">val</span> columnMappings = <span class="std">Map</span>(<span class="lit">"userId"</span> -&gt; <span class="lit">"userId"</span>)
 <span class="kw">val</span> files = index.locateFilesFromDataFrame(lookupDf, columnMappings, <span class="std">Seq</span>(<span class="lit">"userId"</span>))</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if <code>valuesDf</code> is null or <code>columnMappings</code> is null or empty</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.BloomFilterOperations#locateFilesWithBloom" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="locateFilesWithBloom(column:String,values:Array[Any],indexDf:org.apache.spark.sql.DataFrame):Set[String]"></a><a id="locateFilesWithBloom(String,Array[Any],DataFrame):Set[String]"></a>
@@ -1696,7 +1696,7 @@ indexes.
       <span class="symbol">
         <span class="name">locateFilesWithBloom</span><span class="params">(<span name="column">column: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="values">values: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Any">Any</span>]</span>, <span name="indexDf">indexDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Locates files that might contain any of the given values using bloom filters.</p><div class="fullcomment"><div class="comment cmt"><p>Locates files that might contain any of the given values using bloom filters.</p><p>Collects all rows from the index, deserializes each file's bloom filter for the specified column, and tests every
 candidate value. A file is included in the result if any value passes the <code>mightContain</code> check.
 </p></div><dl class="paramcmts block"><dt class="param">column</dt><dd class="cmt"><p>
@@ -1722,7 +1722,7 @@ candidate value. A file is included in the result if any value passes the <code>
       <span class="symbol">
         <span class="name">locateFilesWithBloomFromDataFrame</span><span class="params">(<span name="column">column: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="valuesDf">valuesDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>, <span name="indexDf">indexDf: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Locates files that might contain values from a DataFrame using bloom filters.</p><div class="fullcomment"><div class="comment cmt"><p>Locates files that might contain values from a DataFrame using bloom filters.</p><p>Collects distinct non-null values from the specified column of <code>valuesDf</code>, then delegates to
 <a href="BloomFilterOperations.html#locateFilesWithBloom(column:String,values:Array[Any],indexDf:org.apache.spark.sql.DataFrame):Set[String]" class="extmbr" name="dev.cjfravel.ariadne.BloomFilterOperations#locateFilesWithBloom">locateFilesWithBloom</a> for the actual bloom filter check.
 </p></div><dl class="paramcmts block"><dt class="param">column</dt><dd class="cmt"><p>
@@ -1748,7 +1748,7 @@ candidate value. A file is included in the result if any value passes the <code>
       <span class="symbol">
         <span class="name">lockMaxWait</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Maximum total time in seconds to wait for lock acquisition before failing.</p><div class="fullcomment"><div class="comment cmt"><p>Maximum total time in seconds to wait for lock acquisition before failing. Reads from spark.ariadne.lockMaxWait
 configuration (default: 3600).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Note</dt><dd><span class="cmt"><p>
@@ -1768,7 +1768,7 @@ configuration (default: 3600).
       <span class="symbol">
         <span class="name">lockRefreshInterval</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Refresh the update lock every N batches during updateBatched.</p><div class="fullcomment"><div class="comment cmt"><p>Refresh the update lock every N batches during updateBatched. Reads from spark.ariadne.lockRefreshInterval
 configuration (default: 1).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -1786,7 +1786,7 @@ configuration (default: 1).
       <span class="symbol">
         <span class="name">lockRetryInterval</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Base interval in seconds between lock acquisition retries (exponential backoff applied).</p><div class="fullcomment"><div class="comment cmt"><p>Base interval in seconds between lock acquisition retries (exponential backoff applied). Reads from
 spark.ariadne.lockRetryInterval configuration (default: 60).
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -1804,7 +1804,7 @@ spark.ariadne.lockRetryInterval configuration (default: 60).
       <span class="symbol">
         <span class="name">lockTimeout</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Seconds since <code>lastRefreshedAt</code> before a lock is considered stale and eligible for auto-heal (forcible acquisition
 by another process).</p><div class="fullcomment"><div class="comment cmt"><p>Seconds since <code>lastRefreshedAt</code> before a lock is considered stale and eligible for auto-heal (forcible acquisition
 by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default: 1800).
@@ -1823,7 +1823,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">logger</span><span class="result">: <span class="extype" name="org.apache.logging.log4j.Logger">Logger</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Log4j logger shared by all Ariadne components.</p><div class="fullcomment"><div class="comment cmt"><p>Log4j logger shared by all Ariadne components. Uses the &quot;ariadne&quot; logger name. Marked <code>@transient lazy</code> so that
 <code>Index</code> (a case class) remains serializable across Spark stages — Log4j loggers are not <code>Serializable</code>.
 </p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a> → <a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd></dl></div>
@@ -1841,7 +1841,7 @@ by another process). Reads from <code>spark.ariadne.lockTimeout</code> (default:
       <span class="symbol">
         <span class="name">mapJoinColumnsToStorage</span><span class="params">(<span name="joinColumns">joinColumns: <span class="extype" name="scala.Seq">Seq</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Predef.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Maps join column names to their corresponding storage column names.</p><div class="fullcomment"><div class="comment cmt"><p>Maps join column names to their corresponding storage column names.</p><p>Bloom filter columns are prefixed with the bloom prefix, range columns are prefixed with &quot;range_&quot;, exploded field
 columns are mapped to their backing array column, and all other columns map to themselves.
 </p></div><dl class="paramcmts block"><dt class="param">joinColumns</dt><dd class="cmt"><p>
@@ -1861,7 +1861,7 @@ columns are mapped to their backing array column, and all other columns map to t
       <span class="symbol">
         <span class="name">maybeAutoCompact</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Triggers compaction if the auto-compact threshold has been reached.</p><div class="fullcomment"><div class="comment cmt"><p>Triggers compaction if the auto-compact threshold has been reached.</p><p>Checks the <a href="IndexBuildOperations.html#batchesSinceCompact:Int" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#batchesSinceCompact">batchesSinceCompact</a> counter against the configured <code>autoCompactThreshold</code>. If the threshold is met,
 compacts all Delta tables and resets the counter to zero. The counter is persisted to metadata so it survives
 across Spark jobs.
@@ -1880,7 +1880,7 @@ across Spark jobs.
       <span class="symbol">
         <span class="name">maybeRepartition</span><span class="params">(<span name="df">df: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>)</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Conditionally repartitions a DataFrame if indexRepartitionCount is configured.</p><div class="fullcomment"><div class="comment cmt"><p>Conditionally repartitions a DataFrame if indexRepartitionCount is configured. This helps avoid
 FetchFailedExceptions when working with very large index DataFrames by spreading data across more partitions before
 expensive operations like explode.
@@ -1901,7 +1901,7 @@ expensive operations like explode.
       <span class="symbol">
         <span class="name">metadataExists</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks if metadata exists in the storage location.</p><div class="fullcomment"><div class="comment cmt"><p>Checks if metadata exists in the storage location.</p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   True if metadata exists, otherwise false.</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadataOperations#metadataFilePath" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -1918,7 +1918,7 @@ expensive operations like explode.
       <span class="symbol">
         <span class="name">metadataFilePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop path for the metadata file.</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop path for the metadata file.</p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   the path to <code>metadata.json</code> under the index storage directory</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#migrateExplodedFieldColumns" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -1935,7 +1935,7 @@ expensive operations like explode.
       <span class="symbol">
         <span class="name">migrateExplodedFieldColumns</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Migrates pre-0.1.1 indexes that stored exploded field columns under <code>array_column</code> names to the current <code>as_column</code>
 naming convention.</p><div class="fullcomment"><div class="comment cmt"><p>Migrates pre-0.1.1 indexes that stored exploded field columns under <code>array_column</code> names to the current <code>as_column</code>
 naming convention.</p><p>Detection: reads the main and staging Delta table schemas and checks whether any
@@ -1957,7 +1957,7 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -1973,12 +1973,12 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -1994,12 +1994,12 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#open" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="open(path:org.apache.hadoop.fs.Path):org.apache.hadoop.fs.FSDataInputStream"></a><a id="open(Path):FSDataInputStream"></a>
@@ -2015,12 +2015,12 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">open</span><span class="params">(<span name="path">path: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>)</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.FSDataInputStream">FSDataInputStream</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Opens an input stream to read from a path on the filesystem.</p><div class="fullcomment"><div class="comment cmt"><p>Opens an input stream to read from a path on the filesystem.
 </p></div><dl class="paramcmts block"><dt class="param">path</dt><dd class="cmt"><p>
   The Hadoop Path to open for reading</p></dd><dt>returns</dt><dd class="cmt"><p>
-  An FSDataInputStream for reading the file contents</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
-  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  An FSDataInputStream for reading the file contents</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  if path is null</p></span><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the file does not exist or cannot be opened</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#rangeStorageColumns" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="rangeStorageColumns:Set[String]"></a>
@@ -2036,7 +2036,7 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">rangeStorageColumns</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the set of range index storage column names (each prefixed with <code>range_</code>).</p><div class="fullcomment"><div class="comment cmt"><p>Returns the set of range index storage column names (each prefixed with <code>range_</code>).
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   set of prefixed column names (e.g., <code>range_event_date</code>)</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
@@ -2054,10 +2054,10 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">refreshMetadata</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Forces a reload of metadata from the <code>metadata.json</code> file on disk.</p><div class="fullcomment"><div class="comment cmt"><p>Forces a reload of metadata from the <code>metadata.json</code> file on disk.</p><p>Replaces the in-memory cached metadata with a freshly deserialized copy. This is called automatically by
 <span class="extype" name="metadata">metadata</span> on first access; callers may invoke it explicitly to pick up external changes.
-</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="MetadataMissingOrCorruptException"><code>MetadataMissingOrCorruptException</code></span>
+</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="MetadataMissingOrCorruptException"><code>MetadataMissingOrCorruptException</code></span> 
   if the metadata file does not exist, cannot be read, or contains invalid JSON</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#repartitionDataFiles" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="repartitionDataFiles:Boolean"></a>
@@ -2073,7 +2073,7 @@ pattern is found, each table is rewritten with renamed columns, and any large-in
       <span class="symbol">
         <span class="name">repartitionDataFiles</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">When true, applies indexRepartitionCount repartitioning to the data files read during joinDf.</p><div class="fullcomment"><div class="comment cmt"><p>When true, applies indexRepartitionCount repartitioning to the data files read during joinDf. When false, data
 files keep their natural parquet partitioning. Disable when column selection significantly reduces data volume,
 making the repartition shuffle more expensive than useful. Reads from spark.ariadne.repartitionDataFiles
@@ -2093,7 +2093,7 @@ configuration (default: false).
       <span class="symbol">
         <span class="name">requireNonReservedStagingColumn</span><span class="params">(<span name="column">column: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.AriadneContextUser#safeDestroyBroadcast" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="safeDestroyBroadcast(broadcast:org.apache.spark.broadcast.Broadcast[_]):Unit"></a><a id="safeDestroyBroadcast(Broadcast[_]):Unit"></a>
@@ -2109,7 +2109,7 @@ configuration (default: false).
       <span class="symbol">
         <span class="name">safeDestroyBroadcast</span><span class="params">(<span name="broadcast">broadcast: <span class="extype" name="org.apache.spark.broadcast.Broadcast">Broadcast</span>[_]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Safely destroys a broadcast variable, logging but swallowing any exception.</p><div class="fullcomment"><div class="comment cmt"><p>Safely destroys a broadcast variable, logging but swallowing any exception.</p><p>Intended for use inside <code>finally</code> blocks where a cleanup failure must not mask the original exception propagating
 out of the <code>try</code> block. Tolerates a null broadcast.
 </p></div><dl class="paramcmts block"><dt class="param">broadcast</dt><dd class="cmt"><p>
@@ -2128,7 +2128,7 @@ out of the <code>try</code> block. Tolerates a null broadcast.
       <span class="symbol">
         <span class="name">stagingConsolidationThreshold</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Number of batches to process before consolidating staged data into the main index.</p><div class="fullcomment"><div class="comment cmt"><p>Number of batches to process before consolidating staged data into the main index. This provides fault tolerance
 for large index builds - if a job fails, work is preserved up to the last consolidation point. Reads from
 spark.ariadne.stagingConsolidationThreshold configuration (default: 50).
@@ -2147,7 +2147,7 @@ spark.ariadne.stagingConsolidationThreshold configuration (default: 50).
       <span class="symbol">
         <span class="name">stagingFilePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Hadoop path for the staging Delta table (<code>{storagePath}/staging/</code>).</p><div class="fullcomment"><div class="comment cmt"><p>Hadoop path for the staging Delta table (<code>{storagePath}/staging/</code>).</p><p>The staging table accumulates batch results during <a href="Index.html#update:Unit" class="extmbr" name="dev.cjfravel.ariadne.Index#update">update</a> and is merged into the main index by
 <a href="IndexBuildOperations.html#consolidateStaging():Unit" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#consolidateStaging">consolidateStaging</a>.
 </p></div><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></dd></dl></div>
@@ -2165,7 +2165,7 @@ spark.ariadne.stagingConsolidationThreshold configuration (default: 50).
       <span class="symbol">
         <span class="name">stats</span><span class="params">()</span><span class="result">: <a href="../../../org/apache/spark/sql/index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns a DataFrame of per-column index statistics and total file count.</p><div class="fullcomment"><div class="comment cmt"><p>Returns a DataFrame of per-column index statistics and total file count.</p><p>For each indexed column, computes statistics on the array length (number of distinct values per file): min, max,
 avg, median, and standard deviation. Also includes the total number of indexed files.</p><p>Returns an empty DataFrame if no index table exists. If <code>storageColumns</code> is empty (e.g., only bloom or range
 indexes), the result contains zero stat rows.
@@ -2194,7 +2194,7 @@ statsDF.show()
       <span class="symbol">
         <span class="name">storageColumns</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the set of all storage column names across regular, computed, exploded-field, and temporal index types.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the set of all storage column names across regular, computed, exploded-field, and temporal index types.</p><p>This is used internally to determine which columns to check for large-index separation and to build aggregation
 expressions.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
@@ -2213,10 +2213,10 @@ expressions.
       <span class="symbol">
         <span class="name">storagePath</span><span class="result">: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Base path on the Hadoop-compatible filesystem where all Ariadne index data is stored.</p><div class="fullcomment"><div class="comment cmt"><p>Base path on the Hadoop-compatible filesystem where all Ariadne index data is stored. Each index creates a
 subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</code> (required — no default).
-</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if the configuration key is not set</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexFileOperations#storedSchema" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="storedSchema:org.apache.spark.sql.types.StructType"></a><a id="storedSchema:StructType"></a>
@@ -2232,14 +2232,14 @@ subdirectory under this path.</p><p>Reads from <code>spark.ariadne.storagePath</
       <span class="symbol">
         <span class="name">storedSchema</span><span class="result">: <span class="extype" name="org.apache.spark.sql.types.StructType">StructType</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the stored schema of the index.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the stored schema of the index.</p><p>Parses the JSON schema string from metadata into a Spark StructType.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   The StructType schema parsed from metadata</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a></dd><div class="block">Example:
                <ol><li class="cmt"><p></p><pre><span class="kw">val</span> schema = index.storedSchema
 schema.printTreeString()</pre></li></ol>
-            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="SchemaParseException"><code>SchemaParseException</code></span>
-  if the schema string cannot be parsed as a StructType</p></span><span class="cmt"><p><a href="exceptions/MissingSchemaException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.MissingSchemaException"><code>dev.cjfravel.ariadne.exceptions.MissingSchemaException</code></a>
+            </div><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="SchemaParseException"><code>SchemaParseException</code></span> 
+  if the schema string cannot be parsed as a StructType</p></span><span class="cmt"><p><a href="exceptions/MissingSchemaException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.MissingSchemaException"><code>dev.cjfravel.ariadne.exceptions.MissingSchemaException</code></a> 
   if the schema is null in metadata</p></span></dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -2255,7 +2255,7 @@ schema.printTreeString()</pre></li></ol>
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -2271,7 +2271,7 @@ schema.printTreeString()</pre></li></ol>
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexBuildOperations#vacuumDeltaTables" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="vacuumDeltaTables(retentionHours:Int):Unit"></a><a id="vacuumDeltaTables(Int):Unit"></a>
@@ -2287,7 +2287,7 @@ schema.printTreeString()</pre></li></ol>
       <span class="symbol">
         <span class="name">vacuumDeltaTables</span><span class="params">(<span name="retentionHours">retentionHours: <span class="extype" name="scala.Int">Int</span> = <span class="symbol">168</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Vacuums all Delta tables (main index and large index tables) to remove old files.</p><div class="fullcomment"><div class="comment cmt"><p>Vacuums all Delta tables (main index and large index tables) to remove old files.</p><p>Uses Delta Lake's VACUUM command to delete data files no longer referenced by the transaction log. Temporarily
 disables the retention duration safety check when <code>retentionHours</code> is zero or negative.
 </p></div><dl class="paramcmts block"><dt class="param">retentionHours</dt><dd class="cmt"><p>
@@ -2309,13 +2309,13 @@ disables the retention duration safety check when <code>retentionHours</code> is
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -2331,15 +2331,15 @@ disables the retention duration safety check when <code>retentionHours</code> is
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -2355,13 +2355,13 @@ disables the retention duration safety check when <code>retentionHours</code> is
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexMetadataOperations#writeMetadata" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="writeMetadata(metadata:dev.cjfravel.ariadne.IndexMetadata):Unit"></a><a id="writeMetadata(IndexMetadata):Unit"></a>
@@ -2377,19 +2377,19 @@ disables the retention duration safety check when <code>retentionHours</code> is
       <span class="symbol">
         <span class="name">writeMetadata</span><span class="params">(<span name="metadata">metadata: <a href="IndexMetadata.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadata">IndexMetadata</a></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Writes metadata to the <code>metadata.json</code> file and updates the in-memory cache.</p><div class="fullcomment"><div class="comment cmt"><p>Writes metadata to the <code>metadata.json</code> file and updates the in-memory cache.</p><p>Creates the parent directory if it does not exist. JSON is written and validated at a unique sibling path, then
 replaced through Hadoop's overwrite rename operation. The replacement is atomic on filesystems with atomic rename
 semantics (such as HDFS); object-store connectors may implement rename as copy/delete and cannot provide the same
 guarantee.
 </p></div><dl class="paramcmts block"><dt class="param">metadata</dt><dd class="cmt"><p>
-  the metadata instance to serialize and persist</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span>
+  the metadata instance to serialize and persist</p></dd></dl><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd><a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="java.io.IOException"><code>java.io.IOException</code></span> 
   if the write fails (the error is logged before propagating)</p></span></dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -2407,15 +2407,15 @@ guarantee.
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -2439,13 +2439,13 @@ guarantee.
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/IndexSummary.html
+++ b/docs/api/dev/cjfravel/ariadne/IndexSummary.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.IndexSummary" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.IndexSummary" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="catalog/index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -147,7 +147,7 @@
       <span class="symbol">
         <a title="" href="exceptions/index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented3">
                         <span class="separator"></span>
@@ -256,7 +256,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Summary information for a single Ariadne index.</p><p>Captures the index name, data format, all configured index types, tracked file count, and cumulative indexed file
 size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspark:org.apache.spark.sql.SparkSession):dev.cjfravel.ariadne.IndexSummary" class="extmbr" name="dev.cjfravel.ariadne.IndexCatalog#describe">IndexCatalog.describe</a> and <a href="IndexCatalog$.html#describeAll()(implicitspark:org.apache.spark.sql.SparkSession):Seq[dev.cjfravel.ariadne.IndexSummary]" class="extmbr" name="dev.cjfravel.ariadne.IndexCatalog#describeAll">IndexCatalog.describeAll</a>.
 </p></div><dl class="paramcmts block"><dt class="param">name</dt><dd class="cmt"><p>
@@ -276,7 +276,7 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="scala.Serializable">Serializable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.Product">Product</span>, <span class="extype" name="scala.Equals">Equals</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -291,7 +291,7 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -334,7 +334,7 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span class="name">IndexSummary</span><span class="params">(<span name="name">name: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="format">format: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="columns">columns: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="regularIndexes">regularIndexes: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="bloomIndexes">bloomIndexes: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="computedIndexes">computedIndexes: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="temporalIndexes">temporalIndexes: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="rangeIndexes">rangeIndexes: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="explodedFieldIndexes">explodedFieldIndexes: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="fileCount">fileCount: <span class="extype" name="scala.Long">Long</span></span>, <span name="totalIndexedFileSize">totalIndexedFileSize: <span class="extype" name="scala.Long">Long</span></span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">name</dt><dd class="cmt"><p>
   unique index name</p></dd><dt class="param">format</dt><dd class="cmt"><p>
   data file format (e.g., &quot;parquet&quot;, &quot;csv&quot;, &quot;json&quot;)</p></dd><dt class="param">columns</dt><dd class="cmt"><p>
@@ -350,9 +350,9 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -371,7 +371,7 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -387,7 +387,7 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -403,7 +403,7 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -419,7 +419,7 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexSummary#bloomIndexes" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="bloomIndexes:Set[String]"></a>
@@ -435,8 +435,8 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span class="name">bloomIndexes</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
       <span class="permalink">
@@ -451,17 +451,17 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexSummary#columns" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="columns:Set[String]"></a>
@@ -477,8 +477,8 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span class="name">columns</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
-
+      
+      
     </li><li name="dev.cjfravel.ariadne.IndexSummary#computedIndexes" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="computedIndexes:Set[String]"></a>
       <span class="permalink">
@@ -493,8 +493,8 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span class="name">computedIndexes</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
       <span class="permalink">
@@ -509,7 +509,7 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexSummary#explodedFieldIndexes" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="explodedFieldIndexes:Set[String]"></a>
@@ -525,8 +525,8 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span class="name">explodedFieldIndexes</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
-
+      
+      
     </li><li name="dev.cjfravel.ariadne.IndexSummary#fileCount" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="fileCount:Long"></a>
       <span class="permalink">
@@ -541,8 +541,8 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span class="name">fileCount</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
-
+      
+      
     </li><li name="dev.cjfravel.ariadne.IndexSummary#format" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="format:String"></a>
       <span class="permalink">
@@ -557,8 +557,8 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span class="name">format</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
       <span class="permalink">
@@ -573,12 +573,12 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -594,7 +594,7 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexSummary#name" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="name:String"></a>
@@ -610,8 +610,8 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span class="name">name</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
       <span class="permalink">
@@ -626,7 +626,7 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -642,12 +642,12 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -663,12 +663,12 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexSummary#rangeIndexes" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="rangeIndexes:Set[String]"></a>
@@ -684,8 +684,8 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span class="name">rangeIndexes</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
-
+      
+      
     </li><li name="dev.cjfravel.ariadne.IndexSummary#regularIndexes" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="regularIndexes:Set[String]"></a>
       <span class="permalink">
@@ -700,8 +700,8 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span class="name">regularIndexes</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
       <span class="permalink">
@@ -716,7 +716,7 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.IndexSummary#temporalIndexes" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="temporalIndexes:Set[String]"></a>
@@ -732,8 +732,8 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span class="name">temporalIndexes</span><span class="result">: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
-
+      
+      
     </li><li name="dev.cjfravel.ariadne.IndexSummary#totalIndexedFileSize" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="totalIndexedFileSize:Long"></a>
       <span class="permalink">
@@ -748,8 +748,8 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span class="name">totalIndexedFileSize</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
       <span class="permalink">
@@ -764,13 +764,13 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -786,15 +786,15 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -810,19 +810,19 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -840,15 +840,15 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -868,13 +868,13 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/LockInfo.html
+++ b/docs/api/dev/cjfravel/ariadne/LockInfo.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.LockInfo" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.LockInfo" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="catalog/index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -147,7 +147,7 @@
       <span class="symbol">
         <a title="" href="exceptions/index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented3">
                         <span class="separator"></span>
@@ -256,7 +256,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Metadata stored in lock files to track lock ownership and freshness.</p><p>Each lock file is a JSON document containing these fields, serialized via Gson. The <a href="IndexLock.html" class="extype" name="dev.cjfravel.ariadne.IndexLock">IndexLock</a> reads and writes
 <a href="" class="extype" name="dev.cjfravel.ariadne.LockInfo">LockInfo</a> instances to coordinate distributed access to an index.
 </p></div><dl class="paramcmts block"><dt class="param">correlationId</dt><dd class="cmt"><p>
@@ -269,7 +269,7 @@
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="scala.Serializable">Serializable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.Product">Product</span>, <span class="extype" name="scala.Equals">Equals</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -284,7 +284,7 @@
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -327,7 +327,7 @@
       <span class="symbol">
         <span class="name">LockInfo</span><span class="params">(<span name="correlationId">correlationId: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="acquiredAt">acquiredAt: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="lastRefreshedAt">lastRefreshedAt: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="owner">owner: <span class="extype" name="scala.Predef.String">String</span></span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">correlationId</dt><dd class="cmt"><p>
   Unique identifier for the lock holder's operation</p></dd><dt class="param">acquiredAt</dt><dd class="cmt"><p>
   ISO-8601 timestamp when the lock was first acquired</p></dd><dt class="param">lastRefreshedAt</dt><dd class="cmt"><p>
@@ -336,9 +336,9 @@
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -357,7 +357,7 @@
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -373,7 +373,7 @@
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -389,7 +389,7 @@
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.LockInfo#acquiredAt" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="acquiredAt:String"></a>
@@ -405,8 +405,8 @@
       <span class="symbol">
         <span class="name">acquiredAt</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
       <span class="permalink">
@@ -421,7 +421,7 @@
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -437,17 +437,17 @@
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.LockInfo#correlationId" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="correlationId:String"></a>
@@ -463,8 +463,8 @@
       <span class="symbol">
         <span class="name">correlationId</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
       <span class="permalink">
@@ -479,7 +479,7 @@
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -495,12 +495,12 @@
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -516,7 +516,7 @@
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.LockInfo#lastRefreshedAt" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="lastRefreshedAt:String"></a>
@@ -532,8 +532,8 @@
       <span class="symbol">
         <span class="name">lastRefreshedAt</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
       <span class="permalink">
@@ -548,7 +548,7 @@
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -564,12 +564,12 @@
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -585,12 +585,12 @@
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.LockInfo#owner" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="owner:String"></a>
@@ -606,8 +606,8 @@
       <span class="symbol">
         <span class="name">owner</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
       <span class="permalink">
@@ -622,7 +622,7 @@
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -638,13 +638,13 @@
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -660,15 +660,15 @@
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -684,19 +684,19 @@
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -714,15 +714,15 @@
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -742,13 +742,13 @@
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/RangeIndexConfig.html
+++ b/docs/api/dev/cjfravel/ariadne/RangeIndexConfig.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.RangeIndexConfig" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.RangeIndexConfig" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="catalog/index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -147,7 +147,7 @@
       <span class="symbol">
         <a title="" href="exceptions/index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented3">
                         <span class="separator"></span>
@@ -256,7 +256,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Configuration for a range index.</p><p>Range indexes store min/max values per file for a column, enabling file pruning at query time. Files whose [min, max]
 range does not overlap with the queried values are skipped.
 </p></div><dl class="paramcmts block"><dt class="param">column</dt><dd class="cmt"><p>
@@ -266,7 +266,7 @@ range does not overlap with the queried values are skipped.
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="scala.Serializable">Serializable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.Product">Product</span>, <span class="extype" name="scala.Equals">Equals</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -281,7 +281,7 @@ range does not overlap with the queried values are skipped.
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -324,15 +324,15 @@ range does not overlap with the queried values are skipped.
       <span class="symbol">
         <span class="name">RangeIndexConfig</span><span class="params">(<span name="column">column: <span class="extype" name="scala.Predef.String">String</span></span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">column</dt><dd class="cmt"><p>
   The column name to create a range index for</p></dd></dl></div>
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -351,7 +351,7 @@ range does not overlap with the queried values are skipped.
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -367,7 +367,7 @@ range does not overlap with the queried values are skipped.
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -383,7 +383,7 @@ range does not overlap with the queried values are skipped.
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -399,7 +399,7 @@ range does not overlap with the queried values are skipped.
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -415,17 +415,17 @@ range does not overlap with the queried values are skipped.
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.RangeIndexConfig#column" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="column:String"></a>
@@ -441,8 +441,8 @@ range does not overlap with the queried values are skipped.
       <span class="symbol">
         <span class="name">column</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
       <span class="permalink">
@@ -457,7 +457,7 @@ range does not overlap with the queried values are skipped.
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -473,12 +473,12 @@ range does not overlap with the queried values are skipped.
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -494,7 +494,7 @@ range does not overlap with the queried values are skipped.
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -510,7 +510,7 @@ range does not overlap with the queried values are skipped.
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -526,12 +526,12 @@ range does not overlap with the queried values are skipped.
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -547,12 +547,12 @@ range does not overlap with the queried values are skipped.
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -568,7 +568,7 @@ range does not overlap with the queried values are skipped.
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -584,13 +584,13 @@ range does not overlap with the queried values are skipped.
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -606,15 +606,15 @@ range does not overlap with the queried values are skipped.
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -630,19 +630,19 @@ range does not overlap with the queried values are skipped.
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -660,15 +660,15 @@ range does not overlap with the queried values are skipped.
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -688,13 +688,13 @@ range does not overlap with the queried values are skipped.
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/SchemaHelper$.html
+++ b/docs/api/dev/cjfravel/ariadne/SchemaHelper$.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.SchemaHelper" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.SchemaHelper" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="catalog/index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -147,7 +147,7 @@
       <span class="symbol">
         <a title="" href="exceptions/index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented3">
                         <span class="separator"></span>
@@ -256,7 +256,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Utility object for Spark schema introspection.</p><p>Provides methods for validating field existence within <span class="extype" name="org.apache.spark.sql.types.StructType">org.apache.spark.sql.types.StructType</span> schemas, including
 support for nested field paths using dot notation. Used throughout Ariadne to validate that indexed columns exist in
 the user-supplied schema before persisting metadata.</p><p><b>Thread safety:</b> All methods are pure functions with no mutable state; safe to call concurrently from any thread.
@@ -266,7 +266,7 @@ the user-supplied schema before persisting metadata.</p><p><b>Thread safety:</b>
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -281,7 +281,7 @@ the user-supplied schema before persisting metadata.</p><p><b>Thread safety:</b>
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -308,11 +308,11 @@ the user-supplied schema before persisting metadata.</p><p><b>Thread safety:</b>
 
       <div id="template">
         <div id="allMembers">
+        
 
+        
 
-
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -331,7 +331,7 @@ the user-supplied schema before persisting metadata.</p><p><b>Thread safety:</b>
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -347,7 +347,7 @@ the user-supplied schema before persisting metadata.</p><p><b>Thread safety:</b>
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -363,7 +363,7 @@ the user-supplied schema before persisting metadata.</p><p><b>Thread safety:</b>
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -379,7 +379,7 @@ the user-supplied schema before persisting metadata.</p><p><b>Thread safety:</b>
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -395,17 +395,17 @@ the user-supplied schema before persisting metadata.</p><p><b>Thread safety:</b>
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -421,7 +421,7 @@ the user-supplied schema before persisting metadata.</p><p><b>Thread safety:</b>
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -437,7 +437,7 @@ the user-supplied schema before persisting metadata.</p><p><b>Thread safety:</b>
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.SchemaHelper#fieldExists" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="fieldExists(schema:org.apache.spark.sql.types.StructType,fieldName:String):Boolean"></a><a id="fieldExists(StructType,String):Boolean"></a>
@@ -453,14 +453,14 @@ the user-supplied schema before persisting metadata.</p><p><b>Thread safety:</b>
       <span class="symbol">
         <span class="name">fieldExists</span><span class="params">(<span name="schema">schema: <span class="extype" name="org.apache.spark.sql.types.StructType">StructType</span></span>, <span name="fieldName">fieldName: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks whether a field exists in the given schema, supporting nested paths.</p><div class="fullcomment"><div class="comment cmt"><p>Checks whether a field exists in the given schema, supporting nested paths.</p><p>Supports dot-separated field paths for nested struct navigation (e.g., <code>&quot;address.city&quot;</code> looks for a <code>city</code> field
 inside an <code>address</code> struct). Only direct <code>StructType</code> nesting is traversed — <code>ArrayType</code> elements are <i>not</i>
 descended into.
 </p></div><dl class="paramcmts block"><dt class="param">schema</dt><dd class="cmt"><p>
   The root <code>StructType</code> schema to search. Must not be null.</p></dd><dt class="param">fieldName</dt><dd class="cmt"><p>
   A field name or dot-separated path (e.g., <code>&quot;user.profile.id&quot;</code>). Must not be null or blank.</p></dd><dt>returns</dt><dd class="cmt"><p>
-  <code>true</code> if the field exists at the specified path, <code>false</code> otherwise</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+  <code>true</code> if the field exists at the specified path, <code>false</code> otherwise</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if schema is null or fieldName is null/blank</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.SchemaHelper#fieldType" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="fieldType(schema:org.apache.spark.sql.types.StructType,fieldName:String):Option[org.apache.spark.sql.types.DataType]"></a><a id="fieldType(StructType,String):Option[DataType]"></a>
@@ -476,12 +476,12 @@ descended into.
       <span class="symbol">
         <span class="name">fieldType</span><span class="params">(<span name="schema">schema: <span class="extype" name="org.apache.spark.sql.types.StructType">StructType</span></span>, <span name="fieldName">fieldName: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Option">Option</span>[<span class="extype" name="org.apache.spark.sql.types.DataType">DataType</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the data type of a top-level field in the schema.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the data type of a top-level field in the schema.
 </p></div><dl class="paramcmts block"><dt class="param">schema</dt><dd class="cmt"><p>
   The root <code>StructType</code> schema to search. Must not be null.</p></dd><dt class="param">fieldName</dt><dd class="cmt"><p>
   The top-level field name to look up. Must not be null or blank.</p></dd><dt>returns</dt><dd class="cmt"><p>
-  <code>Some(dataType)</code> if the field exists, <code>None</code> otherwise</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span>
+  <code>Some(dataType)</code> if the field exists, <code>None</code> otherwise</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if schema is null or fieldName is null/blank</p></span></dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -497,12 +497,12 @@ descended into.
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -518,12 +518,12 @@ descended into.
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -539,7 +539,7 @@ descended into.
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -555,7 +555,7 @@ descended into.
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -571,12 +571,12 @@ descended into.
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -592,12 +592,12 @@ descended into.
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -613,7 +613,7 @@ descended into.
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -629,7 +629,7 @@ descended into.
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -645,13 +645,13 @@ descended into.
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -667,15 +667,15 @@ descended into.
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -691,19 +691,19 @@ descended into.
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -721,15 +721,15 @@ descended into.
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -741,13 +741,13 @@ descended into.
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/TemporalIndexConfig.html
+++ b/docs/api/dev/cjfravel/ariadne/TemporalIndexConfig.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.TemporalIndexConfig" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.TemporalIndexConfig" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="catalog/index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -147,7 +147,7 @@
       <span class="symbol">
         <a title="" href="exceptions/index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented3">
                         <span class="separator"></span>
@@ -256,7 +256,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Configuration for a temporal index.</p><p>Temporal indexes track entity versions across files. When joining on the value column, only the row with the latest
 timestamp is returned, effectively deduplicating across files by recency.
 </p></div><dl class="paramcmts block"><dt class="param">column</dt><dd class="cmt"><p>
@@ -267,7 +267,7 @@ timestamp is returned, effectively deduplicating across files by recency.
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="scala.Serializable">Serializable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.Product">Product</span>, <span class="extype" name="scala.Equals">Equals</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -282,7 +282,7 @@ timestamp is returned, effectively deduplicating across files by recency.
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -325,16 +325,16 @@ timestamp is returned, effectively deduplicating across files by recency.
       <span class="symbol">
         <span class="name">TemporalIndexConfig</span><span class="params">(<span name="column">column: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="timestamp_column">timestamp_column: <span class="extype" name="scala.Predef.String">String</span></span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">column</dt><dd class="cmt"><p>
   The value column to index and deduplicate on (e.g., &quot;user_id&quot;)</p></dd><dt class="param">timestamp_column</dt><dd class="cmt"><p>
   The timestamp column used to determine recency (e.g., &quot;updated_at&quot;)</p></dd></dl></div>
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -353,7 +353,7 @@ timestamp is returned, effectively deduplicating across files by recency.
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -369,7 +369,7 @@ timestamp is returned, effectively deduplicating across files by recency.
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -385,7 +385,7 @@ timestamp is returned, effectively deduplicating across files by recency.
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -401,7 +401,7 @@ timestamp is returned, effectively deduplicating across files by recency.
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -417,17 +417,17 @@ timestamp is returned, effectively deduplicating across files by recency.
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.TemporalIndexConfig#column" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="column:String"></a>
@@ -443,8 +443,8 @@ timestamp is returned, effectively deduplicating across files by recency.
       <span class="symbol">
         <span class="name">column</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
       <span class="permalink">
@@ -459,7 +459,7 @@ timestamp is returned, effectively deduplicating across files by recency.
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -475,12 +475,12 @@ timestamp is returned, effectively deduplicating across files by recency.
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -496,7 +496,7 @@ timestamp is returned, effectively deduplicating across files by recency.
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -512,7 +512,7 @@ timestamp is returned, effectively deduplicating across files by recency.
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -528,12 +528,12 @@ timestamp is returned, effectively deduplicating across files by recency.
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -549,12 +549,12 @@ timestamp is returned, effectively deduplicating across files by recency.
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -570,7 +570,7 @@ timestamp is returned, effectively deduplicating across files by recency.
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.TemporalIndexConfig#timestamp_column" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="timestamp_column:String"></a>
@@ -586,8 +586,8 @@ timestamp is returned, effectively deduplicating across files by recency.
       <span class="symbol">
         <span class="name">timestamp_column</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
       <span class="permalink">
@@ -602,13 +602,13 @@ timestamp is returned, effectively deduplicating across files by recency.
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -624,15 +624,15 @@ timestamp is returned, effectively deduplicating across files by recency.
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -648,19 +648,19 @@ timestamp is returned, effectively deduplicating across files by recency.
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -678,15 +678,15 @@ timestamp is returned, effectively deduplicating across files by recency.
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -706,13 +706,13 @@ timestamp is returned, effectively deduplicating across files by recency.
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/catalog/AriadneBaseRelation.html
+++ b/docs/api/dev/cjfravel/ariadne/catalog/AriadneBaseRelation.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.catalog.AriadneBaseRelation" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.catalog.AriadneBaseRelation" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -188,7 +188,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>BaseRelation that reads Ariadne index source data files.</p><p>Delegates to Spark's built-in format readers (CSV, Parquet, JSON) using <code>spark.read</code>. Applies computed indexes and
 exploded field transformations from the index metadata.</p><p>Extends both <code>TableScan</code> and <code>PrunedFilteredScan</code>. Spark prefers
 <code>PrunedFilteredScan.buildScan(requiredColumns, filters)</code> when available, falling back to <code>TableScan.buildScan()</code> only
@@ -199,7 +199,7 @@ if column pruning is not needed.</p><p><b>Thread safety:</b> Instances are creat
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="org.apache.spark.sql.sources.PrunedFilteredScan">PrunedFilteredScan</span>, <span class="extype" name="org.apache.spark.sql.sources.TableScan">TableScan</span>, <span class="extype" name="org.apache.spark.sql.sources.BaseRelation">BaseRelation</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -214,7 +214,7 @@ if column pruning is not needed.</p><p><b>Thread safety:</b> Instances are creat
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -257,7 +257,7 @@ if column pruning is not needed.</p><p><b>Thread safety:</b> Instances are creat
       <span class="symbol">
         <span class="name">AriadneBaseRelation</span><span class="params">(<span name="sqlContext">sqlContext: <span class="extype" name="org.apache.spark.sql.SQLContext">SQLContext</span></span>, <span name="indexName">indexName: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="sourceSchema">sourceSchema: <span class="extype" name="org.apache.spark.sql.types.StructType">StructType</span></span>, <span name="metadata">metadata: <a href="../IndexMetadata.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadata">IndexMetadata</a></span>, <span name="files">files: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">indexName</dt><dd class="cmt"><p>
   the Ariadne index name</p></dd><dt class="param">sourceSchema</dt><dd class="cmt"><p>
   the source data schema</p></dd><dt class="param">metadata</dt><dd class="cmt"><p>
@@ -266,9 +266,9 @@ if column pruning is not needed.</p><p><b>Thread safety:</b> Instances are creat
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -287,7 +287,7 @@ if column pruning is not needed.</p><p><b>Thread safety:</b> Instances are creat
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -303,7 +303,7 @@ if column pruning is not needed.</p><p><b>Thread safety:</b> Instances are creat
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -319,7 +319,7 @@ if column pruning is not needed.</p><p><b>Thread safety:</b> Instances are creat
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -335,7 +335,7 @@ if column pruning is not needed.</p><p><b>Thread safety:</b> Instances are creat
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneBaseRelation#buildScan" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="buildScan(requiredColumns:Array[String],filters:Array[org.apache.spark.sql.sources.Filter]):org.apache.spark.rdd.RDD[org.apache.spark.sql.Row]"></a><a id="buildScan(Array[String],Array[Filter]):RDD[Row]"></a>
@@ -351,7 +351,7 @@ if column pruning is not needed.</p><p><b>Thread safety:</b> Instances are creat
       <span class="symbol">
         <span class="name">buildScan</span><span class="params">(<span name="requiredColumns">requiredColumns: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="filters">filters: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="org.apache.spark.sql.sources.Filter">Filter</span>]</span>)</span><span class="result">: <span class="extype" name="org.apache.spark.rdd.RDD">RDD</span>[<span class="extype" name="org.apache.spark.sql.Row">Row</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds an RDD of Rows by reading source data files.</p><div class="fullcomment"><div class="comment cmt"><p>Builds an RDD of Rows by reading source data files.</p><p>Uses <a href="../Index.html" class="extype" name="dev.cjfravel.ariadne.Index">dev.cjfravel.ariadne.Index</a> internally to read files with computed indexes and exploded fields applied,
 then selects only the required columns.
 </p></div><dl class="paramcmts block"><dt class="param">requiredColumns</dt><dd class="cmt"><p>
@@ -372,7 +372,7 @@ then selects only the required columns.
       <span class="symbol">
         <span class="name">buildScan</span><span class="params">()</span><span class="result">: <span class="extype" name="org.apache.spark.rdd.RDD">RDD</span>[<span class="extype" name="org.apache.spark.sql.Row">Row</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Full table scan — reads all source data files.</p><div class="fullcomment"><div class="comment cmt"><p>Full table scan — reads all source data files.</p><p>Used when Spark doesn't push column pruning or filters.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   RDD of source data rows</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneBaseRelation">AriadneBaseRelation</a> → TableScan</dd></dl></div>
@@ -390,17 +390,17 @@ then selects only the required columns.
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -416,7 +416,7 @@ then selects only the required columns.
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -432,7 +432,7 @@ then selects only the required columns.
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -448,12 +448,12 @@ then selects only the required columns.
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -469,12 +469,12 @@ then selects only the required columns.
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -490,7 +490,7 @@ then selects only the required columns.
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -506,7 +506,7 @@ then selects only the required columns.
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="org.apache.spark.sql.sources.BaseRelation#needConversion" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="needConversion:Boolean"></a>
@@ -522,7 +522,7 @@ then selects only the required columns.
       <span class="symbol">
         <span class="name">needConversion</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>BaseRelation</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -538,12 +538,12 @@ then selects only the required columns.
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -559,12 +559,12 @@ then selects only the required columns.
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneBaseRelation#schema" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="schema:org.apache.spark.sql.types.StructType"></a><a id="schema:StructType"></a>
@@ -580,7 +580,7 @@ then selects only the required columns.
       <span class="symbol">
         <span class="name">schema</span><span class="result">: <span class="extype" name="org.apache.spark.sql.types.StructType">StructType</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the source data schema.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the source data schema.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   the schema of the original source data files</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneBaseRelation">AriadneBaseRelation</a> → BaseRelation</dd></dl></div>
@@ -598,7 +598,7 @@ then selects only the required columns.
       <span class="symbol">
         <span class="name">sizeInBytes</span><span class="result">: <span class="extype" name="scala.Long">Long</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>BaseRelation</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneBaseRelation#sqlContext" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="sqlContext:org.apache.spark.sql.SQLContext"></a><a id="sqlContext:SQLContext"></a>
@@ -614,7 +614,7 @@ then selects only the required columns.
       <span class="symbol">
         <span class="name">sqlContext</span><span class="result">: <span class="extype" name="org.apache.spark.sql.SQLContext">SQLContext</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneBaseRelation">AriadneBaseRelation</a> → BaseRelation</dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -630,7 +630,7 @@ then selects only the required columns.
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -646,7 +646,7 @@ then selects only the required columns.
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="org.apache.spark.sql.sources.BaseRelation#unhandledFilters" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="unhandledFilters(filters:Array[org.apache.spark.sql.sources.Filter]):Array[org.apache.spark.sql.sources.Filter]"></a><a id="unhandledFilters(Array[Filter]):Array[Filter]"></a>
@@ -662,7 +662,7 @@ then selects only the required columns.
       <span class="symbol">
         <span class="name">unhandledFilters</span><span class="params">(<span name="filters">filters: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="org.apache.spark.sql.sources.Filter">Filter</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="org.apache.spark.sql.sources.Filter">Filter</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>BaseRelation</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -678,13 +678,13 @@ then selects only the required columns.
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -700,15 +700,15 @@ then selects only the required columns.
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -724,19 +724,19 @@ then selects only the required columns.
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -754,15 +754,15 @@ then selects only the required columns.
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -780,13 +780,13 @@ then selects only the required columns.
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/catalog/AriadneCatalog.html
+++ b/docs/api/dev/cjfravel/ariadne/catalog/AriadneCatalog.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.catalog.AriadneCatalog" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.catalog.AriadneCatalog" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -188,7 +188,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Spark V2 catalog plugin that exposes Ariadne indexes as SQL tables.</p><p>All indexes under <code>spark.ariadne.storagePath</code> are automatically discovered and exposed under a single <code>default</code>
 namespace. Users reference indexes as <code>{catalogName}.{indexName}</code> (which resolves via the default namespace) or
 explicitly as <code>{catalogName}.default.{indexName}</code>.</p><p><b>Configuration:</b></p><pre>spark.conf.set(<span class="lit">"spark.sql.catalog.ariadne"</span>, <span class="lit">"dev.cjfravel.ariadne.catalog.AriadneCatalog"</span>)</pre><p><b>SQL usage:</b></p><pre>SHOW TABLES IN ariadne;
@@ -206,7 +206,7 @@ initialization.
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="org.apache.spark.sql.connector.catalog.SupportsNamespaces">SupportsNamespaces</span>, <span class="extype" name="org.apache.spark.sql.connector.catalog.TableCatalog">TableCatalog</span>, <span class="extype" name="org.apache.spark.sql.connector.catalog.CatalogPlugin">CatalogPlugin</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -221,7 +221,7 @@ initialization.
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -264,12 +264,12 @@ initialization.
       <span class="symbol">
         <span class="name">AriadneCatalog</span><span class="params">()</span>
       </span>
-
-
+      
+      
     </li></ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Abstract Value Members</h3>
@@ -287,15 +287,15 @@ initialization.
       <span class="symbol">
         <span class="name">alterNamespace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.String">String</span>]</span>, <span name="arg1">arg1: <span class="extype" name="scala.&lt;repeated...&gt;">&lt;repeated...&gt;</span>[<span class="extype" name="org.apache.spark.sql.connector.catalog.NamespaceChange">NamespaceChange</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>SupportsNamespaces</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@transient</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="org.apache.spark.sql.connector.catalog.TableCatalog#alterTable" visbl="pub" class="indented0 " data-isabs="true" fullComment="yes" group="Ungrouped">
       <a id="alterTable(x$1:org.apache.spark.sql.connector.catalog.Identifier,x$2:org.apache.spark.sql.connector.catalog.TableChange*):org.apache.spark.sql.connector.catalog.Table"></a><a id="alterTable(Identifier,&lt;repeated...&gt;[TableChange]):Table"></a>
@@ -311,15 +311,15 @@ initialization.
       <span class="symbol">
         <span class="name">alterTable</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="org.apache.spark.sql.connector.catalog.Identifier">Identifier</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.&lt;repeated...&gt;">&lt;repeated...&gt;</span>[<span class="extype" name="org.apache.spark.sql.connector.catalog.TableChange">TableChange</span>]</span>)</span><span class="result">: <span class="extype" name="org.apache.spark.sql.connector.catalog.Table">Table</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>TableCatalog</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[org.apache.spark.sql.catalyst.analysis.NoSuchTableException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@transient</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li></ol>
             </div>
@@ -341,7 +341,7 @@ initialization.
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -357,7 +357,7 @@ initialization.
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -373,7 +373,7 @@ initialization.
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneCatalog#alterNamespace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="alterNamespace(namespace:Array[String],changes:org.apache.spark.sql.connector.catalog.NamespaceChange*):Unit"></a><a id="alterNamespace(Array[String],NamespaceChange*):Unit"></a>
@@ -389,9 +389,9 @@ initialization.
       <span class="symbol">
         <span class="name">alterNamespace</span><span class="params">(<span name="namespace">namespace: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="changes">changes: <span class="extype" name="org.apache.spark.sql.connector.catalog.NamespaceChange">NamespaceChange</span>*</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Not supported — always throws.</p><div class="fullcomment"><div class="comment cmt"><p>Not supported — always throws.</p><p>Ariadne has a single <code>default</code> namespace.
-</p></div><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="UnsupportedOperationException"><code>UnsupportedOperationException</code></span>
+</p></div><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="UnsupportedOperationException"><code>UnsupportedOperationException</code></span> 
   always</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneCatalog#alterTable" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="alterTable(ident:org.apache.spark.sql.connector.catalog.Identifier,changes:org.apache.spark.sql.connector.catalog.TableChange*):org.apache.spark.sql.connector.catalog.Table"></a><a id="alterTable(Identifier,TableChange*):Table"></a>
@@ -407,9 +407,9 @@ initialization.
       <span class="symbol">
         <span class="name">alterTable</span><span class="params">(<span name="ident">ident: <span class="extype" name="org.apache.spark.sql.connector.catalog.Identifier">Identifier</span></span>, <span name="changes">changes: <span class="extype" name="org.apache.spark.sql.connector.catalog.TableChange">TableChange</span>*</span>)</span><span class="result">: <span class="extype" name="org.apache.spark.sql.connector.catalog.Table">Table</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Not supported — always throws.</p><div class="fullcomment"><div class="comment cmt"><p>Not supported — always throws.</p><p>Use the <a href="../Index.html" class="extype" name="dev.cjfravel.ariadne.Index">dev.cjfravel.ariadne.Index</a> API to modify indexes.
-</p></div><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="UnsupportedOperationException"><code>UnsupportedOperationException</code></span>
+</p></div><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="UnsupportedOperationException"><code>UnsupportedOperationException</code></span> 
   always</p></span></dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -425,7 +425,7 @@ initialization.
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="org.apache.spark.sql.connector.catalog.TableCatalog#capabilities" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="capabilities():java.util.Set[org.apache.spark.sql.connector.catalog.TableCatalogCapability]"></a><a id="capabilities():Set[TableCatalogCapability]"></a>
@@ -441,7 +441,7 @@ initialization.
       <span class="symbol">
         <span class="name">capabilities</span><span class="params">()</span><span class="result">: <span class="extype" name="java.util.Set">Set</span>[<span class="extype" name="org.apache.spark.sql.connector.catalog.TableCatalogCapability">TableCatalogCapability</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>TableCatalog</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -457,17 +457,17 @@ initialization.
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneCatalog#createNamespace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="createNamespace(namespace:Array[String],metadata:java.util.Map[String,String]):Unit"></a><a id="createNamespace(Array[String],Map[String,String]):Unit"></a>
@@ -483,9 +483,9 @@ initialization.
       <span class="symbol">
         <span class="name">createNamespace</span><span class="params">(<span name="namespace">namespace: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="metadata">metadata: <span class="extype" name="java.util.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Not supported — always throws.</p><div class="fullcomment"><div class="comment cmt"><p>Not supported — always throws.</p><p>Ariadne has a single <code>default</code> namespace.
-</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneCatalog">AriadneCatalog</a> → SupportsNamespaces</dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="UnsupportedOperationException"><code>UnsupportedOperationException</code></span>
+</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneCatalog">AriadneCatalog</a> → SupportsNamespaces</dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="UnsupportedOperationException"><code>UnsupportedOperationException</code></span> 
   always</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneCatalog#createTable" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="createTable(ident:org.apache.spark.sql.connector.catalog.Identifier,schema:org.apache.spark.sql.types.StructType,partitions:Array[org.apache.spark.sql.connector.expressions.Transform],properties:java.util.Map[String,String]):org.apache.spark.sql.connector.catalog.Table"></a><a id="createTable(Identifier,StructType,Array[Transform],Map[String,String]):Table"></a>
@@ -501,9 +501,9 @@ initialization.
       <span class="symbol">
         <span class="name">createTable</span><span class="params">(<span name="ident">ident: <span class="extype" name="org.apache.spark.sql.connector.catalog.Identifier">Identifier</span></span>, <span name="schema">schema: <span class="extype" name="org.apache.spark.sql.types.StructType">StructType</span></span>, <span name="partitions">partitions: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="org.apache.spark.sql.connector.expressions.Transform">Transform</span>]</span>, <span name="properties">properties: <span class="extype" name="java.util.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <span class="extype" name="org.apache.spark.sql.connector.catalog.Table">Table</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Not supported — always throws.</p><div class="fullcomment"><div class="comment cmt"><p>Not supported — always throws.</p><p>Use <a href="../Index$.html#apply(name:String,schema:Option[org.apache.spark.sql.types.StructType],format:Option[String],allowSchemaMismatch:Boolean,readOptions:Option[Map[String,String]])(implicitspark:org.apache.spark.sql.SparkSession):dev.cjfravel.ariadne.Index" class="extmbr" name="dev.cjfravel.ariadne.Index#apply">dev.cjfravel.ariadne.Index.apply</a> to create indexes.
-</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneCatalog">AriadneCatalog</a> → TableCatalog</dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="UnsupportedOperationException"><code>UnsupportedOperationException</code></span>
+</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneCatalog">AriadneCatalog</a> → TableCatalog</dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="UnsupportedOperationException"><code>UnsupportedOperationException</code></span> 
   always</p></span></dd></dl></div>
     </li><li name="org.apache.spark.sql.connector.catalog.TableCatalog#createTable" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="createTable(x$1:org.apache.spark.sql.connector.catalog.Identifier,x$2:Array[org.apache.spark.sql.connector.catalog.Column],x$3:Array[org.apache.spark.sql.connector.expressions.Transform],x$4:java.util.Map[String,String]):org.apache.spark.sql.connector.catalog.Table"></a><a id="createTable(Identifier,Array[Column],Array[Transform],Map[String,String]):Table"></a>
@@ -519,18 +519,18 @@ initialization.
       <span class="symbol">
         <span class="name">createTable</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="org.apache.spark.sql.connector.catalog.Identifier">Identifier</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="org.apache.spark.sql.connector.catalog.Column">Column</span>]</span>, <span name="arg2">arg2: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="org.apache.spark.sql.connector.expressions.Transform">Transform</span>]</span>, <span name="arg3">arg3: <span class="extype" name="java.util.Map">Map</span>[<span class="extype" name="java.lang.String">String</span>, <span class="extype" name="java.lang.String">String</span>]</span>)</span><span class="result">: <span class="extype" name="org.apache.spark.sql.connector.catalog.Table">Table</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>TableCatalog</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneCatalog#defaultNamespace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="defaultNamespace():Array[String]"></a>
@@ -546,7 +546,7 @@ initialization.
       <span class="symbol">
         <span class="name">defaultNamespace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns <code>Array(&quot;default&quot;)</code> as the default namespace.</p><div class="fullcomment"><div class="comment cmt"><p>Returns <code>Array(&quot;default&quot;)</code> as the default namespace.</p><p>This follows Spark conventions (Delta, Iceberg) so that <code>ariadne.customers</code> resolves to <code>ariadne.default.customers</code>
 and <code>SHOW TABLES IN ariadne</code> displays <code>default</code> in the namespace column.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
@@ -565,9 +565,9 @@ and <code>SHOW TABLES IN ariadne</code> displays <code>default</code> in the nam
       <span class="symbol">
         <span class="name">dropNamespace</span><span class="params">(<span name="namespace">namespace: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="cascade">cascade: <span class="extype" name="scala.Boolean">Boolean</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Not supported — always throws.</p><div class="fullcomment"><div class="comment cmt"><p>Not supported — always throws.</p><p>Ariadne has a single <code>default</code> namespace.
-</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneCatalog">AriadneCatalog</a> → SupportsNamespaces</dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="UnsupportedOperationException"><code>UnsupportedOperationException</code></span>
+</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneCatalog">AriadneCatalog</a> → SupportsNamespaces</dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="UnsupportedOperationException"><code>UnsupportedOperationException</code></span> 
   always</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneCatalog#dropTable" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dropTable(ident:org.apache.spark.sql.connector.catalog.Identifier):Boolean"></a><a id="dropTable(Identifier):Boolean"></a>
@@ -583,9 +583,9 @@ and <code>SHOW TABLES IN ariadne</code> displays <code>default</code> in the nam
       <span class="symbol">
         <span class="name">dropTable</span><span class="params">(<span name="ident">ident: <span class="extype" name="org.apache.spark.sql.connector.catalog.Identifier">Identifier</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Not supported — always throws.</p><div class="fullcomment"><div class="comment cmt"><p>Not supported — always throws.</p><p>Use <a href="../Index$.html#remove(name:String)(implicitspark:org.apache.spark.sql.SparkSession):Boolean" class="extmbr" name="dev.cjfravel.ariadne.Index#remove">dev.cjfravel.ariadne.Index.remove</a> to delete indexes.
-</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneCatalog">AriadneCatalog</a> → TableCatalog</dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="UnsupportedOperationException"><code>UnsupportedOperationException</code></span>
+</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneCatalog">AriadneCatalog</a> → TableCatalog</dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="UnsupportedOperationException"><code>UnsupportedOperationException</code></span> 
   always</p></span></dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -601,7 +601,7 @@ and <code>SHOW TABLES IN ariadne</code> displays <code>default</code> in the nam
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -617,7 +617,7 @@ and <code>SHOW TABLES IN ariadne</code> displays <code>default</code> in the nam
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -633,12 +633,12 @@ and <code>SHOW TABLES IN ariadne</code> displays <code>default</code> in the nam
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -654,12 +654,12 @@ and <code>SHOW TABLES IN ariadne</code> displays <code>default</code> in the nam
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneCatalog#initialize" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="initialize(name:String,options:org.apache.spark.sql.util.CaseInsensitiveStringMap):Unit"></a><a id="initialize(String,CaseInsensitiveStringMap):Unit"></a>
@@ -675,7 +675,7 @@ and <code>SHOW TABLES IN ariadne</code> displays <code>default</code> in the nam
       <span class="symbol">
         <span class="name">initialize</span><span class="params">(<span name="name">name: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="options">options: <span class="extype" name="org.apache.spark.sql.util.CaseInsensitiveStringMap">CaseInsensitiveStringMap</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Initializes the catalog with the name assigned in the Spark configuration.</p><div class="fullcomment"><div class="comment cmt"><p>Initializes the catalog with the name assigned in the Spark configuration.</p><p>Called once by Spark when the catalog is first accessed.
 </p></div><dl class="paramcmts block"><dt class="param">name</dt><dd class="cmt"><p>
   the catalog name from <code>spark.sql.catalog.{name}</code></p></dd><dt class="param">options</dt><dd class="cmt"><p>
@@ -694,7 +694,7 @@ and <code>SHOW TABLES IN ariadne</code> displays <code>default</code> in the nam
       <span class="symbol">
         <span class="name">invalidateTable</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="org.apache.spark.sql.connector.catalog.Identifier">Identifier</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>TableCatalog</dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -710,7 +710,7 @@ and <code>SHOW TABLES IN ariadne</code> displays <code>default</code> in the nam
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneCatalog#listNamespaces" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="listNamespaces(namespace:Array[String]):Array[Array[String]]"></a><a id="listNamespaces(Array[String]):Array[Array[String]]"></a>
@@ -726,11 +726,11 @@ and <code>SHOW TABLES IN ariadne</code> displays <code>default</code> in the nam
       <span class="symbol">
         <span class="name">listNamespaces</span><span class="params">(<span name="namespace">namespace: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Predef.String">String</span>]]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Lists child namespaces under the given namespace.</p><div class="fullcomment"><div class="comment cmt"><p>Lists child namespaces under the given namespace.</p><p>Since Ariadne has a flat namespace structure, this always returns empty.
 </p></div><dl class="paramcmts block"><dt class="param">namespace</dt><dd class="cmt"><p>
   the parent namespace (must be <code>default</code> or empty)</p></dd><dt>returns</dt><dd class="cmt"><p>
-  empty array (no child namespaces)</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneCatalog">AriadneCatalog</a> → SupportsNamespaces</dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException"><code>org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException</code></span>
+  empty array (no child namespaces)</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneCatalog">AriadneCatalog</a> → SupportsNamespaces</dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException"><code>org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException</code></span> 
   if the namespace is not <code>default</code></p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneCatalog#listNamespaces" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="listNamespaces():Array[Array[String]]"></a>
@@ -746,7 +746,7 @@ and <code>SHOW TABLES IN ariadne</code> displays <code>default</code> in the nam
       <span class="symbol">
         <span class="name">listNamespaces</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Predef.String">String</span>]]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Lists available namespaces.</p><div class="fullcomment"><div class="comment cmt"><p>Lists available namespaces. Returns a single <code>&quot;default&quot;</code> namespace.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   array containing one element: <code>Array(&quot;default&quot;)</code></p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneCatalog">AriadneCatalog</a> → SupportsNamespaces</dd></dl></div>
@@ -764,12 +764,12 @@ and <code>SHOW TABLES IN ariadne</code> displays <code>default</code> in the nam
       <span class="symbol">
         <span class="name">listTables</span><span class="params">(<span name="namespace">namespace: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="org.apache.spark.sql.connector.catalog.Identifier">Identifier</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Lists all Ariadne indexes as table identifiers.</p><div class="fullcomment"><div class="comment cmt"><p>Lists all Ariadne indexes as table identifiers.</p><p>Delegates to <span class="extype" name="IndexCatalog.list()">IndexCatalog.list()</span> which scans <code>storagePath/indexes/</code> for directories containing <code>metadata.json</code>.
 All indexes are placed in the <code>default</code> namespace.
 </p></div><dl class="paramcmts block"><dt class="param">namespace</dt><dd class="cmt"><p>
   must be <code>Array(&quot;default&quot;)</code> or empty</p></dd><dt>returns</dt><dd class="cmt"><p>
-  array of identifiers, one per index</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneCatalog">AriadneCatalog</a> → TableCatalog</dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException"><code>org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException</code></span>
+  array of identifiers, one per index</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneCatalog">AriadneCatalog</a> → TableCatalog</dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException"><code>org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException</code></span> 
   if an unrecognized namespace is provided</p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneCatalog#loadNamespaceMetadata" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="loadNamespaceMetadata(namespace:Array[String]):java.util.Map[String,String]"></a><a id="loadNamespaceMetadata(Array[String]):Map[String,String]"></a>
@@ -785,11 +785,11 @@ All indexes are placed in the <code>default</code> namespace.
       <span class="symbol">
         <span class="name">loadNamespaceMetadata</span><span class="params">(<span name="namespace">namespace: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>)</span><span class="result">: <span class="extype" name="java.util.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Predef.String">String</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Loads metadata for the given namespace.</p><div class="fullcomment"><div class="comment cmt"><p>Loads metadata for the given namespace.</p><p>Returns an empty map for the <code>default</code> namespace. Ariadne does not store namespace-level metadata.
 </p></div><dl class="paramcmts block"><dt class="param">namespace</dt><dd class="cmt"><p>
   the namespace to load (must be <code>default</code> or empty)</p></dd><dt>returns</dt><dd class="cmt"><p>
-  empty metadata map</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneCatalog">AriadneCatalog</a> → SupportsNamespaces</dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException"><code>org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException</code></span>
+  empty metadata map</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneCatalog">AriadneCatalog</a> → SupportsNamespaces</dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException"><code>org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException</code></span> 
   if the namespace is not <code>default</code></p></span></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneCatalog#loadTable" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="loadTable(ident:org.apache.spark.sql.connector.catalog.Identifier):org.apache.spark.sql.connector.catalog.Table"></a><a id="loadTable(Identifier):Table"></a>
@@ -805,11 +805,11 @@ All indexes are placed in the <code>default</code> namespace.
       <span class="symbol">
         <span class="name">loadTable</span><span class="params">(<span name="ident">ident: <span class="extype" name="org.apache.spark.sql.connector.catalog.Identifier">Identifier</span></span>)</span><span class="result">: <span class="extype" name="org.apache.spark.sql.connector.catalog.Table">Table</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Loads an Ariadne index as a Spark V2 <a href="AriadneTable.html" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneTable">AriadneTable</a>.</p><div class="fullcomment"><div class="comment cmt"><p>Loads an Ariadne index as a Spark V2 <a href="AriadneTable.html" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneTable">AriadneTable</a>.</p><p>Reads the index's metadata to obtain the source data schema, format, and index configuration.
 </p></div><dl class="paramcmts block"><dt class="param">ident</dt><dd class="cmt"><p>
   table identifier (namespace must be <code>default</code> or empty, name is the index name)</p></dd><dt>returns</dt><dd class="cmt"><p>
-  the AriadneTable wrapping this index</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneCatalog">AriadneCatalog</a> → TableCatalog</dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="org.apache.spark.sql.catalyst.analysis.NoSuchTableException"><code>org.apache.spark.sql.catalyst.analysis.NoSuchTableException</code></span>
+  the AriadneTable wrapping this index</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneCatalog">AriadneCatalog</a> → TableCatalog</dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="org.apache.spark.sql.catalyst.analysis.NoSuchTableException"><code>org.apache.spark.sql.catalyst.analysis.NoSuchTableException</code></span> 
   if no index with the given name exists</p></span></dd></dl></div>
     </li><li name="org.apache.spark.sql.connector.catalog.TableCatalog#loadTable" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="loadTable(x$1:org.apache.spark.sql.connector.catalog.Identifier,x$2:Long):org.apache.spark.sql.connector.catalog.Table"></a><a id="loadTable(Identifier,Long):Table"></a>
@@ -825,13 +825,13 @@ All indexes are placed in the <code>default</code> namespace.
       <span class="symbol">
         <span class="name">loadTable</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="org.apache.spark.sql.connector.catalog.Identifier">Identifier</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="org.apache.spark.sql.connector.catalog.Table">Table</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>TableCatalog</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[org.apache.spark.sql.catalyst.analysis.NoSuchTableException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="org.apache.spark.sql.connector.catalog.TableCatalog#loadTable" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="loadTable(x$1:org.apache.spark.sql.connector.catalog.Identifier,x$2:String):org.apache.spark.sql.connector.catalog.Table"></a><a id="loadTable(Identifier,String):Table"></a>
@@ -847,13 +847,13 @@ All indexes are placed in the <code>default</code> namespace.
       <span class="symbol">
         <span class="name">loadTable</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="org.apache.spark.sql.connector.catalog.Identifier">Identifier</span></span>, <span name="arg1">arg1: <span class="extype" name="java.lang.String">String</span></span>)</span><span class="result">: <span class="extype" name="org.apache.spark.sql.connector.catalog.Table">Table</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>TableCatalog</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[org.apache.spark.sql.catalyst.analysis.NoSuchTableException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="org.apache.spark.sql.connector.catalog.TableCatalog#loadTable" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="loadTable(x$1:org.apache.spark.sql.connector.catalog.Identifier,x$2:java.util.Set[org.apache.spark.sql.connector.catalog.TableWritePrivilege]):org.apache.spark.sql.connector.catalog.Table"></a><a id="loadTable(Identifier,Set[TableWritePrivilege]):Table"></a>
@@ -869,13 +869,13 @@ All indexes are placed in the <code>default</code> namespace.
       <span class="symbol">
         <span class="name">loadTable</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="org.apache.spark.sql.connector.catalog.Identifier">Identifier</span></span>, <span name="arg1">arg1: <span class="extype" name="java.util.Set">Set</span>[<span class="extype" name="org.apache.spark.sql.connector.catalog.TableWritePrivilege">TableWritePrivilege</span>]</span>)</span><span class="result">: <span class="extype" name="org.apache.spark.sql.connector.catalog.Table">Table</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>TableCatalog</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[org.apache.spark.sql.catalyst.analysis.NoSuchTableException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneCatalog#name" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="name():String"></a>
@@ -891,7 +891,7 @@ All indexes are placed in the <code>default</code> namespace.
       <span class="symbol">
         <span class="name">name</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the catalog name assigned during initialization.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the catalog name assigned during initialization.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   the catalog name</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneCatalog">AriadneCatalog</a> → CatalogPlugin</dd></dl></div>
@@ -909,7 +909,7 @@ All indexes are placed in the <code>default</code> namespace.
       <span class="symbol">
         <span class="name">namespaceExists</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.String">String</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>SupportsNamespaces</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -925,7 +925,7 @@ All indexes are placed in the <code>default</code> namespace.
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -941,12 +941,12 @@ All indexes are placed in the <code>default</code> namespace.
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -962,12 +962,12 @@ All indexes are placed in the <code>default</code> namespace.
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="org.apache.spark.sql.connector.catalog.TableCatalog#purgeTable" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="purgeTable(x$1:org.apache.spark.sql.connector.catalog.Identifier):Boolean"></a><a id="purgeTable(Identifier):Boolean"></a>
@@ -983,13 +983,13 @@ All indexes are placed in the <code>default</code> namespace.
       <span class="symbol">
         <span class="name">purgeTable</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="org.apache.spark.sql.connector.catalog.Identifier">Identifier</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>TableCatalog</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.UnsupportedOperationException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneCatalog#renameTable" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="renameTable(oldIdent:org.apache.spark.sql.connector.catalog.Identifier,newIdent:org.apache.spark.sql.connector.catalog.Identifier):Unit"></a><a id="renameTable(Identifier,Identifier):Unit"></a>
@@ -1005,9 +1005,9 @@ All indexes are placed in the <code>default</code> namespace.
       <span class="symbol">
         <span class="name">renameTable</span><span class="params">(<span name="oldIdent">oldIdent: <span class="extype" name="org.apache.spark.sql.connector.catalog.Identifier">Identifier</span></span>, <span name="newIdent">newIdent: <span class="extype" name="org.apache.spark.sql.connector.catalog.Identifier">Identifier</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Not supported — always throws.</p><div class="fullcomment"><div class="comment cmt"><p>Not supported — always throws.
-</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneCatalog">AriadneCatalog</a> → TableCatalog</dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="UnsupportedOperationException"><code>UnsupportedOperationException</code></span>
+</p></div><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneCatalog">AriadneCatalog</a> → TableCatalog</dd><dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="UnsupportedOperationException"><code>UnsupportedOperationException</code></span> 
   always</p></span></dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -1023,7 +1023,7 @@ All indexes are placed in the <code>default</code> namespace.
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneCatalog#tableExists" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="tableExists(ident:org.apache.spark.sql.connector.catalog.Identifier):Boolean"></a><a id="tableExists(Identifier):Boolean"></a>
@@ -1039,7 +1039,7 @@ All indexes are placed in the <code>default</code> namespace.
       <span class="symbol">
         <span class="name">tableExists</span><span class="params">(<span name="ident">ident: <span class="extype" name="org.apache.spark.sql.connector.catalog.Identifier">Identifier</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Checks whether an Ariadne index with the given name exists.</p><div class="fullcomment"><div class="comment cmt"><p>Checks whether an Ariadne index with the given name exists.
 </p></div><dl class="paramcmts block"><dt class="param">ident</dt><dd class="cmt"><p>
   table identifier (name is the index name)</p></dd><dt>returns</dt><dd class="cmt"><p>
@@ -1058,7 +1058,7 @@ All indexes are placed in the <code>default</code> namespace.
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="org.apache.spark.sql.connector.catalog.TableCatalog#useNullableQuerySchema" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="useNullableQuerySchema():Boolean"></a>
@@ -1074,7 +1074,7 @@ All indexes are placed in the <code>default</code> namespace.
       <span class="symbol">
         <span class="name">useNullableQuerySchema</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>TableCatalog</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -1090,13 +1090,13 @@ All indexes are placed in the <code>default</code> namespace.
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -1112,15 +1112,15 @@ All indexes are placed in the <code>default</code> namespace.
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -1136,19 +1136,19 @@ All indexes are placed in the <code>default</code> namespace.
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -1166,15 +1166,15 @@ All indexes are placed in the <code>default</code> namespace.
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -1192,13 +1192,13 @@ All indexes are placed in the <code>default</code> namespace.
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/catalog/AriadneJoinRule.html
+++ b/docs/api/dev/cjfravel/ariadne/catalog/AriadneJoinRule.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.catalog.AriadneJoinRule" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.catalog.AriadneJoinRule" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -188,7 +188,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Catalyst optimizer rule that rewrites JOINs involving Ariadne tables.</p><p>When a SQL query joins against an Ariadne catalog table, this rule intercepts the logical plan and replaces the
 Ariadne scan with a pre-pruned read that only includes files matching the join values. The original <code>Join</code> node,
 condition, hints, and ExprIds are all preserved.</p><p><b>Safety constraints (the rule only fires when ALL hold):</b></p><ol class="decimal"><li>The join type is <code>INNER</code> 2. The entire condition is composed of equi-join predicates (<code>a.col = b.col</code>) 3. Every
@@ -213,7 +213,7 @@ each invocation is independent.
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="org.apache.spark.sql.catalyst.rules.Rule">Rule</span>[<span class="extype" name="org.apache.spark.sql.catalyst.plans.logical.LogicalPlan">LogicalPlan</span>], <span class="extype" name="org.apache.spark.internal.Logging">Logging</span>, <span class="extype" name="org.apache.spark.sql.catalyst.SQLConfHelper">SQLConfHelper</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -228,7 +228,7 @@ each invocation is independent.
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -271,15 +271,15 @@ each invocation is independent.
       <span class="symbol">
         <span class="name">AriadneJoinRule</span><span class="params">(<span name="sparkSession">sparkSession: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">sparkSession</dt><dd class="cmt"><p>
   the active SparkSession</p></dd></dl></div>
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -298,7 +298,7 @@ each invocation is independent.
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -314,7 +314,7 @@ each invocation is independent.
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -330,7 +330,7 @@ each invocation is independent.
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneJoinRule#apply" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="apply(plan:org.apache.spark.sql.catalyst.plans.logical.LogicalPlan):org.apache.spark.sql.catalyst.plans.logical.LogicalPlan"></a><a id="apply(LogicalPlan):LogicalPlan"></a>
@@ -346,7 +346,7 @@ each invocation is independent.
       <span class="symbol">
         <span class="name">apply</span><span class="params">(<span name="plan">plan: <span class="extype" name="org.apache.spark.sql.catalyst.plans.logical.LogicalPlan">LogicalPlan</span></span>)</span><span class="result">: <span class="extype" name="org.apache.spark.sql.catalyst.plans.logical.LogicalPlan">LogicalPlan</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Transforms a logical plan by rewriting eligible JOINs involving Ariadne tables.</p><div class="fullcomment"><div class="comment cmt"><p>Transforms a logical plan by rewriting eligible JOINs involving Ariadne tables.</p><p>Uses <code>transformUp</code> to visit each Join node bottom-up. Only rewrites INNER equi-joins where every Ariadne-side
 column is indexed. If the rewrite fails for any reason, the original Join node is returned unchanged and Spark
 falls back to the standard V1Scan path.
@@ -367,7 +367,7 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -383,17 +383,17 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="org.apache.spark.sql.catalyst.SQLConfHelper#conf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="conf:org.apache.spark.sql.internal.SQLConf"></a><a id="conf:SQLConf"></a>
@@ -409,7 +409,7 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">conf</span><span class="result">: <span class="extype" name="org.apache.spark.sql.internal.SQLConf">SQLConf</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>SQLConfHelper</dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -425,7 +425,7 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -441,7 +441,7 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -457,12 +457,12 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -478,12 +478,12 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="org.apache.spark.internal.Logging#initializeLogIfNecessary" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="initializeLogIfNecessary(isInterpreter:Boolean,silent:Boolean):Boolean"></a><a id="initializeLogIfNecessary(Boolean,Boolean):Boolean"></a>
@@ -499,7 +499,7 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">initializeLogIfNecessary</span><span class="params">(<span name="isInterpreter">isInterpreter: <span class="extype" name="scala.Boolean">Boolean</span></span>, <span name="silent">silent: <span class="extype" name="scala.Boolean">Boolean</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd>Logging</dd></dl></div>
     </li><li name="org.apache.spark.internal.Logging#initializeLogIfNecessary" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="initializeLogIfNecessary(isInterpreter:Boolean):Unit"></a><a id="initializeLogIfNecessary(Boolean):Unit"></a>
@@ -515,7 +515,7 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">initializeLogIfNecessary</span><span class="params">(<span name="isInterpreter">isInterpreter: <span class="extype" name="scala.Boolean">Boolean</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd>Logging</dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -531,7 +531,7 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="org.apache.spark.internal.Logging#isTraceEnabled" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isTraceEnabled():Boolean"></a>
@@ -547,7 +547,7 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">isTraceEnabled</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd>Logging</dd></dl></div>
     </li><li name="org.apache.spark.internal.Logging#log" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="log:org.slf4j.Logger"></a><a id="log:Logger"></a>
@@ -563,7 +563,7 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">log</span><span class="result">: <span class="extype" name="org.slf4j.Logger">Logger</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd>Logging</dd></dl></div>
     </li><li name="org.apache.spark.internal.Logging#logDebug" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="logDebug(msg:=&gt;String,throwable:Throwable):Unit"></a><a id="logDebug(⇒String,Throwable):Unit"></a>
@@ -579,7 +579,7 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">logDebug</span><span class="params">(<span name="msg">msg: ⇒ <span class="extype" name="scala.Predef.String">String</span></span>, <span name="throwable">throwable: <span class="extype" name="scala.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd>Logging</dd></dl></div>
     </li><li name="org.apache.spark.internal.Logging#logDebug" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="logDebug(msg:=&gt;String):Unit"></a><a id="logDebug(⇒String):Unit"></a>
@@ -595,7 +595,7 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">logDebug</span><span class="params">(<span name="msg">msg: ⇒ <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd>Logging</dd></dl></div>
     </li><li name="org.apache.spark.internal.Logging#logError" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="logError(msg:=&gt;String,throwable:Throwable):Unit"></a><a id="logError(⇒String,Throwable):Unit"></a>
@@ -611,7 +611,7 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">logError</span><span class="params">(<span name="msg">msg: ⇒ <span class="extype" name="scala.Predef.String">String</span></span>, <span name="throwable">throwable: <span class="extype" name="scala.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd>Logging</dd></dl></div>
     </li><li name="org.apache.spark.internal.Logging#logError" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="logError(msg:=&gt;String):Unit"></a><a id="logError(⇒String):Unit"></a>
@@ -627,7 +627,7 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">logError</span><span class="params">(<span name="msg">msg: ⇒ <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd>Logging</dd></dl></div>
     </li><li name="org.apache.spark.internal.Logging#logInfo" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="logInfo(msg:=&gt;String,throwable:Throwable):Unit"></a><a id="logInfo(⇒String,Throwable):Unit"></a>
@@ -643,7 +643,7 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">logInfo</span><span class="params">(<span name="msg">msg: ⇒ <span class="extype" name="scala.Predef.String">String</span></span>, <span name="throwable">throwable: <span class="extype" name="scala.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd>Logging</dd></dl></div>
     </li><li name="org.apache.spark.internal.Logging#logInfo" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="logInfo(msg:=&gt;String):Unit"></a><a id="logInfo(⇒String):Unit"></a>
@@ -659,7 +659,7 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">logInfo</span><span class="params">(<span name="msg">msg: ⇒ <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd>Logging</dd></dl></div>
     </li><li name="org.apache.spark.internal.Logging#logName" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="logName:String"></a>
@@ -675,7 +675,7 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">logName</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd>Logging</dd></dl></div>
     </li><li name="org.apache.spark.internal.Logging#logTrace" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="logTrace(msg:=&gt;String,throwable:Throwable):Unit"></a><a id="logTrace(⇒String,Throwable):Unit"></a>
@@ -691,7 +691,7 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">logTrace</span><span class="params">(<span name="msg">msg: ⇒ <span class="extype" name="scala.Predef.String">String</span></span>, <span name="throwable">throwable: <span class="extype" name="scala.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd>Logging</dd></dl></div>
     </li><li name="org.apache.spark.internal.Logging#logTrace" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="logTrace(msg:=&gt;String):Unit"></a><a id="logTrace(⇒String):Unit"></a>
@@ -707,7 +707,7 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">logTrace</span><span class="params">(<span name="msg">msg: ⇒ <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd>Logging</dd></dl></div>
     </li><li name="org.apache.spark.internal.Logging#logWarning" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="logWarning(msg:=&gt;String,throwable:Throwable):Unit"></a><a id="logWarning(⇒String,Throwable):Unit"></a>
@@ -723,7 +723,7 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">logWarning</span><span class="params">(<span name="msg">msg: ⇒ <span class="extype" name="scala.Predef.String">String</span></span>, <span name="throwable">throwable: <span class="extype" name="scala.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd>Logging</dd></dl></div>
     </li><li name="org.apache.spark.internal.Logging#logWarning" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="logWarning(msg:=&gt;String):Unit"></a><a id="logWarning(⇒String):Unit"></a>
@@ -739,7 +739,7 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">logWarning</span><span class="params">(<span name="msg">msg: ⇒ <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd>Logging</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -755,7 +755,7 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -771,12 +771,12 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -792,12 +792,12 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="org.apache.spark.sql.catalyst.rules.Rule#ruleId" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ruleId:org.apache.spark.sql.catalyst.rules.RuleId"></a><a id="ruleId:RuleId"></a>
@@ -813,7 +813,7 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">ruleId</span><span class="result">: <span class="extype" name="org.apache.spark.sql.catalyst.rules.RuleId">RuleId</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected </dd><dt>Definition Classes</dt><dd>Rule</dd></dl></div>
     </li><li name="org.apache.spark.sql.catalyst.rules.Rule#ruleName" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ruleName:String"></a>
@@ -829,7 +829,7 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">ruleName</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Rule</dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -845,7 +845,7 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -861,7 +861,7 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -877,13 +877,13 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -899,15 +899,15 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -923,19 +923,19 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -953,15 +953,15 @@ falls back to the standard V1Scan path.
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -979,13 +979,13 @@ falls back to the standard V1Scan path.
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/catalog/AriadneScanBuilder.html
+++ b/docs/api/dev/cjfravel/ariadne/catalog/AriadneScanBuilder.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.catalog.AriadneScanBuilder" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.catalog.AriadneScanBuilder" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -188,7 +188,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Builds a scan for reading Ariadne index source data with filter pushdown.</p><p>Implements <span class="extype" name="SupportsPushDownFilters">SupportsPushDownFilters</span> to convert <code>WHERE</code> clause filters on indexed columns into
 <a href="../IndexQueryOperations.html#locateFiles(indexes:Map[String,Array[Any]]):Set[String]" class="extmbr" name="dev.cjfravel.ariadne.IndexQueryOperations#locateFiles">dev.cjfravel.ariadne.IndexQueryOperations.locateFiles</a> calls, pruning the source file list before reading.</p><p><b>Thread safety:</b> Instances are created per scan by <a href="AriadneTable.html#newScanBuilder(options:org.apache.spark.sql.util.CaseInsensitiveStringMap):org.apache.spark.sql.connector.read.ScanBuilder" class="extmbr" name="dev.cjfravel.ariadne.catalog.AriadneTable#newScanBuilder">AriadneTable.newScanBuilder</a> and are not shared across
 threads.
@@ -199,7 +199,7 @@ threads.
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="org.apache.spark.sql.connector.read.SupportsPushDownFilters">SupportsPushDownFilters</span>, <span class="extype" name="org.apache.spark.sql.connector.read.ScanBuilder">ScanBuilder</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -214,7 +214,7 @@ threads.
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -257,7 +257,7 @@ threads.
       <span class="symbol">
         <span class="name">AriadneScanBuilder</span><span class="params">(<span name="indexName">indexName: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="sourceSchema">sourceSchema: <span class="extype" name="org.apache.spark.sql.types.StructType">StructType</span></span>, <span name="metadata">metadata: <a href="../IndexMetadata.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadata">IndexMetadata</a></span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">indexName</dt><dd class="cmt"><p>
   the Ariadne index name</p></dd><dt class="param">sourceSchema</dt><dd class="cmt"><p>
   the schema of the source data files</p></dd><dt class="param">metadata</dt><dd class="cmt"><p>
@@ -265,9 +265,9 @@ threads.
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -286,7 +286,7 @@ threads.
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -302,7 +302,7 @@ threads.
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -318,7 +318,7 @@ threads.
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -334,7 +334,7 @@ threads.
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneScanBuilder#build" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="build():org.apache.spark.sql.connector.read.Scan"></a><a id="build():Scan"></a>
@@ -350,7 +350,7 @@ threads.
       <span class="symbol">
         <span class="name">build</span><span class="params">()</span><span class="result">: <span class="extype" name="org.apache.spark.sql.connector.read.Scan">Scan</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds a <a href="AriadneV1Scan.html" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneV1Scan">AriadneV1Scan</a> with the current pushed filters.</p><div class="fullcomment"><div class="comment cmt"><p>Builds a <a href="AriadneV1Scan.html" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneV1Scan">AriadneV1Scan</a> with the current pushed filters.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   a new V1-based scan for reading Ariadne source data</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneScanBuilder">AriadneScanBuilder</a> → ScanBuilder</dd></dl></div>
@@ -368,17 +368,17 @@ threads.
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -394,7 +394,7 @@ threads.
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -410,7 +410,7 @@ threads.
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -426,12 +426,12 @@ threads.
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -447,12 +447,12 @@ threads.
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -468,7 +468,7 @@ threads.
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -484,7 +484,7 @@ threads.
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -500,12 +500,12 @@ threads.
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -521,12 +521,12 @@ threads.
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneScanBuilder#pushFilters" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="pushFilters(filters:Array[org.apache.spark.sql.sources.Filter]):Array[org.apache.spark.sql.sources.Filter]"></a><a id="pushFilters(Array[Filter]):Array[Filter]"></a>
@@ -542,7 +542,7 @@ threads.
       <span class="symbol">
         <span class="name">pushFilters</span><span class="params">(<span name="filters">filters: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="org.apache.spark.sql.sources.Filter">Filter</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="org.apache.spark.sql.sources.Filter">Filter</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Pushes filters to the scan for file-level pruning via the index.</p><div class="fullcomment"><div class="comment cmt"><p>Pushes filters to the scan for file-level pruning via the index.</p><p>Filters on indexed columns (<code>EqualTo</code>, <code>In</code>) are accepted and used to call <code>locateFiles()</code> to prune the source file
 list. Filters on non-indexed columns are returned for Spark to apply post-scan.
 </p></div><dl class="paramcmts block"><dt class="param">filters</dt><dd class="cmt"><p>
@@ -562,7 +562,7 @@ list. Filters on non-indexed columns are returned for Spark to apply post-scan.
       <span class="symbol">
         <span class="name">pushedFilters</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="org.apache.spark.sql.sources.Filter">Filter</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the filters that were successfully pushed for file-level pruning.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the filters that were successfully pushed for file-level pruning.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   array of pushed filters</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneScanBuilder">AriadneScanBuilder</a> → SupportsPushDownFilters</dd></dl></div>
@@ -580,7 +580,7 @@ list. Filters on non-indexed columns are returned for Spark to apply post-scan.
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -596,7 +596,7 @@ list. Filters on non-indexed columns are returned for Spark to apply post-scan.
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -612,13 +612,13 @@ list. Filters on non-indexed columns are returned for Spark to apply post-scan.
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -634,15 +634,15 @@ list. Filters on non-indexed columns are returned for Spark to apply post-scan.
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -658,19 +658,19 @@ list. Filters on non-indexed columns are returned for Spark to apply post-scan.
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -688,15 +688,15 @@ list. Filters on non-indexed columns are returned for Spark to apply post-scan.
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -712,13 +712,13 @@ list. Filters on non-indexed columns are returned for Spark to apply post-scan.
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/catalog/AriadneSparkExtension.html
+++ b/docs/api/dev/cjfravel/ariadne/catalog/AriadneSparkExtension.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.catalog.AriadneSparkExtension" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.catalog.AriadneSparkExtension" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -188,7 +188,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Spark session extension that registers the Ariadne JOIN optimization rule.</p><p>When registered, this extension injects the <a href="AriadneJoinRule.html" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneJoinRule">AriadneJoinRule</a> into Spark's optimizer. The rule rewrites JOINs
 involving Ariadne catalog tables to use the optimized file-pruning join path.</p><p><b>Configuration:</b></p><pre>spark.conf.set(<span class="lit">"spark.sql.extensions"</span>,
   <span class="lit">"dev.cjfravel.ariadne.catalog.AriadneSparkExtension"</span>)</pre><p><b>Note:</b> If your Spark session also uses Delta Lake SQL features, append this extension to the existing
@@ -202,7 +202,7 @@ concurrently.
           </span>
           <div class="superTypes hiddenContent">(<span class="extype" name="org.apache.spark.sql.SparkSessionExtensions">SparkSessionExtensions</span>) ⇒ <span class="extype" name="scala.Unit">Unit</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -217,7 +217,7 @@ concurrently.
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -260,14 +260,14 @@ concurrently.
       <span class="symbol">
         <span class="name">AriadneSparkExtension</span><span class="params">()</span>
       </span>
-
-
+      
+      
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -286,7 +286,7 @@ concurrently.
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -302,7 +302,7 @@ concurrently.
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -318,7 +318,7 @@ concurrently.
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.Function1#andThen" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="andThen[A](g:R=&gt;A):T1=&gt;A"></a><a id="andThen[A]((Unit)⇒A):(SparkSessionExtensions)⇒A"></a>
@@ -334,10 +334,10 @@ concurrently.
       <span class="symbol">
         <span class="name">andThen</span><span class="tparams">[<span name="A">A</span>]</span><span class="params">(<span name="g">g: (<span class="extype" name="scala.Unit">Unit</span>) ⇒ <span class="extype" name="scala.Function1.andThen.A">A</span></span>)</span><span class="result">: (<span class="extype" name="org.apache.spark.sql.SparkSessionExtensions">SparkSessionExtensions</span>) ⇒ <span class="extype" name="scala.Function1.andThen.A">A</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Function1</dd><dt>Annotations</dt><dd>
                 <span class="name">@unspecialized</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneSparkExtension#apply" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="apply(extensions:org.apache.spark.sql.SparkSessionExtensions):Unit"></a><a id="apply(SparkSessionExtensions):Unit"></a>
@@ -353,7 +353,7 @@ concurrently.
       <span class="symbol">
         <span class="name">apply</span><span class="params">(<span name="extensions">extensions: <span class="extype" name="org.apache.spark.sql.SparkSessionExtensions">SparkSessionExtensions</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Registers the <a href="AriadneJoinRule.html" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneJoinRule">AriadneJoinRule</a> optimizer rule with the Spark session.</p><div class="fullcomment"><div class="comment cmt"><p>Registers the <a href="AriadneJoinRule.html" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneJoinRule">AriadneJoinRule</a> optimizer rule with the Spark session.
 </p></div><dl class="paramcmts block"><dt class="param">extensions</dt><dd class="cmt"><p>
   the SparkSessionExtensions to inject rules into</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneSparkExtension">AriadneSparkExtension</a> → Function1</dd></dl></div>
@@ -371,7 +371,7 @@ concurrently.
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -387,17 +387,17 @@ concurrently.
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.Function1#compose" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="compose[A](g:A=&gt;T1):A=&gt;R"></a><a id="compose[A]((A)⇒SparkSessionExtensions):(A)⇒Unit"></a>
@@ -413,10 +413,10 @@ concurrently.
       <span class="symbol">
         <span class="name">compose</span><span class="tparams">[<span name="A">A</span>]</span><span class="params">(<span name="g">g: (<span class="extype" name="scala.Function1.compose.A">A</span>) ⇒ <span class="extype" name="org.apache.spark.sql.SparkSessionExtensions">SparkSessionExtensions</span></span>)</span><span class="result">: (<span class="extype" name="scala.Function1.compose.A">A</span>) ⇒ <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Function1</dd><dt>Annotations</dt><dd>
                 <span class="name">@unspecialized</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -432,7 +432,7 @@ concurrently.
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -448,7 +448,7 @@ concurrently.
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -464,12 +464,12 @@ concurrently.
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -485,12 +485,12 @@ concurrently.
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -506,7 +506,7 @@ concurrently.
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -522,7 +522,7 @@ concurrently.
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -538,12 +538,12 @@ concurrently.
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -559,12 +559,12 @@ concurrently.
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -580,7 +580,7 @@ concurrently.
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.Function1#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -596,7 +596,7 @@ concurrently.
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Function1 → AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -612,13 +612,13 @@ concurrently.
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -634,15 +634,15 @@ concurrently.
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -658,19 +658,19 @@ concurrently.
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -688,15 +688,15 @@ concurrently.
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -710,13 +710,13 @@ concurrently.
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/catalog/AriadneTable.html
+++ b/docs/api/dev/cjfravel/ariadne/catalog/AriadneTable.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.catalog.AriadneTable" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.catalog.AriadneTable" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -188,7 +188,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Spark V2 table representing an Ariadne index's source data.</p><p>When queried, this table reads the original data files that were indexed (not the index metadata tables). The schema
 is the source data schema stored in the index's <code>metadata.json</code>.</p><p>This table supports batch reads only and is read-only. Write operations are not supported — index updates are
 performed via <a href="../Index.html#update:Unit" class="extmbr" name="dev.cjfravel.ariadne.Index#update">dev.cjfravel.ariadne.Index.update</a>.</p><p>When used in a JOIN, the <a href="AriadneJoinRule.html" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneJoinRule">AriadneJoinRule</a> optimizer rule rewrites the plan to use Ariadne's optimized file-pruning
@@ -205,7 +205,7 @@ threads.
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="scala.Serializable">Serializable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.Product">Product</span>, <span class="extype" name="scala.Equals">Equals</span>, <span class="extype" name="org.apache.spark.sql.connector.catalog.SupportsRead">SupportsRead</span>, <span class="extype" name="org.apache.spark.sql.connector.catalog.Table">Table</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -220,7 +220,7 @@ threads.
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -263,7 +263,7 @@ threads.
       <span class="symbol">
         <span class="name">AriadneTable</span><span class="params">(<span name="indexName">indexName: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="sourceSchema">sourceSchema: <span class="extype" name="org.apache.spark.sql.types.StructType">StructType</span></span>, <span name="metadata">metadata: <a href="../IndexMetadata.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadata">IndexMetadata</a></span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">indexName</dt><dd class="cmt"><p>
   the name of the Ariadne index</p></dd><dt class="param">sourceSchema</dt><dd class="cmt"><p>
   the schema of the original source data files</p></dd><dt class="param">metadata</dt><dd class="cmt"><p>
@@ -271,9 +271,9 @@ threads.
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -292,7 +292,7 @@ threads.
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -308,7 +308,7 @@ threads.
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -324,7 +324,7 @@ threads.
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -340,7 +340,7 @@ threads.
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneTable#capabilities" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="capabilities():java.util.Set[org.apache.spark.sql.connector.catalog.TableCapability]"></a><a id="capabilities():Set[TableCapability]"></a>
@@ -356,7 +356,7 @@ threads.
       <span class="symbol">
         <span class="name">capabilities</span><span class="params">()</span><span class="result">: <span class="extype" name="java.util.Set">Set</span>[<span class="extype" name="org.apache.spark.sql.connector.catalog.TableCapability">TableCapability</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the table capabilities.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the table capabilities.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   a set containing only <code>BATCH_READ</code></p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneTable">AriadneTable</a> → Table</dd></dl></div>
@@ -374,17 +374,17 @@ threads.
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="org.apache.spark.sql.connector.catalog.Table#columns" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="columns():Array[org.apache.spark.sql.connector.catalog.Column]"></a><a id="columns():Array[Column]"></a>
@@ -400,7 +400,7 @@ threads.
       <span class="symbol">
         <span class="name">columns</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="org.apache.spark.sql.connector.catalog.Column">Column</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Table</dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -416,7 +416,7 @@ threads.
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -432,12 +432,12 @@ threads.
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneTable#indexName" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="indexName:String"></a>
@@ -453,8 +453,8 @@ threads.
       <span class="symbol">
         <span class="name">indexName</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
       <span class="permalink">
@@ -469,7 +469,7 @@ threads.
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneTable#metadata" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="metadata:dev.cjfravel.ariadne.IndexMetadata"></a><a id="metadata:IndexMetadata"></a>
@@ -485,8 +485,8 @@ threads.
       <span class="symbol">
         <span class="name">metadata</span><span class="result">: <a href="../IndexMetadata.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadata">IndexMetadata</a></span>
       </span>
-
-
+      
+      
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneTable#name" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="name():String"></a>
       <span class="permalink">
@@ -501,7 +501,7 @@ threads.
       <span class="symbol">
         <span class="name">name</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the index name as the table name.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the index name as the table name.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   the Ariadne index name</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneTable">AriadneTable</a> → Table</dd></dl></div>
@@ -519,7 +519,7 @@ threads.
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneTable#newScanBuilder" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="newScanBuilder(options:org.apache.spark.sql.util.CaseInsensitiveStringMap):org.apache.spark.sql.connector.read.ScanBuilder"></a><a id="newScanBuilder(CaseInsensitiveStringMap):ScanBuilder"></a>
@@ -535,7 +535,7 @@ threads.
       <span class="symbol">
         <span class="name">newScanBuilder</span><span class="params">(<span name="options">options: <span class="extype" name="org.apache.spark.sql.util.CaseInsensitiveStringMap">CaseInsensitiveStringMap</span></span>)</span><span class="result">: <span class="extype" name="org.apache.spark.sql.connector.read.ScanBuilder">ScanBuilder</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Creates a new scan builder for reading this table's source data.</p><div class="fullcomment"><div class="comment cmt"><p>Creates a new scan builder for reading this table's source data.
 </p></div><dl class="paramcmts block"><dt class="param">options</dt><dd class="cmt"><p>
   scan options (currently unused; filter pushdown is configured via the <a href="AriadneScanBuilder.html" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneScanBuilder">AriadneScanBuilder</a>)</p></dd><dt>returns</dt><dd class="cmt"><p>
@@ -554,12 +554,12 @@ threads.
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -575,12 +575,12 @@ threads.
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="org.apache.spark.sql.connector.catalog.Table#partitioning" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="partitioning():Array[org.apache.spark.sql.connector.expressions.Transform]"></a><a id="partitioning():Array[Transform]"></a>
@@ -596,7 +596,7 @@ threads.
       <span class="symbol">
         <span class="name">partitioning</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="org.apache.spark.sql.connector.expressions.Transform">Transform</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Table</dd></dl></div>
     </li><li name="org.apache.spark.sql.connector.catalog.Table#properties" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="properties():java.util.Map[String,String]"></a><a id="properties():Map[String,String]"></a>
@@ -612,7 +612,7 @@ threads.
       <span class="symbol">
         <span class="name">properties</span><span class="params">()</span><span class="result">: <span class="extype" name="java.util.Map">Map</span>[<span class="extype" name="java.lang.String">String</span>, <span class="extype" name="java.lang.String">String</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Table</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneTable#schema" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="schema():org.apache.spark.sql.types.StructType"></a><a id="schema():StructType"></a>
@@ -628,7 +628,7 @@ threads.
       <span class="symbol">
         <span class="name">schema</span><span class="params">()</span><span class="result">: <span class="extype" name="org.apache.spark.sql.types.StructType">StructType</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the source data schema.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the source data schema.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   the schema of the original source data files</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneTable">AriadneTable</a> → Table</dd></dl></div>
@@ -646,8 +646,8 @@ threads.
       <span class="symbol">
         <span class="name">sourceSchema</span><span class="result">: <span class="extype" name="org.apache.spark.sql.types.StructType">StructType</span></span>
       </span>
-
-
+      
+      
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
       <span class="permalink">
@@ -662,7 +662,7 @@ threads.
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -678,13 +678,13 @@ threads.
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -700,15 +700,15 @@ threads.
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -724,19 +724,19 @@ threads.
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -754,15 +754,15 @@ threads.
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -786,13 +786,13 @@ threads.
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/catalog/AriadneV1Scan.html
+++ b/docs/api/dev/cjfravel/ariadne/catalog/AriadneV1Scan.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.catalog.AriadneV1Scan" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.catalog.AriadneV1Scan" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -188,7 +188,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>V1-based scan that delegates file reading to Spark's built-in readers.</p><p>Uses <code>V1Scan</code> to create a <code>BaseRelation</code> that reads source data files using <code>spark.read</code> with the appropriate format
 (CSV, Parquet, JSON). This avoids reimplementing file readers and gives full Spark optimization (predicate pushdown
 to Parquet, column pruning, etc.).</p><p>When WHERE filters were pushed through <a href="AriadneScanBuilder.html" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneScanBuilder">AriadneScanBuilder</a>, the file list is pruned via
@@ -200,7 +200,7 @@ of indexed files (not row count), but extremely large file lists could pressure 
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="org.apache.spark.sql.connector.read.V1Scan">V1Scan</span>, <span class="extype" name="org.apache.spark.sql.connector.read.Scan">Scan</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -215,7 +215,7 @@ of indexed files (not row count), but extremely large file lists could pressure 
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -258,7 +258,7 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span class="name">AriadneV1Scan</span><span class="params">(<span name="indexName">indexName: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="sourceSchema">sourceSchema: <span class="extype" name="org.apache.spark.sql.types.StructType">StructType</span></span>, <span name="metadata">metadata: <a href="../IndexMetadata.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadata">IndexMetadata</a></span>, <span name="pushedFilters">pushedFilters: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="org.apache.spark.sql.sources.Filter">Filter</span>]</span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">indexName</dt><dd class="cmt"><p>
   the Ariadne index name</p></dd><dt class="param">sourceSchema</dt><dd class="cmt"><p>
   the schema of the source data files</p></dd><dt class="param">metadata</dt><dd class="cmt"><p>
@@ -267,9 +267,9 @@ of indexed files (not row count), but extremely large file lists could pressure 
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -288,7 +288,7 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -304,7 +304,7 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -320,7 +320,7 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -336,7 +336,7 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -352,17 +352,17 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="org.apache.spark.sql.connector.read.Scan#columnarSupportMode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="columnarSupportMode():org.apache.spark.sql.connector.read.Scan.ColumnarSupportMode"></a><a id="columnarSupportMode():ColumnarSupportMode"></a>
@@ -378,7 +378,7 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span class="name">columnarSupportMode</span><span class="params">()</span><span class="result">: <span class="extype" name="org.apache.spark.sql.connector.read.Scan.ColumnarSupportMode">ColumnarSupportMode</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Scan</dd></dl></div>
     </li><li name="org.apache.spark.sql.connector.read.Scan#description" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="description():String"></a>
@@ -394,7 +394,7 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span class="name">description</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Scan</dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -410,7 +410,7 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -426,7 +426,7 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -442,12 +442,12 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -463,12 +463,12 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -484,7 +484,7 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -500,7 +500,7 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -516,12 +516,12 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -537,12 +537,12 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneV1Scan#readSchema" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="readSchema():org.apache.spark.sql.types.StructType"></a><a id="readSchema():StructType"></a>
@@ -558,7 +558,7 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span class="name">readSchema</span><span class="params">()</span><span class="result">: <span class="extype" name="org.apache.spark.sql.types.StructType">StructType</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Returns the schema of the source data files.</p><div class="fullcomment"><div class="comment cmt"><p>Returns the schema of the source data files.
 </p></div><dl class="paramcmts block"><dt>returns</dt><dd class="cmt"><p>
   the source data schema stored in index metadata</p></dd></dl><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneV1Scan">AriadneV1Scan</a> → Scan</dd></dl></div>
@@ -576,7 +576,7 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span class="name">reportDriverMetrics</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="org.apache.spark.sql.connector.metric.CustomTaskMetric">CustomTaskMetric</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Scan</dd></dl></div>
     </li><li name="org.apache.spark.sql.connector.read.Scan#supportedCustomMetrics" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="supportedCustomMetrics():Array[org.apache.spark.sql.connector.metric.CustomMetric]"></a><a id="supportedCustomMetrics():Array[CustomMetric]"></a>
@@ -592,7 +592,7 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span class="name">supportedCustomMetrics</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="org.apache.spark.sql.connector.metric.CustomMetric">CustomMetric</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Scan</dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -608,7 +608,7 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="org.apache.spark.sql.connector.read.Scan#toBatch" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toBatch():org.apache.spark.sql.connector.read.Batch"></a><a id="toBatch():Batch"></a>
@@ -624,7 +624,7 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span class="name">toBatch</span><span class="params">()</span><span class="result">: <span class="extype" name="org.apache.spark.sql.connector.read.Batch">Batch</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Scan</dd></dl></div>
     </li><li name="org.apache.spark.sql.connector.read.Scan#toContinuousStream" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toContinuousStream(x$1:String):org.apache.spark.sql.connector.read.streaming.ContinuousStream"></a><a id="toContinuousStream(String):ContinuousStream"></a>
@@ -640,7 +640,7 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span class="name">toContinuousStream</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.String">String</span></span>)</span><span class="result">: <span class="extype" name="org.apache.spark.sql.connector.read.streaming.ContinuousStream">ContinuousStream</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Scan</dd></dl></div>
     </li><li name="org.apache.spark.sql.connector.read.Scan#toMicroBatchStream" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toMicroBatchStream(x$1:String):org.apache.spark.sql.connector.read.streaming.MicroBatchStream"></a><a id="toMicroBatchStream(String):MicroBatchStream"></a>
@@ -656,7 +656,7 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span class="name">toMicroBatchStream</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.String">String</span></span>)</span><span class="result">: <span class="extype" name="org.apache.spark.sql.connector.read.streaming.MicroBatchStream">MicroBatchStream</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Scan</dd></dl></div>
     </li><li name="scala.AnyRef#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -672,7 +672,7 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog.AriadneV1Scan#toV1TableScan" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toV1TableScan[T&lt;:org.apache.spark.sql.sources.BaseRelationwithorg.apache.spark.sql.sources.TableScan](sqlCtx:org.apache.spark.sql.SQLContext):T"></a><a id="toV1TableScan[T&lt;:BaseRelationwithTableScan](SQLContext):T"></a>
@@ -688,7 +688,7 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span class="name">toV1TableScan</span><span class="tparams">[<span name="T">T &lt;: <span class="extype" name="org.apache.spark.sql.sources.BaseRelation">BaseRelation</span> with <span class="extype" name="org.apache.spark.sql.sources.TableScan">TableScan</span></span>]</span><span class="params">(<span name="sqlCtx">sqlCtx: <span class="extype" name="org.apache.spark.sql.SQLContext">SQLContext</span></span>)</span><span class="result">: <span class="extype" name="dev.cjfravel.ariadne.catalog.AriadneV1Scan.toV1TableScan.T">T</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Creates a V1 BaseRelation that reads the source data files.</p><div class="fullcomment"><div class="comment cmt"><p>Creates a V1 BaseRelation that reads the source data files.</p><p>If filters were pushed, uses <code>locateFiles()</code> to prune the file list. Otherwise reads all indexed files.
 </p></div><dl class="paramcmts block"><dt class="param">sqlCtx</dt><dd class="cmt"><p>
   the SQLContext provided by Spark</p></dd><dt>returns</dt><dd class="cmt"><p>
@@ -707,13 +707,13 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -729,15 +729,15 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -753,19 +753,19 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -783,15 +783,15 @@ of indexed files (not row count), but extremely large file lists could pressure 
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -807,13 +807,13 @@ of indexed files (not row count), but extremely large file lists could pressure 
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/catalog/index.html
+++ b/docs/api/dev/cjfravel/ariadne/catalog/index.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.catalog" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.catalog" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 current" data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <span class="name">catalog</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -175,7 +175,7 @@
       <span class="symbol">
         <a title="" href="../exceptions/index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li>
               </ul>
@@ -191,7 +191,7 @@
         <i class="material-icons"></i>
       </a>
     </span></h1>
-
+        
       </div>
 
       <h4 id="signature" class="signature">
@@ -204,15 +204,15 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"></div>
+        
 
-
-
+      
 
       <div id="template">
         <div id="allMembers">
-
+        
 
         <div id="types" class="types members">
               <h3>Type Members</h3>
@@ -230,7 +230,7 @@
       <span class="symbol">
         <a title="BaseRelation that reads Ariadne index source data files." href="AriadneBaseRelation.html"><span class="name">AriadneBaseRelation</span></a><span class="result"> extends <span class="extype" name="org.apache.spark.sql.sources.BaseRelation">BaseRelation</span> with <span class="extype" name="org.apache.spark.sql.sources.TableScan">TableScan</span> with <span class="extype" name="org.apache.spark.sql.sources.PrunedFilteredScan">PrunedFilteredScan</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">BaseRelation that reads Ariadne index source data files.</p><div class="fullcomment"><div class="comment cmt"><p>BaseRelation that reads Ariadne index source data files.</p><p>Delegates to Spark's built-in format readers (CSV, Parquet, JSON) using <code>spark.read</code>. Applies computed indexes and
 exploded field transformations from the index metadata.</p><p>Extends both <code>TableScan</code> and <code>PrunedFilteredScan</code>. Spark prefers
 <code>PrunedFilteredScan.buildScan(requiredColumns, filters)</code> when available, falling back to <code>TableScan.buildScan()</code> only
@@ -250,7 +250,7 @@ if column pruning is not needed.</p><p><b>Thread safety:</b> Instances are creat
       <span class="symbol">
         <a title="Spark V2 catalog plugin that exposes Ariadne indexes as SQL tables." href="AriadneCatalog.html"><span class="name">AriadneCatalog</span></a><span class="result"> extends <span class="extype" name="org.apache.spark.sql.connector.catalog.TableCatalog">TableCatalog</span> with <span class="extype" name="org.apache.spark.sql.connector.catalog.SupportsNamespaces">SupportsNamespaces</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Spark V2 catalog plugin that exposes Ariadne indexes as SQL tables.</p><div class="fullcomment"><div class="comment cmt"><p>Spark V2 catalog plugin that exposes Ariadne indexes as SQL tables.</p><p>All indexes under <code>spark.ariadne.storagePath</code> are automatically discovered and exposed under a single <code>default</code>
 namespace. Users reference indexes as <code>{catalogName}.{indexName}</code> (which resolves via the default namespace) or
 explicitly as <code>{catalogName}.default.{indexName}</code>.</p><p><b>Configuration:</b></p><pre>spark.conf.set(<span class="lit">"spark.sql.catalog.ariadne"</span>, <span class="lit">"dev.cjfravel.ariadne.catalog.AriadneCatalog"</span>)</pre><p><b>SQL usage:</b></p><pre>SHOW TABLES IN ariadne;
@@ -277,7 +277,7 @@ initialization.
       <span class="symbol">
         <a title="Catalyst optimizer rule that rewrites JOINs involving Ariadne tables." href="AriadneJoinRule.html"><span class="name">AriadneJoinRule</span></a><span class="result"> extends <span class="extype" name="org.apache.spark.sql.catalyst.rules.Rule">Rule</span>[<span class="extype" name="org.apache.spark.sql.catalyst.plans.logical.LogicalPlan">LogicalPlan</span>]</span>
       </span>
-
+      
       <p class="shortcomment cmt">Catalyst optimizer rule that rewrites JOINs involving Ariadne tables.</p><div class="fullcomment"><div class="comment cmt"><p>Catalyst optimizer rule that rewrites JOINs involving Ariadne tables.</p><p>When a SQL query joins against an Ariadne catalog table, this rule intercepts the logical plan and replaces the
 Ariadne scan with a pre-pruned read that only includes files matching the join values. The original <code>Join</code> node,
 condition, hints, and ExprIds are all preserved.</p><p><b>Safety constraints (the rule only fires when ALL hold):</b></p><ol class="decimal"><li>The join type is <code>INNER</code> 2. The entire condition is composed of equi-join predicates (<code>a.col = b.col</code>) 3. Every
@@ -311,7 +311,7 @@ each invocation is independent.
       <span class="symbol">
         <a title="Builds a scan for reading Ariadne index source data with filter pushdown." href="AriadneScanBuilder.html"><span class="name">AriadneScanBuilder</span></a><span class="result"> extends <span class="extype" name="org.apache.spark.sql.connector.read.ScanBuilder">ScanBuilder</span> with <span class="extype" name="org.apache.spark.sql.connector.read.SupportsPushDownFilters">SupportsPushDownFilters</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Builds a scan for reading Ariadne index source data with filter pushdown.</p><div class="fullcomment"><div class="comment cmt"><p>Builds a scan for reading Ariadne index source data with filter pushdown.</p><p>Implements <span class="extype" name="SupportsPushDownFilters">SupportsPushDownFilters</span> to convert <code>WHERE</code> clause filters on indexed columns into
 <a href="../IndexQueryOperations.html#locateFiles(indexes:Map[String,Array[Any]]):Set[String]" class="extmbr" name="dev.cjfravel.ariadne.IndexQueryOperations#locateFiles">dev.cjfravel.ariadne.IndexQueryOperations.locateFiles</a> calls, pruning the source file list before reading.</p><p><b>Thread safety:</b> Instances are created per scan by <a href="AriadneTable.html#newScanBuilder(options:org.apache.spark.sql.util.CaseInsensitiveStringMap):org.apache.spark.sql.connector.read.ScanBuilder" class="extmbr" name="dev.cjfravel.ariadne.catalog.AriadneTable#newScanBuilder">AriadneTable.newScanBuilder</a> and are not shared across
 threads.
@@ -331,7 +331,7 @@ threads.
       <span class="symbol">
         <a title="Spark session extension that registers the Ariadne JOIN optimization rule." href="AriadneSparkExtension.html"><span class="name">AriadneSparkExtension</span></a><span class="result"> extends (<span class="extype" name="org.apache.spark.sql.SparkSessionExtensions">SparkSessionExtensions</span>) ⇒ <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Spark session extension that registers the Ariadne JOIN optimization rule.</p><div class="fullcomment"><div class="comment cmt"><p>Spark session extension that registers the Ariadne JOIN optimization rule.</p><p>When registered, this extension injects the <a href="AriadneJoinRule.html" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneJoinRule">AriadneJoinRule</a> into Spark's optimizer. The rule rewrites JOINs
 involving Ariadne catalog tables to use the optimized file-pruning join path.</p><p><b>Configuration:</b></p><pre>spark.conf.set(<span class="lit">"spark.sql.extensions"</span>,
   <span class="lit">"dev.cjfravel.ariadne.catalog.AriadneSparkExtension"</span>)</pre><p><b>Note:</b> If your Spark session also uses Delta Lake SQL features, append this extension to the existing
@@ -354,7 +354,7 @@ concurrently.
       <span class="symbol">
         <a title="Spark V2 table representing an Ariadne index's source data." href="AriadneTable.html"><span class="name">AriadneTable</span></a><span class="params">(<span name="indexName">indexName: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="sourceSchema">sourceSchema: <span class="extype" name="org.apache.spark.sql.types.StructType">StructType</span></span>, <span name="metadata">metadata: <a href="../IndexMetadata.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadata">IndexMetadata</a></span>)</span><span class="result"> extends <span class="extype" name="org.apache.spark.sql.connector.catalog.Table">Table</span> with <span class="extype" name="org.apache.spark.sql.connector.catalog.SupportsRead">SupportsRead</span> with <span class="extype" name="scala.Product">Product</span> with <span class="extype" name="scala.Serializable">Serializable</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Spark V2 table representing an Ariadne index's source data.</p><div class="fullcomment"><div class="comment cmt"><p>Spark V2 table representing an Ariadne index's source data.</p><p>When queried, this table reads the original data files that were indexed (not the index metadata tables). The schema
 is the source data schema stored in the index's <code>metadata.json</code>.</p><p>This table supports batch reads only and is read-only. Write operations are not supported — index updates are
 performed via <a href="../Index.html#update:Unit" class="extmbr" name="dev.cjfravel.ariadne.Index#update">dev.cjfravel.ariadne.Index.update</a>.</p><p>When used in a JOIN, the <a href="AriadneJoinRule.html" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneJoinRule">AriadneJoinRule</a> optimizer rule rewrites the plan to use Ariadne's optimized file-pruning
@@ -380,7 +380,7 @@ threads.
       <span class="symbol">
         <a title="V1-based scan that delegates file reading to Spark's built-in readers." href="AriadneV1Scan.html"><span class="name">AriadneV1Scan</span></a><span class="result"> extends <span class="extype" name="org.apache.spark.sql.connector.read.V1Scan">V1Scan</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">V1-based scan that delegates file reading to Spark's built-in readers.</p><div class="fullcomment"><div class="comment cmt"><p>V1-based scan that delegates file reading to Spark's built-in readers.</p><p>Uses <code>V1Scan</code> to create a <code>BaseRelation</code> that reads source data files using <code>spark.read</code> with the appropriate format
 (CSV, Parquet, JSON). This avoids reimplementing file readers and gives full Spark optimization (predicate pushdown
 to Parquet, column pruning, etc.).</p><p>When WHERE filters were pushed through <a href="AriadneScanBuilder.html" class="extype" name="dev.cjfravel.ariadne.catalog.AriadneScanBuilder">AriadneScanBuilder</a>, the file list is pruned via
@@ -390,24 +390,24 @@ of indexed files (not row count), but extremely large file lists could pressure 
     </li></ol>
             </div>
 
+        
 
+        
 
+        
 
-
-
-
-
+        
         </div>
 
         <div id="inheritedMembers">
-
-
+        
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/exceptions/AriadneException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/AriadneException.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.AriadneException" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.AriadneException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -224,7 +224,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Base exception class for all Ariadne library errors.</p><p>Extends <code>RuntimeException</code> following Scala conventions for unchecked exceptions. All domain-specific exceptions in
 the Ariadne library extend this class, enabling callers to catch any Ariadne error with a single handler if desired.</p><p><b>Thread safety:</b> Instances are immutable after construction and safe to share across threads.</p><pre><span class="kw">try</span> {
   index.update(<span class="lit">"abfss://data@mystorage.dfs.core.windows.net/"</span>)
@@ -243,7 +243,7 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
             </span>
             <div class="subClasses hiddenContent"><a href="ColumnNotFoundException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.ColumnNotFoundException">ColumnNotFoundException</a>, <a href="FileListNotFoundException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.FileListNotFoundException">FileListNotFoundException</a>, <a href="FormatMismatchException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.FormatMismatchException">FormatMismatchException</a>, <a href="IndexLockException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.IndexLockException">IndexLockException</a>, <a href="IndexNotFoundException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.IndexNotFoundException">IndexNotFoundException</a>, <a href="IndexNotFoundInNewSchemaException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.IndexNotFoundInNewSchemaException">IndexNotFoundInNewSchemaException</a>, <a href="MetadataMissingOrCorruptException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.MetadataMissingOrCorruptException">MetadataMissingOrCorruptException</a>, <a href="MissingFormatException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.MissingFormatException">MissingFormatException</a>, <a href="MissingSchemaException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.MissingSchemaException">MissingSchemaException</a>, <a href="SchemaMismatchException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.SchemaMismatchException">SchemaMismatchException</a>, <a href="SchemaNotProvidedException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.SchemaNotProvidedException">SchemaNotProvidedException</a>, <a href="SchemaParseException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.SchemaParseException">SchemaParseException</a>, <a href="StorageMigrationException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.StorageMigrationException">StorageMigrationException</a>, <a href="UnsupportedMetadataVersionException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.UnsupportedMetadataVersionException">UnsupportedMetadataVersionException</a>, <a href="UnsupportedStorageFormatVersionException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.UnsupportedStorageFormatVersionException">UnsupportedStorageFormatVersionException</a></div>
           </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -258,7 +258,7 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -301,16 +301,16 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">AriadneException</span><span class="params">(<span name="message">message: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="cause">cause: <span class="extype" name="scala.Throwable">Throwable</span> = <span class="symbol">null</span></span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">message</dt><dd class="cmt"><p>
   descriptive error message</p></dd><dt class="param">cause</dt><dd class="cmt"><p>
   optional underlying cause of the error</p></dd></dl></div>
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -329,7 +329,7 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -345,7 +345,7 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -361,7 +361,7 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#addSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addSuppressed(x$1:Throwable):Unit"></a><a id="addSuppressed(Throwable):Unit"></a>
@@ -377,7 +377,7 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">addSuppressed</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -393,7 +393,7 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -409,17 +409,17 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -435,7 +435,7 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -451,7 +451,7 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#fillInStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="fillInStackTrace():Throwable"></a>
@@ -467,7 +467,7 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">fillInStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getCause():Throwable"></a>
@@ -483,7 +483,7 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">getCause</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -499,12 +499,12 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#getLocalizedMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getLocalizedMessage():String"></a>
@@ -520,7 +520,7 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">getLocalizedMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getMessage():String"></a>
@@ -536,7 +536,7 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">getMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getStackTrace():Array[StackTraceElement]"></a>
@@ -552,7 +552,7 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">getStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getSuppressed():Array[Throwable]"></a>
@@ -568,7 +568,7 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">getSuppressed</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.Throwable">Throwable</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -584,12 +584,12 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#initCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="initCause(x$1:Throwable):Throwable"></a><a id="initCause(Throwable):Throwable"></a>
@@ -605,7 +605,7 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">initCause</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -621,7 +621,7 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -637,7 +637,7 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -653,12 +653,12 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -674,12 +674,12 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintWriter):Unit"></a><a id="printStackTrace(PrintWriter):Unit"></a>
@@ -695,7 +695,7 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintWriter">PrintWriter</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintStream):Unit"></a><a id="printStackTrace(PrintStream):Unit"></a>
@@ -711,7 +711,7 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintStream">PrintStream</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace():Unit"></a>
@@ -727,7 +727,7 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#setStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="setStackTrace(x$1:Array[StackTraceElement]):Unit"></a><a id="setStackTrace(Array[StackTraceElement]):Unit"></a>
@@ -743,7 +743,7 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">setStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -759,7 +759,7 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="java.lang.Throwable#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -775,7 +775,7 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable → AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -791,13 +791,13 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -813,15 +813,15 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -837,19 +837,19 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -867,15 +867,15 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -895,13 +895,13 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/exceptions/ColumnNotFoundException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/ColumnNotFoundException.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.ColumnNotFoundException" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.ColumnNotFoundException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -224,7 +224,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Thrown when a specified column is not found in the DataFrame schema or index configuration.</p><p>This exception is raised by index build and query operations when a column referenced in the index configuration does
 not exist in the data schema. Callers include <code>Index.addIndex</code>, <code>Index.addBloomIndex</code>, <code>Index.addTemporalIndex</code>,
 <code>Index.addRangeIndex</code>, <code>Index.addExplodedFieldIndex</code>, <code>Index.addComputedIndex</code>, <code>IndexJoinOperations.joinDf</code>, and
@@ -236,7 +236,7 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
           </span>
           <div class="superTypes hiddenContent"><a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a>, <span class="extype" name="java.lang.RuntimeException">RuntimeException</span>, <span class="extype" name="java.lang.Exception">Exception</span>, <span class="extype" name="java.lang.Throwable">Throwable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -251,7 +251,7 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -294,15 +294,15 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">ColumnNotFoundException</span><span class="params">(<span name="column">column: <span class="extype" name="scala.Predef.String">String</span></span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">column</dt><dd class="cmt"><p>
   The name of the column that was not found</p></dd></dl></div>
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -321,7 +321,7 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -337,7 +337,7 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -353,7 +353,7 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#addSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addSuppressed(x$1:Throwable):Unit"></a><a id="addSuppressed(Throwable):Unit"></a>
@@ -369,7 +369,7 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">addSuppressed</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -385,7 +385,7 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -401,17 +401,17 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -427,7 +427,7 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -443,7 +443,7 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#fillInStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="fillInStackTrace():Throwable"></a>
@@ -459,7 +459,7 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">fillInStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getCause():Throwable"></a>
@@ -475,7 +475,7 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">getCause</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -491,12 +491,12 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#getLocalizedMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getLocalizedMessage():String"></a>
@@ -512,7 +512,7 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">getLocalizedMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getMessage():String"></a>
@@ -528,7 +528,7 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">getMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getStackTrace():Array[StackTraceElement]"></a>
@@ -544,7 +544,7 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">getStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getSuppressed():Array[Throwable]"></a>
@@ -560,7 +560,7 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">getSuppressed</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.Throwable">Throwable</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -576,12 +576,12 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#initCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="initCause(x$1:Throwable):Throwable"></a><a id="initCause(Throwable):Throwable"></a>
@@ -597,7 +597,7 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">initCause</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -613,7 +613,7 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -629,7 +629,7 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -645,12 +645,12 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -666,12 +666,12 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintWriter):Unit"></a><a id="printStackTrace(PrintWriter):Unit"></a>
@@ -687,7 +687,7 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintWriter">PrintWriter</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintStream):Unit"></a><a id="printStackTrace(PrintStream):Unit"></a>
@@ -703,7 +703,7 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintStream">PrintStream</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace():Unit"></a>
@@ -719,7 +719,7 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#setStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="setStackTrace(x$1:Array[StackTraceElement]):Unit"></a><a id="setStackTrace(Array[StackTraceElement]):Unit"></a>
@@ -735,7 +735,7 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">setStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -751,7 +751,7 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="java.lang.Throwable#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -767,7 +767,7 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable → AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -783,13 +783,13 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -805,15 +805,15 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -829,19 +829,19 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -859,15 +859,15 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -889,13 +889,13 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div><div class
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/exceptions/FileListNotFoundException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/FileListNotFoundException.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.FileListNotFoundException" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.FileListNotFoundException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -224,7 +224,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Thrown when a FileList with the specified name cannot be found on storage.</p><p>Raised by <code>FileList.remove</code> when the Delta table backing the file list does not exist. Also encountered indirectly
 via <code>IndexPathUtils.remove</code> and <code>IndexCatalog.remove</code> when cleaning up an index whose file list has already been
 deleted.</p><p><b>Recovery:</b> This is typically non-fatal during cleanup operations. If encountered during <code>IndexCatalog.remove</code>,
@@ -236,7 +236,7 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
           </span>
           <div class="superTypes hiddenContent"><a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a>, <span class="extype" name="java.lang.RuntimeException">RuntimeException</span>, <span class="extype" name="java.lang.Exception">Exception</span>, <span class="extype" name="java.lang.Throwable">Throwable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -251,7 +251,7 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -294,15 +294,15 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">FileListNotFoundException</span><span class="params">(<span name="name">name: <span class="extype" name="scala.Predef.String">String</span></span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">name</dt><dd class="cmt"><p>
   The name of the FileList that was not found</p></dd></dl></div>
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -321,7 +321,7 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -337,7 +337,7 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -353,7 +353,7 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#addSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addSuppressed(x$1:Throwable):Unit"></a><a id="addSuppressed(Throwable):Unit"></a>
@@ -369,7 +369,7 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">addSuppressed</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -385,7 +385,7 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -401,17 +401,17 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -427,7 +427,7 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -443,7 +443,7 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#fillInStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="fillInStackTrace():Throwable"></a>
@@ -459,7 +459,7 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">fillInStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getCause():Throwable"></a>
@@ -475,7 +475,7 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">getCause</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -491,12 +491,12 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#getLocalizedMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getLocalizedMessage():String"></a>
@@ -512,7 +512,7 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">getLocalizedMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getMessage():String"></a>
@@ -528,7 +528,7 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">getMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getStackTrace():Array[StackTraceElement]"></a>
@@ -544,7 +544,7 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">getStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getSuppressed():Array[Throwable]"></a>
@@ -560,7 +560,7 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">getSuppressed</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.Throwable">Throwable</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -576,12 +576,12 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#initCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="initCause(x$1:Throwable):Throwable"></a><a id="initCause(Throwable):Throwable"></a>
@@ -597,7 +597,7 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">initCause</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -613,7 +613,7 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -629,7 +629,7 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -645,12 +645,12 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -666,12 +666,12 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintWriter):Unit"></a><a id="printStackTrace(PrintWriter):Unit"></a>
@@ -687,7 +687,7 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintWriter">PrintWriter</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintStream):Unit"></a><a id="printStackTrace(PrintStream):Unit"></a>
@@ -703,7 +703,7 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintStream">PrintStream</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace():Unit"></a>
@@ -719,7 +719,7 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#setStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="setStackTrace(x$1:Array[StackTraceElement]):Unit"></a><a id="setStackTrace(Array[StackTraceElement]):Unit"></a>
@@ -735,7 +735,7 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">setStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -751,7 +751,7 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="java.lang.Throwable#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -767,7 +767,7 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable → AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -783,13 +783,13 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -805,15 +805,15 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -829,19 +829,19 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -859,15 +859,15 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -889,13 +889,13 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/exceptions/FormatMismatchException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/FormatMismatchException.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.FormatMismatchException" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.FormatMismatchException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -224,7 +224,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Thrown when the data format provided for an index operation does not match the format stored in the index metadata.</p><p>Raised by <code>Index.apply</code> when reconnecting to an existing index with a different format than what was originally
 configured (e.g., creating an index as &quot;parquet&quot; then attempting to use it as &quot;json&quot;).</p><p><b>Recovery:</b> Use the correct format matching the stored metadata, or delete and re-create the index with the
 desired format. Call <code>IndexCatalog.describe(name)</code> to inspect the stored format.</p><p><b>Thread safety:</b> Instances are immutable after construction and safe to share across threads.</p><pre><span class="cmt">// First creation stores format = "parquet"</span>
@@ -236,7 +236,7 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
           </span>
           <div class="superTypes hiddenContent"><a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a>, <span class="extype" name="java.lang.RuntimeException">RuntimeException</span>, <span class="extype" name="java.lang.Exception">Exception</span>, <span class="extype" name="java.lang.Throwable">Throwable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -251,7 +251,7 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -294,7 +294,7 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">FormatMismatchException</span><span class="params">(<span name="indexName">indexName: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="expected">expected: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="actual">actual: <span class="extype" name="scala.Predef.String">String</span></span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">indexName</dt><dd class="cmt"><p>
   the name of the index with the format conflict</p></dd><dt class="param">expected</dt><dd class="cmt"><p>
   the format stored in existing metadata</p></dd><dt class="param">actual</dt><dd class="cmt"><p>
@@ -302,9 +302,9 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -323,7 +323,7 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -339,7 +339,7 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -355,7 +355,7 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#addSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addSuppressed(x$1:Throwable):Unit"></a><a id="addSuppressed(Throwable):Unit"></a>
@@ -371,7 +371,7 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">addSuppressed</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -387,7 +387,7 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -403,17 +403,17 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -429,7 +429,7 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -445,7 +445,7 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#fillInStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="fillInStackTrace():Throwable"></a>
@@ -461,7 +461,7 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">fillInStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getCause():Throwable"></a>
@@ -477,7 +477,7 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">getCause</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -493,12 +493,12 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#getLocalizedMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getLocalizedMessage():String"></a>
@@ -514,7 +514,7 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">getLocalizedMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getMessage():String"></a>
@@ -530,7 +530,7 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">getMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getStackTrace():Array[StackTraceElement]"></a>
@@ -546,7 +546,7 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">getStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getSuppressed():Array[Throwable]"></a>
@@ -562,7 +562,7 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">getSuppressed</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.Throwable">Throwable</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -578,12 +578,12 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#initCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="initCause(x$1:Throwable):Throwable"></a><a id="initCause(Throwable):Throwable"></a>
@@ -599,7 +599,7 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">initCause</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -615,7 +615,7 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -631,7 +631,7 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -647,12 +647,12 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -668,12 +668,12 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintWriter):Unit"></a><a id="printStackTrace(PrintWriter):Unit"></a>
@@ -689,7 +689,7 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintWriter">PrintWriter</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintStream):Unit"></a><a id="printStackTrace(PrintStream):Unit"></a>
@@ -705,7 +705,7 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintStream">PrintStream</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace():Unit"></a>
@@ -721,7 +721,7 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#setStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="setStackTrace(x$1:Array[StackTraceElement]):Unit"></a><a id="setStackTrace(Array[StackTraceElement]):Unit"></a>
@@ -737,7 +737,7 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">setStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -753,7 +753,7 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="java.lang.Throwable#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -769,7 +769,7 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable → AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -785,13 +785,13 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -807,15 +807,15 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -831,19 +831,19 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -861,15 +861,15 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -891,13 +891,13 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/exceptions/IndexLockException$.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/IndexLockException$.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.IndexLockException" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.IndexLockException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -226,7 +226,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Factory for <a href="IndexLockException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.IndexLockException">IndexLockException</a> instances.</p><p>Provides a convenient <code>apply</code> method to create timeout-based lock exceptions without specifying holder details.
 </p></div><div class="toggleContainer block">
           <span class="toggle">
@@ -234,7 +234,7 @@
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="scala.Serializable">Serializable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -249,7 +249,7 @@
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -276,11 +276,11 @@
 
       <div id="template">
         <div id="allMembers">
+        
 
+        
 
-
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -299,7 +299,7 @@
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -315,7 +315,7 @@
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -331,7 +331,7 @@
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions.IndexLockException#apply" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="apply(indexName:String):dev.cjfravel.ariadne.exceptions.IndexLockException"></a><a id="apply(String):IndexLockException"></a>
@@ -347,7 +347,7 @@
       <span class="symbol">
         <span class="name">apply</span><span class="params">(<span name="indexName">indexName: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result">: <a href="IndexLockException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.IndexLockException">IndexLockException</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Creates an <a href="IndexLockException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.IndexLockException">IndexLockException</a> for a lock acquisition timeout.</p><div class="fullcomment"><div class="comment cmt"><p>Creates an <a href="IndexLockException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.IndexLockException">IndexLockException</a> for a lock acquisition timeout.
 </p></div><dl class="paramcmts block"><dt class="param">indexName</dt><dd class="cmt"><p>
   the name of the index whose lock could not be acquired</p></dd><dt>returns</dt><dd class="cmt"><p>
@@ -366,7 +366,7 @@
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -382,17 +382,17 @@
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -408,7 +408,7 @@
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -424,7 +424,7 @@
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -440,12 +440,12 @@
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -461,12 +461,12 @@
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -482,7 +482,7 @@
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -498,7 +498,7 @@
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -514,12 +514,12 @@
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -535,12 +535,12 @@
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -556,7 +556,7 @@
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -572,7 +572,7 @@
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -588,13 +588,13 @@
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -610,15 +610,15 @@
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -634,19 +634,19 @@
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -664,15 +664,15 @@
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -688,13 +688,13 @@
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/exceptions/IndexLockException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/IndexLockException.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.IndexLockException" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.IndexLockException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -226,7 +226,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Thrown when a distributed lock for an index operation cannot be acquired.</p><p>This may occur when another process holds the lock and the maximum wait time (<code>lockMaxWait</code>) is exceeded, when lock
 acquisition is interrupted, or when a corrupt lock file cannot be recovered after multiple attempts.</p><p>Raised by <a href="../IndexLock.html#acquire(correlationId:String):Unit" class="extmbr" name="dev.cjfravel.ariadne.IndexLock#acquire">dev.cjfravel.ariadne.IndexLock.acquire</a> and propagated through <code>Index.update</code>, <code>Index.compact</code>,
 <code>Index.vacuum</code>, and <code>Index.deleteFiles</code>.</p><p><b>Recovery:</b> Retry the operation after a delay, increase the <code>lockMaxWait</code> configuration, or check for
@@ -244,7 +244,7 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
           </span>
           <div class="superTypes hiddenContent"><a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a>, <span class="extype" name="java.lang.RuntimeException">RuntimeException</span>, <span class="extype" name="java.lang.Exception">Exception</span>, <span class="extype" name="java.lang.Throwable">Throwable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -259,7 +259,7 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -302,7 +302,7 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">IndexLockException</span><span class="params">(<span name="indexName">indexName: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="holderCorrelationId">holderCorrelationId: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="holderOwner">holderOwner: <span class="extype" name="scala.Predef.String">String</span></span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt">Creates an <code>IndexLockException</code> with details about the current lock holder.</p><div class="fullcomment"><div class="comment cmt"><p>Creates an <code>IndexLockException</code> with details about the current lock holder.
 </p></div><dl class="paramcmts block"><dt class="param">indexName</dt><dd class="cmt"><p>
   the name of the index whose lock could not be acquired</p></dd><dt class="param">holderCorrelationId</dt><dd class="cmt"><p>
@@ -322,15 +322,15 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">IndexLockException</span><span class="params">(<span name="message">message: <span class="extype" name="scala.Predef.String">String</span></span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">message</dt><dd class="cmt"><p>
   A descriptive error message including index name and lock holder details</p></dd></dl></div>
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -349,7 +349,7 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -365,7 +365,7 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -381,7 +381,7 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#addSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addSuppressed(x$1:Throwable):Unit"></a><a id="addSuppressed(Throwable):Unit"></a>
@@ -397,7 +397,7 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">addSuppressed</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -413,7 +413,7 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -429,17 +429,17 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -455,7 +455,7 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -471,7 +471,7 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#fillInStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="fillInStackTrace():Throwable"></a>
@@ -487,7 +487,7 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">fillInStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getCause():Throwable"></a>
@@ -503,7 +503,7 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">getCause</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -519,12 +519,12 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#getLocalizedMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getLocalizedMessage():String"></a>
@@ -540,7 +540,7 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">getLocalizedMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getMessage():String"></a>
@@ -556,7 +556,7 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">getMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getStackTrace():Array[StackTraceElement]"></a>
@@ -572,7 +572,7 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">getStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getSuppressed():Array[Throwable]"></a>
@@ -588,7 +588,7 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">getSuppressed</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.Throwable">Throwable</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -604,12 +604,12 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#initCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="initCause(x$1:Throwable):Throwable"></a><a id="initCause(Throwable):Throwable"></a>
@@ -625,7 +625,7 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">initCause</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -641,7 +641,7 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -657,7 +657,7 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -673,12 +673,12 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -694,12 +694,12 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintWriter):Unit"></a><a id="printStackTrace(PrintWriter):Unit"></a>
@@ -715,7 +715,7 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintWriter">PrintWriter</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintStream):Unit"></a><a id="printStackTrace(PrintStream):Unit"></a>
@@ -731,7 +731,7 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintStream">PrintStream</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace():Unit"></a>
@@ -747,7 +747,7 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#setStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="setStackTrace(x$1:Array[StackTraceElement]):Unit"></a><a id="setStackTrace(Array[StackTraceElement]):Unit"></a>
@@ -763,7 +763,7 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">setStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -779,7 +779,7 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="java.lang.Throwable#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -795,7 +795,7 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable → AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -811,13 +811,13 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -833,15 +833,15 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -857,19 +857,19 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -887,15 +887,15 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -917,13 +917,13 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/exceptions/IndexNotFoundException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/IndexNotFoundException.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.IndexNotFoundException" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.IndexNotFoundException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -224,7 +224,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Thrown when an index with the specified name does not exist in storage.</p><p>Raised by <code>IndexCatalog.get</code>, <code>IndexCatalog.remove</code>, <code>IndexCatalog.describe</code>, <code>IndexPathUtils.remove</code>, and
 <code>Index.remove</code> when the requested index name cannot be found in the configured <code>spark.ariadne.storagePath</code>.</p><p><b>Recovery:</b> Verify the index name is correct and that <code>spark.ariadne.storagePath</code> points to the expected storage
 location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><b>Thread safety:</b> Instances are immutable after construction and safe to share across threads.</p><pre><span class="cmt">// Throws IndexNotFoundException if "missing" does not exist</span>
@@ -234,7 +234,7 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
           </span>
           <div class="superTypes hiddenContent"><a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a>, <span class="extype" name="java.lang.RuntimeException">RuntimeException</span>, <span class="extype" name="java.lang.Exception">Exception</span>, <span class="extype" name="java.lang.Throwable">Throwable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -249,7 +249,7 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -292,15 +292,15 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">IndexNotFoundException</span><span class="params">(<span name="name">name: <span class="extype" name="scala.Predef.String">String</span></span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">name</dt><dd class="cmt"><p>
   The name of the index that was not found</p></dd></dl></div>
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -319,7 +319,7 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -335,7 +335,7 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -351,7 +351,7 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#addSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addSuppressed(x$1:Throwable):Unit"></a><a id="addSuppressed(Throwable):Unit"></a>
@@ -367,7 +367,7 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">addSuppressed</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -383,7 +383,7 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -399,17 +399,17 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -425,7 +425,7 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -441,7 +441,7 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#fillInStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="fillInStackTrace():Throwable"></a>
@@ -457,7 +457,7 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">fillInStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getCause():Throwable"></a>
@@ -473,7 +473,7 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">getCause</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -489,12 +489,12 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#getLocalizedMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getLocalizedMessage():String"></a>
@@ -510,7 +510,7 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">getLocalizedMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getMessage():String"></a>
@@ -526,7 +526,7 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">getMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getStackTrace():Array[StackTraceElement]"></a>
@@ -542,7 +542,7 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">getStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getSuppressed():Array[Throwable]"></a>
@@ -558,7 +558,7 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">getSuppressed</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.Throwable">Throwable</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -574,12 +574,12 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#initCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="initCause(x$1:Throwable):Throwable"></a><a id="initCause(Throwable):Throwable"></a>
@@ -595,7 +595,7 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">initCause</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -611,7 +611,7 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -627,7 +627,7 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -643,12 +643,12 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -664,12 +664,12 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintWriter):Unit"></a><a id="printStackTrace(PrintWriter):Unit"></a>
@@ -685,7 +685,7 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintWriter">PrintWriter</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintStream):Unit"></a><a id="printStackTrace(PrintStream):Unit"></a>
@@ -701,7 +701,7 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintStream">PrintStream</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace():Unit"></a>
@@ -717,7 +717,7 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#setStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="setStackTrace(x$1:Array[StackTraceElement]):Unit"></a><a id="setStackTrace(Array[StackTraceElement]):Unit"></a>
@@ -733,7 +733,7 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">setStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -749,7 +749,7 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="java.lang.Throwable#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -765,7 +765,7 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable → AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -781,13 +781,13 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -803,15 +803,15 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -827,19 +827,19 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -857,15 +857,15 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -887,13 +887,13 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/exceptions/IndexNotFoundInNewSchemaException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/IndexNotFoundInNewSchemaException.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.IndexNotFoundInNewSchemaException" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.IndexNotFoundInNewSchemaException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -224,7 +224,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Thrown when a previously indexed column is not found in the new schema during a schema evolution check.</p><p>Raised by <code>Index.apply</code> when <code>allowSchemaMismatch = true</code> and the provided schema is missing a column that the
 existing index tracks. When schema mismatch is allowed, Ariadne still validates that all indexed columns exist in the
 new schema to prevent silent data loss where an indexed column would become inaccessible.</p><p><b>Recovery:</b> Add the missing column to the new schema, or remove the index on that column (via
@@ -237,7 +237,7 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
           </span>
           <div class="superTypes hiddenContent"><a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a>, <span class="extype" name="java.lang.RuntimeException">RuntimeException</span>, <span class="extype" name="java.lang.Exception">Exception</span>, <span class="extype" name="java.lang.Throwable">Throwable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -252,7 +252,7 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -295,15 +295,15 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">IndexNotFoundInNewSchemaException</span><span class="params">(<span name="col">col: <span class="extype" name="scala.Predef.String">String</span></span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">col</dt><dd class="cmt"><p>
   The name of the indexed column missing from the new schema</p></dd></dl></div>
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -322,7 +322,7 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -338,7 +338,7 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -354,7 +354,7 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#addSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addSuppressed(x$1:Throwable):Unit"></a><a id="addSuppressed(Throwable):Unit"></a>
@@ -370,7 +370,7 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">addSuppressed</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -386,7 +386,7 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -402,17 +402,17 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -428,7 +428,7 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -444,7 +444,7 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#fillInStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="fillInStackTrace():Throwable"></a>
@@ -460,7 +460,7 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">fillInStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getCause():Throwable"></a>
@@ -476,7 +476,7 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">getCause</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -492,12 +492,12 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#getLocalizedMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getLocalizedMessage():String"></a>
@@ -513,7 +513,7 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">getLocalizedMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getMessage():String"></a>
@@ -529,7 +529,7 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">getMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getStackTrace():Array[StackTraceElement]"></a>
@@ -545,7 +545,7 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">getStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getSuppressed():Array[Throwable]"></a>
@@ -561,7 +561,7 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">getSuppressed</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.Throwable">Throwable</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -577,12 +577,12 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#initCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="initCause(x$1:Throwable):Throwable"></a><a id="initCause(Throwable):Throwable"></a>
@@ -598,7 +598,7 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">initCause</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -614,7 +614,7 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -630,7 +630,7 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -646,12 +646,12 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -667,12 +667,12 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintWriter):Unit"></a><a id="printStackTrace(PrintWriter):Unit"></a>
@@ -688,7 +688,7 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintWriter">PrintWriter</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintStream):Unit"></a><a id="printStackTrace(PrintStream):Unit"></a>
@@ -704,7 +704,7 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintStream">PrintStream</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace():Unit"></a>
@@ -720,7 +720,7 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#setStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="setStackTrace(x$1:Array[StackTraceElement]):Unit"></a><a id="setStackTrace(Array[StackTraceElement]):Unit"></a>
@@ -736,7 +736,7 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">setStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -752,7 +752,7 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="java.lang.Throwable#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -768,7 +768,7 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable → AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -784,13 +784,13 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -806,15 +806,15 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -830,19 +830,19 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -860,15 +860,15 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -890,13 +890,13 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/exceptions/MetadataMissingOrCorruptException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/MetadataMissingOrCorruptException.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.MetadataMissingOrCorruptException" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.MetadataMissingOrCorruptException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -224,7 +224,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Thrown when the index metadata file (<code>metadata.json</code>) is missing, empty, or cannot be parsed into a valid
 <a href="../IndexMetadata.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadata">dev.cjfravel.ariadne.IndexMetadata</a>.</p><p>Raised by <code>IndexMetadataOperations.refreshMetadata</code> when the file does not exist or contains invalid JSON, and by
 <code>IndexMetadata.apply</code> when the JSON string is null, empty, or deserializes to null. Recovery typically requires
@@ -241,7 +241,7 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
           </span>
           <div class="superTypes hiddenContent"><a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a>, <span class="extype" name="java.lang.RuntimeException">RuntimeException</span>, <span class="extype" name="java.lang.Exception">Exception</span>, <span class="extype" name="java.lang.Throwable">Throwable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -256,7 +256,7 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -299,15 +299,15 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">MetadataMissingOrCorruptException</span><span class="params">(<span name="cause">cause: <span class="extype" name="scala.Throwable">Throwable</span> = <span class="symbol">null</span></span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">cause</dt><dd class="cmt"><p>
   The underlying exception that caused the parse failure, or null if the file is missing</p></dd></dl></div>
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -326,7 +326,7 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -342,7 +342,7 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -358,7 +358,7 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#addSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addSuppressed(x$1:Throwable):Unit"></a><a id="addSuppressed(Throwable):Unit"></a>
@@ -374,7 +374,7 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">addSuppressed</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -390,7 +390,7 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -406,17 +406,17 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -432,7 +432,7 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -448,7 +448,7 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#fillInStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="fillInStackTrace():Throwable"></a>
@@ -464,7 +464,7 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">fillInStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getCause():Throwable"></a>
@@ -480,7 +480,7 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">getCause</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -496,12 +496,12 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#getLocalizedMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getLocalizedMessage():String"></a>
@@ -517,7 +517,7 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">getLocalizedMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getMessage():String"></a>
@@ -533,7 +533,7 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">getMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getStackTrace():Array[StackTraceElement]"></a>
@@ -549,7 +549,7 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">getStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getSuppressed():Array[Throwable]"></a>
@@ -565,7 +565,7 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">getSuppressed</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.Throwable">Throwable</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -581,12 +581,12 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#initCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="initCause(x$1:Throwable):Throwable"></a><a id="initCause(Throwable):Throwable"></a>
@@ -602,7 +602,7 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">initCause</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -618,7 +618,7 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -634,7 +634,7 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -650,12 +650,12 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -671,12 +671,12 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintWriter):Unit"></a><a id="printStackTrace(PrintWriter):Unit"></a>
@@ -692,7 +692,7 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintWriter">PrintWriter</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintStream):Unit"></a><a id="printStackTrace(PrintStream):Unit"></a>
@@ -708,7 +708,7 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintStream">PrintStream</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace():Unit"></a>
@@ -724,7 +724,7 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#setStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="setStackTrace(x$1:Array[StackTraceElement]):Unit"></a><a id="setStackTrace(Array[StackTraceElement]):Unit"></a>
@@ -740,7 +740,7 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">setStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -756,7 +756,7 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="java.lang.Throwable#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -772,7 +772,7 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable → AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -788,13 +788,13 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -810,15 +810,15 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -834,19 +834,19 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -864,15 +864,15 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -894,13 +894,13 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/exceptions/MissingFormatException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/MissingFormatException.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.MissingFormatException" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.MissingFormatException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -224,7 +224,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Thrown when an index does not have a file format specified in its metadata.</p><p>Raised by <code>Index.apply</code> when creating a new index without providing a format, or when the existing
 <code>IndexMetadata.format</code> is null or empty (indicating a corrupt or manually edited metadata file).</p><p><b>Recovery:</b> Provide the <code>format</code> parameter when creating a new index (e.g.,
 <code>Index(&quot;myIndex&quot;, schema, &quot;parquet&quot;)</code>). If the metadata is corrupt, delete and re-create the index.</p><p><b>Thread safety:</b> Instances are immutable after construction and safe to share across threads.</p><pre><span class="cmt">// Throws MissingFormatException if no format is provided for a new index</span>
@@ -234,7 +234,7 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
           </span>
           <div class="superTypes hiddenContent"><a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a>, <span class="extype" name="java.lang.RuntimeException">RuntimeException</span>, <span class="extype" name="java.lang.Exception">Exception</span>, <span class="extype" name="java.lang.Throwable">Throwable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -249,7 +249,7 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -292,14 +292,14 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">MissingFormatException</span><span class="params">()</span>
       </span>
-
-
+      
+      
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -318,7 +318,7 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -334,7 +334,7 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -350,7 +350,7 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#addSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addSuppressed(x$1:Throwable):Unit"></a><a id="addSuppressed(Throwable):Unit"></a>
@@ -366,7 +366,7 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">addSuppressed</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -382,7 +382,7 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -398,17 +398,17 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -424,7 +424,7 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -440,7 +440,7 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#fillInStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="fillInStackTrace():Throwable"></a>
@@ -456,7 +456,7 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">fillInStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getCause():Throwable"></a>
@@ -472,7 +472,7 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">getCause</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -488,12 +488,12 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#getLocalizedMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getLocalizedMessage():String"></a>
@@ -509,7 +509,7 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">getLocalizedMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getMessage():String"></a>
@@ -525,7 +525,7 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">getMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getStackTrace():Array[StackTraceElement]"></a>
@@ -541,7 +541,7 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">getStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getSuppressed():Array[Throwable]"></a>
@@ -557,7 +557,7 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">getSuppressed</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.Throwable">Throwable</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -573,12 +573,12 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#initCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="initCause(x$1:Throwable):Throwable"></a><a id="initCause(Throwable):Throwable"></a>
@@ -594,7 +594,7 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">initCause</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -610,7 +610,7 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -626,7 +626,7 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -642,12 +642,12 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -663,12 +663,12 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintWriter):Unit"></a><a id="printStackTrace(PrintWriter):Unit"></a>
@@ -684,7 +684,7 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintWriter">PrintWriter</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintStream):Unit"></a><a id="printStackTrace(PrintStream):Unit"></a>
@@ -700,7 +700,7 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintStream">PrintStream</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace():Unit"></a>
@@ -716,7 +716,7 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#setStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="setStackTrace(x$1:Array[StackTraceElement]):Unit"></a><a id="setStackTrace(Array[StackTraceElement]):Unit"></a>
@@ -732,7 +732,7 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">setStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -748,7 +748,7 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="java.lang.Throwable#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -764,7 +764,7 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable → AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -780,13 +780,13 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -802,15 +802,15 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -826,19 +826,19 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -856,15 +856,15 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -886,13 +886,13 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/exceptions/MissingSchemaException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/MissingSchemaException.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.MissingSchemaException" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.MissingSchemaException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -224,7 +224,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Thrown when the schema field is missing from the index metadata.</p><p>Raised by <code>IndexFileOperations.storedSchema</code> when <code>IndexMetadata.schema</code> is null or empty. This typically indicates a
 corrupt or manually edited metadata file, since <code>Index.apply</code> always writes a schema during creation.</p><p><b>Recovery:</b> Delete and re-create the index, or restore the metadata file from a backup.</p><p><b>Thread safety:</b> Instances are immutable after construction and safe to share across threads.</p><pre><span class="cmt">// A metadata file with no "schema" field will trigger this</span>
 <span class="kw">val</span> schema = index.storedSchema <span class="cmt">// throws MissingSchemaException</span></pre></div><div class="toggleContainer block">
@@ -233,7 +233,7 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
           </span>
           <div class="superTypes hiddenContent"><a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a>, <span class="extype" name="java.lang.RuntimeException">RuntimeException</span>, <span class="extype" name="java.lang.Exception">Exception</span>, <span class="extype" name="java.lang.Throwable">Throwable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -248,7 +248,7 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -291,14 +291,14 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">MissingSchemaException</span><span class="params">()</span>
       </span>
-
-
+      
+      
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -317,7 +317,7 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -333,7 +333,7 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -349,7 +349,7 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#addSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addSuppressed(x$1:Throwable):Unit"></a><a id="addSuppressed(Throwable):Unit"></a>
@@ -365,7 +365,7 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">addSuppressed</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -381,7 +381,7 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -397,17 +397,17 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -423,7 +423,7 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -439,7 +439,7 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#fillInStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="fillInStackTrace():Throwable"></a>
@@ -455,7 +455,7 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">fillInStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getCause():Throwable"></a>
@@ -471,7 +471,7 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">getCause</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -487,12 +487,12 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#getLocalizedMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getLocalizedMessage():String"></a>
@@ -508,7 +508,7 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">getLocalizedMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getMessage():String"></a>
@@ -524,7 +524,7 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">getMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getStackTrace():Array[StackTraceElement]"></a>
@@ -540,7 +540,7 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">getStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getSuppressed():Array[Throwable]"></a>
@@ -556,7 +556,7 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">getSuppressed</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.Throwable">Throwable</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -572,12 +572,12 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#initCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="initCause(x$1:Throwable):Throwable"></a><a id="initCause(Throwable):Throwable"></a>
@@ -593,7 +593,7 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">initCause</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -609,7 +609,7 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -625,7 +625,7 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -641,12 +641,12 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -662,12 +662,12 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintWriter):Unit"></a><a id="printStackTrace(PrintWriter):Unit"></a>
@@ -683,7 +683,7 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintWriter">PrintWriter</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintStream):Unit"></a><a id="printStackTrace(PrintStream):Unit"></a>
@@ -699,7 +699,7 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintStream">PrintStream</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace():Unit"></a>
@@ -715,7 +715,7 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#setStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="setStackTrace(x$1:Array[StackTraceElement]):Unit"></a><a id="setStackTrace(Array[StackTraceElement]):Unit"></a>
@@ -731,7 +731,7 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">setStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -747,7 +747,7 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="java.lang.Throwable#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -763,7 +763,7 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable → AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -779,13 +779,13 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -801,15 +801,15 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -825,19 +825,19 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -855,15 +855,15 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -885,13 +885,13 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/exceptions/SchemaMismatchException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/SchemaMismatchException.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.SchemaMismatchException" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.SchemaMismatchException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -224,7 +224,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Thrown when the schema provided for an index operation does not match the schema stored in the existing index
 metadata.</p><p>Raised by <code>Index.apply</code> when reconnecting to an existing index and the provided schema differs from the persisted
 one, with <code>allowSchemaMismatch = false</code> (the default).</p><p><b>Recovery:</b> Use the same schema as stored in the index, or pass <code>allowSchemaMismatch = true</code> to <code>Index.apply</code> to
@@ -239,7 +239,7 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
           </span>
           <div class="superTypes hiddenContent"><a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a>, <span class="extype" name="java.lang.RuntimeException">RuntimeException</span>, <span class="extype" name="java.lang.Exception">Exception</span>, <span class="extype" name="java.lang.Throwable">Throwable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -254,7 +254,7 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -297,15 +297,15 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">SchemaMismatchException</span><span class="params">(<span name="indexName">indexName: <span class="extype" name="scala.Predef.String">String</span></span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">indexName</dt><dd class="cmt"><p>
   the name of the index with the schema conflict</p></dd></dl></div>
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -324,7 +324,7 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -340,7 +340,7 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -356,7 +356,7 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#addSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addSuppressed(x$1:Throwable):Unit"></a><a id="addSuppressed(Throwable):Unit"></a>
@@ -372,7 +372,7 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">addSuppressed</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -388,7 +388,7 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -404,17 +404,17 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -430,7 +430,7 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -446,7 +446,7 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#fillInStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="fillInStackTrace():Throwable"></a>
@@ -462,7 +462,7 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">fillInStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getCause():Throwable"></a>
@@ -478,7 +478,7 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">getCause</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -494,12 +494,12 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#getLocalizedMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getLocalizedMessage():String"></a>
@@ -515,7 +515,7 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">getLocalizedMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getMessage():String"></a>
@@ -531,7 +531,7 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">getMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getStackTrace():Array[StackTraceElement]"></a>
@@ -547,7 +547,7 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">getStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getSuppressed():Array[Throwable]"></a>
@@ -563,7 +563,7 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">getSuppressed</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.Throwable">Throwable</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -579,12 +579,12 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#initCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="initCause(x$1:Throwable):Throwable"></a><a id="initCause(Throwable):Throwable"></a>
@@ -600,7 +600,7 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">initCause</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -616,7 +616,7 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -632,7 +632,7 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -648,12 +648,12 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -669,12 +669,12 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintWriter):Unit"></a><a id="printStackTrace(PrintWriter):Unit"></a>
@@ -690,7 +690,7 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintWriter">PrintWriter</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintStream):Unit"></a><a id="printStackTrace(PrintStream):Unit"></a>
@@ -706,7 +706,7 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintStream">PrintStream</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace():Unit"></a>
@@ -722,7 +722,7 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#setStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="setStackTrace(x$1:Array[StackTraceElement]):Unit"></a><a id="setStackTrace(Array[StackTraceElement]):Unit"></a>
@@ -738,7 +738,7 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">setStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -754,7 +754,7 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="java.lang.Throwable#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -770,7 +770,7 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable → AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -786,13 +786,13 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -808,15 +808,15 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -832,19 +832,19 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -862,15 +862,15 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -892,13 +892,13 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/exceptions/SchemaNotProvidedException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/SchemaNotProvidedException.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.SchemaNotProvidedException" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.SchemaNotProvidedException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -224,7 +224,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Thrown when no existing metadata is found and no schema was provided to create a new index.</p><p>Raised by <code>Index.apply</code> when the index does not yet exist on storage and the caller did not supply a schema. A schema
 is required for first-time index creation so that column validation can be performed.</p><p><b>Recovery:</b> Provide a schema when creating a new index, e.g., <code>Index(&quot;myIndex&quot;, schema, &quot;parquet&quot;)</code>.</p><p><b>Thread safety:</b> Instances are immutable after construction and safe to share across threads.</p><pre><span class="cmt">// Index "newIndex" does not exist yet — schema is required</span>
 Index(<span class="lit">"newIndex"</span>)                       <span class="cmt">// throws SchemaNotProvidedException</span>
@@ -234,7 +234,7 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
           </span>
           <div class="superTypes hiddenContent"><a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a>, <span class="extype" name="java.lang.RuntimeException">RuntimeException</span>, <span class="extype" name="java.lang.Exception">Exception</span>, <span class="extype" name="java.lang.Throwable">Throwable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -249,7 +249,7 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -292,14 +292,14 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">SchemaNotProvidedException</span><span class="params">()</span>
       </span>
-
-
+      
+      
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -318,7 +318,7 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -334,7 +334,7 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -350,7 +350,7 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#addSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addSuppressed(x$1:Throwable):Unit"></a><a id="addSuppressed(Throwable):Unit"></a>
@@ -366,7 +366,7 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">addSuppressed</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -382,7 +382,7 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -398,17 +398,17 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -424,7 +424,7 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -440,7 +440,7 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#fillInStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="fillInStackTrace():Throwable"></a>
@@ -456,7 +456,7 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">fillInStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getCause():Throwable"></a>
@@ -472,7 +472,7 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">getCause</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -488,12 +488,12 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#getLocalizedMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getLocalizedMessage():String"></a>
@@ -509,7 +509,7 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">getLocalizedMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getMessage():String"></a>
@@ -525,7 +525,7 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">getMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getStackTrace():Array[StackTraceElement]"></a>
@@ -541,7 +541,7 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">getStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getSuppressed():Array[Throwable]"></a>
@@ -557,7 +557,7 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">getSuppressed</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.Throwable">Throwable</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -573,12 +573,12 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#initCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="initCause(x$1:Throwable):Throwable"></a><a id="initCause(Throwable):Throwable"></a>
@@ -594,7 +594,7 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">initCause</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -610,7 +610,7 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -626,7 +626,7 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -642,12 +642,12 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -663,12 +663,12 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintWriter):Unit"></a><a id="printStackTrace(PrintWriter):Unit"></a>
@@ -684,7 +684,7 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintWriter">PrintWriter</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintStream):Unit"></a><a id="printStackTrace(PrintStream):Unit"></a>
@@ -700,7 +700,7 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintStream">PrintStream</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace():Unit"></a>
@@ -716,7 +716,7 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#setStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="setStackTrace(x$1:Array[StackTraceElement]):Unit"></a><a id="setStackTrace(Array[StackTraceElement]):Unit"></a>
@@ -732,7 +732,7 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">setStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -748,7 +748,7 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="java.lang.Throwable#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -764,7 +764,7 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable → AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -780,13 +780,13 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -802,15 +802,15 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -826,19 +826,19 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -856,15 +856,15 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -886,13 +886,13 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/exceptions/SchemaParseException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/SchemaParseException.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.SchemaParseException" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.SchemaParseException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -224,7 +224,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Thrown when a schema string is found in metadata but cannot be parsed into a valid Spark <code>StructType</code>.</p><p>Raised by <code>IndexFileOperations.storedSchema</code> when <code>DataType.fromJson</code> cannot deserialize the schema string stored in
 <code>IndexMetadata.schema</code>. This typically indicates a corrupt metadata file or a metadata file written by an
 incompatible version of Spark.</p><p><b>Recovery:</b> Delete and re-create the index. If the metadata was written by a different Spark version, ensure the
@@ -235,7 +235,7 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
           </span>
           <div class="superTypes hiddenContent"><a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a>, <span class="extype" name="java.lang.RuntimeException">RuntimeException</span>, <span class="extype" name="java.lang.Exception">Exception</span>, <span class="extype" name="java.lang.Throwable">Throwable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -250,7 +250,7 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -293,14 +293,14 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">SchemaParseException</span><span class="params">()</span>
       </span>
-
-
+      
+      
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -319,7 +319,7 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -335,7 +335,7 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -351,7 +351,7 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#addSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addSuppressed(x$1:Throwable):Unit"></a><a id="addSuppressed(Throwable):Unit"></a>
@@ -367,7 +367,7 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">addSuppressed</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -383,7 +383,7 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -399,17 +399,17 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -425,7 +425,7 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -441,7 +441,7 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#fillInStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="fillInStackTrace():Throwable"></a>
@@ -457,7 +457,7 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">fillInStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getCause():Throwable"></a>
@@ -473,7 +473,7 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">getCause</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -489,12 +489,12 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#getLocalizedMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getLocalizedMessage():String"></a>
@@ -510,7 +510,7 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">getLocalizedMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getMessage():String"></a>
@@ -526,7 +526,7 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">getMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getStackTrace():Array[StackTraceElement]"></a>
@@ -542,7 +542,7 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">getStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getSuppressed():Array[Throwable]"></a>
@@ -558,7 +558,7 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">getSuppressed</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.Throwable">Throwable</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -574,12 +574,12 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#initCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="initCause(x$1:Throwable):Throwable"></a><a id="initCause(Throwable):Throwable"></a>
@@ -595,7 +595,7 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">initCause</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -611,7 +611,7 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -627,7 +627,7 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -643,12 +643,12 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -664,12 +664,12 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintWriter):Unit"></a><a id="printStackTrace(PrintWriter):Unit"></a>
@@ -685,7 +685,7 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintWriter">PrintWriter</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintStream):Unit"></a><a id="printStackTrace(PrintStream):Unit"></a>
@@ -701,7 +701,7 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintStream">PrintStream</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace():Unit"></a>
@@ -717,7 +717,7 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#setStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="setStackTrace(x$1:Array[StackTraceElement]):Unit"></a><a id="setStackTrace(Array[StackTraceElement]):Unit"></a>
@@ -733,7 +733,7 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">setStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -749,7 +749,7 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="java.lang.Throwable#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -765,7 +765,7 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable → AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -781,13 +781,13 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -803,15 +803,15 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -827,19 +827,19 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -857,15 +857,15 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -887,13 +887,13 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/exceptions/StorageMigrationException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/StorageMigrationException.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.StorageMigrationException" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.StorageMigrationException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -224,7 +224,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Thrown when a persisted index cannot be migrated safely to the current storage format.</p><p>Operations abort without advancing <code>storage_format_version</code>. Correct the reported collision/corruption and retry;
 idempotent migration detection will resume from the persisted version.
 </p></div><div class="toggleContainer block">
@@ -238,7 +238,7 @@ idempotent migration detection will resume from the persisted version.
             </span>
             <div class="subClasses hiddenContent"><a href="UnsupportedMetadataVersionException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.UnsupportedMetadataVersionException">UnsupportedMetadataVersionException</a>, <a href="UnsupportedStorageFormatVersionException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.UnsupportedStorageFormatVersionException">UnsupportedStorageFormatVersionException</a></div>
           </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -253,7 +253,7 @@ idempotent migration detection will resume from the persisted version.
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -296,16 +296,16 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">StorageMigrationException</span><span class="params">(<span name="message">message: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="cause">cause: <span class="extype" name="scala.Throwable">Throwable</span> = <span class="symbol">null</span></span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">message</dt><dd class="cmt"><p>
   description of the failed migration invariant</p></dd><dt class="param">cause</dt><dd class="cmt"><p>
   optional underlying filesystem or Delta exception</p></dd></dl></div>
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -324,7 +324,7 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -340,7 +340,7 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -356,7 +356,7 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#addSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addSuppressed(x$1:Throwable):Unit"></a><a id="addSuppressed(Throwable):Unit"></a>
@@ -372,7 +372,7 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">addSuppressed</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -388,7 +388,7 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -404,17 +404,17 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -430,7 +430,7 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -446,7 +446,7 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#fillInStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="fillInStackTrace():Throwable"></a>
@@ -462,7 +462,7 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">fillInStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getCause():Throwable"></a>
@@ -478,7 +478,7 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">getCause</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -494,12 +494,12 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#getLocalizedMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getLocalizedMessage():String"></a>
@@ -515,7 +515,7 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">getLocalizedMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getMessage():String"></a>
@@ -531,7 +531,7 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">getMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getStackTrace():Array[StackTraceElement]"></a>
@@ -547,7 +547,7 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">getStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getSuppressed():Array[Throwable]"></a>
@@ -563,7 +563,7 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">getSuppressed</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.Throwable">Throwable</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -579,12 +579,12 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#initCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="initCause(x$1:Throwable):Throwable"></a><a id="initCause(Throwable):Throwable"></a>
@@ -600,7 +600,7 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">initCause</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -616,7 +616,7 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -632,7 +632,7 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -648,12 +648,12 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -669,12 +669,12 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintWriter):Unit"></a><a id="printStackTrace(PrintWriter):Unit"></a>
@@ -690,7 +690,7 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintWriter">PrintWriter</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintStream):Unit"></a><a id="printStackTrace(PrintStream):Unit"></a>
@@ -706,7 +706,7 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintStream">PrintStream</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace():Unit"></a>
@@ -722,7 +722,7 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#setStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="setStackTrace(x$1:Array[StackTraceElement]):Unit"></a><a id="setStackTrace(Array[StackTraceElement]):Unit"></a>
@@ -738,7 +738,7 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">setStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -754,7 +754,7 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="java.lang.Throwable#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -770,7 +770,7 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable → AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -786,13 +786,13 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -808,15 +808,15 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -832,19 +832,19 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -862,15 +862,15 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -892,13 +892,13 @@ idempotent migration detection will resume from the persisted version.
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/exceptions/UnsupportedMetadataVersionException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/UnsupportedMetadataVersionException.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.UnsupportedMetadataVersionException" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.UnsupportedMetadataVersionException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -224,7 +224,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Thrown when an index declares a metadata schema newer than this Ariadne build supports.</p><p>Upgrade Ariadne before opening the index so unknown metadata semantics are not discarded or misinterpreted.
 </p></div><div class="toggleContainer block">
           <span class="toggle">
@@ -232,7 +232,7 @@
           </span>
           <div class="superTypes hiddenContent"><a href="StorageMigrationException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.StorageMigrationException">StorageMigrationException</a>, <a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a>, <span class="extype" name="java.lang.RuntimeException">RuntimeException</span>, <span class="extype" name="java.lang.Exception">Exception</span>, <span class="extype" name="java.lang.Throwable">Throwable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -247,7 +247,7 @@
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -290,16 +290,16 @@
       <span class="symbol">
         <span class="name">UnsupportedMetadataVersionException</span><span class="params">(<span name="found">found: <span class="extype" name="scala.Int">Int</span></span>, <span name="supported">supported: <span class="extype" name="scala.Int">Int</span></span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">found</dt><dd class="cmt"><p>
   metadata version declared by the index</p></dd><dt class="param">supported</dt><dd class="cmt"><p>
   newest metadata version supported by this build</p></dd></dl></div>
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -318,7 +318,7 @@
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -334,7 +334,7 @@
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -350,7 +350,7 @@
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#addSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addSuppressed(x$1:Throwable):Unit"></a><a id="addSuppressed(Throwable):Unit"></a>
@@ -366,7 +366,7 @@
       <span class="symbol">
         <span class="name">addSuppressed</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -382,7 +382,7 @@
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -398,17 +398,17 @@
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -424,7 +424,7 @@
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -440,7 +440,7 @@
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#fillInStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="fillInStackTrace():Throwable"></a>
@@ -456,7 +456,7 @@
       <span class="symbol">
         <span class="name">fillInStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getCause():Throwable"></a>
@@ -472,7 +472,7 @@
       <span class="symbol">
         <span class="name">getCause</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -488,12 +488,12 @@
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#getLocalizedMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getLocalizedMessage():String"></a>
@@ -509,7 +509,7 @@
       <span class="symbol">
         <span class="name">getLocalizedMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getMessage():String"></a>
@@ -525,7 +525,7 @@
       <span class="symbol">
         <span class="name">getMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getStackTrace():Array[StackTraceElement]"></a>
@@ -541,7 +541,7 @@
       <span class="symbol">
         <span class="name">getStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getSuppressed():Array[Throwable]"></a>
@@ -557,7 +557,7 @@
       <span class="symbol">
         <span class="name">getSuppressed</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.Throwable">Throwable</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -573,12 +573,12 @@
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#initCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="initCause(x$1:Throwable):Throwable"></a><a id="initCause(Throwable):Throwable"></a>
@@ -594,7 +594,7 @@
       <span class="symbol">
         <span class="name">initCause</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -610,7 +610,7 @@
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -626,7 +626,7 @@
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -642,12 +642,12 @@
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -663,12 +663,12 @@
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintWriter):Unit"></a><a id="printStackTrace(PrintWriter):Unit"></a>
@@ -684,7 +684,7 @@
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintWriter">PrintWriter</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintStream):Unit"></a><a id="printStackTrace(PrintStream):Unit"></a>
@@ -700,7 +700,7 @@
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintStream">PrintStream</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace():Unit"></a>
@@ -716,7 +716,7 @@
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#setStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="setStackTrace(x$1:Array[StackTraceElement]):Unit"></a><a id="setStackTrace(Array[StackTraceElement]):Unit"></a>
@@ -732,7 +732,7 @@
       <span class="symbol">
         <span class="name">setStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -748,7 +748,7 @@
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="java.lang.Throwable#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -764,7 +764,7 @@
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable → AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -780,13 +780,13 @@
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -802,15 +802,15 @@
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -826,19 +826,19 @@
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -856,15 +856,15 @@
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -888,13 +888,13 @@
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/exceptions/UnsupportedStorageFormatVersionException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/UnsupportedStorageFormatVersionException.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.UnsupportedStorageFormatVersionException" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.UnsupportedStorageFormatVersionException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">exceptions</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -224,7 +224,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Thrown when an index declares a storage format newer than this Ariadne build supports.</p><p>Upgrade Ariadne to a release supporting the declared version. Never rebuild or downgrade the metadata in place,
 because the newer physical layout may not be understood safely.
 </p></div><div class="toggleContainer block">
@@ -233,7 +233,7 @@ because the newer physical layout may not be understood safely.
           </span>
           <div class="superTypes hiddenContent"><a href="StorageMigrationException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.StorageMigrationException">StorageMigrationException</a>, <a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a>, <span class="extype" name="java.lang.RuntimeException">RuntimeException</span>, <span class="extype" name="java.lang.Exception">Exception</span>, <span class="extype" name="java.lang.Throwable">Throwable</span>, <span class="extype" name="java.io.Serializable">Serializable</span>, <span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -248,7 +248,7 @@ because the newer physical layout may not be understood safely.
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -291,16 +291,16 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">UnsupportedStorageFormatVersionException</span><span class="params">(<span name="found">found: <span class="extype" name="scala.Int">Int</span></span>, <span name="supported">supported: <span class="extype" name="scala.Int">Int</span></span>)</span>
       </span>
-
+      
       <p class="shortcomment cmt"></p><div class="fullcomment"><div class="comment cmt"></div><dl class="paramcmts block"><dt class="param">found</dt><dd class="cmt"><p>
   storage format version declared by the index</p></dd><dt class="param">supported</dt><dd class="cmt"><p>
   newest storage format supported by this build</p></dd></dl></div>
     </li></ol>
             </div>
 
+        
 
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -319,7 +319,7 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -335,7 +335,7 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -351,7 +351,7 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#addSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="addSuppressed(x$1:Throwable):Unit"></a><a id="addSuppressed(Throwable):Unit"></a>
@@ -367,7 +367,7 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">addSuppressed</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -383,7 +383,7 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -399,17 +399,17 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#eq" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="eq(x$1:AnyRef):Boolean"></a><a id="eq(AnyRef):Boolean"></a>
@@ -425,7 +425,7 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -441,7 +441,7 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="java.lang.Throwable#fillInStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="fillInStackTrace():Throwable"></a>
@@ -457,7 +457,7 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">fillInStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getCause():Throwable"></a>
@@ -473,7 +473,7 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">getCause</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -489,12 +489,12 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#getLocalizedMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getLocalizedMessage():String"></a>
@@ -510,7 +510,7 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">getLocalizedMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getMessage" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getMessage():String"></a>
@@ -526,7 +526,7 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">getMessage</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getStackTrace():Array[StackTraceElement]"></a>
@@ -542,7 +542,7 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">getStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#getSuppressed" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getSuppressed():Array[Throwable]"></a>
@@ -558,7 +558,7 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">getSuppressed</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.Throwable">Throwable</span>]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -574,12 +574,12 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#initCause" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="initCause(x$1:Throwable):Throwable"></a><a id="initCause(Throwable):Throwable"></a>
@@ -595,7 +595,7 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">initCause</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.lang.Throwable">Throwable</span></span>)</span><span class="result">: <span class="extype" name="java.lang.Throwable">Throwable</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -611,7 +611,7 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -627,7 +627,7 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -643,12 +643,12 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -664,12 +664,12 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintWriter):Unit"></a><a id="printStackTrace(PrintWriter):Unit"></a>
@@ -685,7 +685,7 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintWriter">PrintWriter</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace(x$1:java.io.PrintStream):Unit"></a><a id="printStackTrace(PrintStream):Unit"></a>
@@ -701,7 +701,7 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="java.io.PrintStream">PrintStream</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#printStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="printStackTrace():Unit"></a>
@@ -717,7 +717,7 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">printStackTrace</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="java.lang.Throwable#setStackTrace" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="setStackTrace(x$1:Array[StackTraceElement]):Unit"></a><a id="setStackTrace(Array[StackTraceElement]):Unit"></a>
@@ -733,7 +733,7 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">setStackTrace</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Array">Array</span>[<span class="extype" name="java.lang.StackTraceElement">StackTraceElement</span>]</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable</dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -749,7 +749,7 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="java.lang.Throwable#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -765,7 +765,7 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Throwable → AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -781,13 +781,13 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -803,15 +803,15 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -827,19 +827,19 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -857,15 +857,15 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -889,13 +889,13 @@ because the newer physical layout may not be understood safely.
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/exceptions/index.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/index.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">ariadne</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="../catalog/index.html"><span class="name">catalog</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 current" data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
@@ -147,7 +147,7 @@
       <span class="symbol">
         <span class="name">exceptions</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel.ariadne">ariadne</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -227,7 +227,7 @@
         <i class="material-icons"></i>
       </a>
     </span></h1>
-
+        
       </div>
 
       <h4 id="signature" class="signature">
@@ -240,9 +240,9 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -257,12 +257,12 @@
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
-
+              
             </ol>
           </div>
-
+          
           <div id="visbl">
               <span class="filtertype">Visibility</span>
               <ol><li class="public in"><span>Public</span></li><li class="all out"><span>All</span></li></ol>
@@ -272,7 +272,7 @@
 
       <div id="template">
         <div id="allMembers">
-
+        
 
         <div id="types" class="types members">
               <h3>Type Members</h3>
@@ -290,7 +290,7 @@
       <span class="symbol">
         <a title="Base exception class for all Ariadne library errors." href="AriadneException.html"><span class="name">AriadneException</span></a><span class="result"> extends <span class="extype" name="scala.RuntimeException">RuntimeException</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Base exception class for all Ariadne library errors.</p><div class="fullcomment"><div class="comment cmt"><p>Base exception class for all Ariadne library errors.</p><p>Extends <code>RuntimeException</code> following Scala conventions for unchecked exceptions. All domain-specific exceptions in
 the Ariadne library extend this class, enabling callers to catch any Ariadne error with a single handler if desired.</p><p><b>Thread safety:</b> Instances are immutable after construction and safe to share across threads.</p><pre><span class="kw">try</span> {
   index.update(<span class="lit">"abfss://data@mystorage.dfs.core.windows.net/"</span>)
@@ -313,7 +313,7 @@ the Ariadne library extend this class, enabling callers to catch any Ariadne err
       <span class="symbol">
         <a title="Thrown when a specified column is not found in the DataFrame schema or index configuration." href="ColumnNotFoundException.html"><span class="name">ColumnNotFoundException</span></a><span class="result"> extends <a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Thrown when a specified column is not found in the DataFrame schema or index configuration.</p><div class="fullcomment"><div class="comment cmt"><p>Thrown when a specified column is not found in the DataFrame schema or index configuration.</p><p>This exception is raised by index build and query operations when a column referenced in the index configuration does
 not exist in the data schema. Callers include <code>Index.addIndex</code>, <code>Index.addBloomIndex</code>, <code>Index.addTemporalIndex</code>,
 <code>Index.addRangeIndex</code>, <code>Index.addExplodedFieldIndex</code>, <code>Index.addComputedIndex</code>, <code>IndexJoinOperations.joinDf</code>, and
@@ -334,7 +334,7 @@ index.addIndex(<span class="lit">"nonexistent_col"</span>)</pre></div></div>
       <span class="symbol">
         <a title="Thrown when a FileList with the specified name cannot be found on storage." href="FileListNotFoundException.html"><span class="name">FileListNotFoundException</span></a><span class="result"> extends <a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Thrown when a FileList with the specified name cannot be found on storage.</p><div class="fullcomment"><div class="comment cmt"><p>Thrown when a FileList with the specified name cannot be found on storage.</p><p>Raised by <code>FileList.remove</code> when the Delta table backing the file list does not exist. Also encountered indirectly
 via <code>IndexPathUtils.remove</code> and <code>IndexCatalog.remove</code> when cleaning up an index whose file list has already been
 deleted.</p><p><b>Recovery:</b> This is typically non-fatal during cleanup operations. If encountered during <code>IndexCatalog.remove</code>,
@@ -355,7 +355,7 @@ FileList.remove(<span class="lit">"[ariadne_index] myIndex"</span>)</pre></div><
       <span class="symbol">
         <a title="Thrown when the data format provided for an index operation does not match the format stored in the index metadata." href="FormatMismatchException.html"><span class="name">FormatMismatchException</span></a><span class="result"> extends <a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Thrown when the data format provided for an index operation does not match the format stored in the index metadata.</p><div class="fullcomment"><div class="comment cmt"><p>Thrown when the data format provided for an index operation does not match the format stored in the index metadata.</p><p>Raised by <code>Index.apply</code> when reconnecting to an existing index with a different format than what was originally
 configured (e.g., creating an index as &quot;parquet&quot; then attempting to use it as &quot;json&quot;).</p><p><b>Recovery:</b> Use the correct format matching the stored metadata, or delete and re-create the index with the
 desired format. Call <code>IndexCatalog.describe(name)</code> to inspect the stored format.</p><p><b>Thread safety:</b> Instances are immutable after construction and safe to share across threads.</p><pre><span class="cmt">// First creation stores format = "parquet"</span>
@@ -376,7 +376,7 @@ Index(<span class="lit">"myIndex"</span>, schema, <span class="lit">"json"</span
       <span class="symbol">
         <a title="Thrown when a distributed lock for an index operation cannot be acquired." href="IndexLockException.html"><span class="name">IndexLockException</span></a><span class="result"> extends <a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Thrown when a distributed lock for an index operation cannot be acquired.</p><div class="fullcomment"><div class="comment cmt"><p>Thrown when a distributed lock for an index operation cannot be acquired.</p><p>This may occur when another process holds the lock and the maximum wait time (<code>lockMaxWait</code>) is exceeded, when lock
 acquisition is interrupted, or when a corrupt lock file cannot be recovered after multiple attempts.</p><p>Raised by <a href="../IndexLock.html#acquire(correlationId:String):Unit" class="extmbr" name="dev.cjfravel.ariadne.IndexLock#acquire">dev.cjfravel.ariadne.IndexLock.acquire</a> and propagated through <code>Index.update</code>, <code>Index.compact</code>,
 <code>Index.vacuum</code>, and <code>Index.deleteFiles</code>.</p><p><b>Recovery:</b> Retry the operation after a delay, increase the <code>lockMaxWait</code> configuration, or check for
@@ -403,7 +403,7 @@ contention is inherently a concurrency concern — <code>IndexLock.acquire</code
       <span class="symbol">
         <a title="Thrown when an index with the specified name does not exist in storage." href="IndexNotFoundException.html"><span class="name">IndexNotFoundException</span></a><span class="result"> extends <a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Thrown when an index with the specified name does not exist in storage.</p><div class="fullcomment"><div class="comment cmt"><p>Thrown when an index with the specified name does not exist in storage.</p><p>Raised by <code>IndexCatalog.get</code>, <code>IndexCatalog.remove</code>, <code>IndexCatalog.describe</code>, <code>IndexPathUtils.remove</code>, and
 <code>Index.remove</code> when the requested index name cannot be found in the configured <code>spark.ariadne.storagePath</code>.</p><p><b>Recovery:</b> Verify the index name is correct and that <code>spark.ariadne.storagePath</code> points to the expected storage
 location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><b>Thread safety:</b> Instances are immutable after construction and safe to share across threads.</p><pre><span class="cmt">// Throws IndexNotFoundException if "missing" does not exist</span>
@@ -422,7 +422,7 @@ location. Use <code>IndexCatalog.list()</code> to see available indexes.</p><p><
       <span class="symbol">
         <a title="Thrown when a previously indexed column is not found in the new schema during a schema evolution check." href="IndexNotFoundInNewSchemaException.html"><span class="name">IndexNotFoundInNewSchemaException</span></a><span class="result"> extends <a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Thrown when a previously indexed column is not found in the new schema during a schema evolution check.</p><div class="fullcomment"><div class="comment cmt"><p>Thrown when a previously indexed column is not found in the new schema during a schema evolution check.</p><p>Raised by <code>Index.apply</code> when <code>allowSchemaMismatch = true</code> and the provided schema is missing a column that the
 existing index tracks. When schema mismatch is allowed, Ariadne still validates that all indexed columns exist in the
 new schema to prevent silent data loss where an indexed column would become inaccessible.</p><p><b>Recovery:</b> Add the missing column to the new schema, or remove the index on that column (via
@@ -444,7 +444,7 @@ Index(<span class="lit">"myIndex"</span>, newSchema, <span class="lit">"parquet"
       <span class="symbol">
         <a title="Thrown when the index metadata file (metadata.json) is missing, empty, or cannot be parsed into a valid dev.cjfravel.ariadne.IndexMetadata." href="MetadataMissingOrCorruptException.html"><span class="name">MetadataMissingOrCorruptException</span></a><span class="result"> extends <a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Thrown when the index metadata file (<code>metadata.json</code>) is missing, empty, or cannot be parsed into a valid
 <a href="../IndexMetadata.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadata">dev.cjfravel.ariadne.IndexMetadata</a>.</p><div class="fullcomment"><div class="comment cmt"><p>Thrown when the index metadata file (<code>metadata.json</code>) is missing, empty, or cannot be parsed into a valid
 <a href="../IndexMetadata.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadata">dev.cjfravel.ariadne.IndexMetadata</a>.</p><p>Raised by <code>IndexMetadataOperations.refreshMetadata</code> when the file does not exist or contains invalid JSON, and by
@@ -471,7 +471,7 @@ deleting the corrupt index and re-creating it.</p><p><b>Thread safety:</b> Insta
       <span class="symbol">
         <a title="Thrown when an index does not have a file format specified in its metadata." href="MissingFormatException.html"><span class="name">MissingFormatException</span></a><span class="result"> extends <a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Thrown when an index does not have a file format specified in its metadata.</p><div class="fullcomment"><div class="comment cmt"><p>Thrown when an index does not have a file format specified in its metadata.</p><p>Raised by <code>Index.apply</code> when creating a new index without providing a format, or when the existing
 <code>IndexMetadata.format</code> is null or empty (indicating a corrupt or manually edited metadata file).</p><p><b>Recovery:</b> Provide the <code>format</code> parameter when creating a new index (e.g.,
 <code>Index(&quot;myIndex&quot;, schema, &quot;parquet&quot;)</code>). If the metadata is corrupt, delete and re-create the index.</p><p><b>Thread safety:</b> Instances are immutable after construction and safe to share across threads.</p><pre><span class="cmt">// Throws MissingFormatException if no format is provided for a new index</span>
@@ -490,7 +490,7 @@ Index(<span class="lit">"newIndex"</span>, schema)  <span class="cmt">// missing
       <span class="symbol">
         <a title="Thrown when the schema field is missing from the index metadata." href="MissingSchemaException.html"><span class="name">MissingSchemaException</span></a><span class="result"> extends <a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Thrown when the schema field is missing from the index metadata.</p><div class="fullcomment"><div class="comment cmt"><p>Thrown when the schema field is missing from the index metadata.</p><p>Raised by <code>IndexFileOperations.storedSchema</code> when <code>IndexMetadata.schema</code> is null or empty. This typically indicates a
 corrupt or manually edited metadata file, since <code>Index.apply</code> always writes a schema during creation.</p><p><b>Recovery:</b> Delete and re-create the index, or restore the metadata file from a backup.</p><p><b>Thread safety:</b> Instances are immutable after construction and safe to share across threads.</p><pre><span class="cmt">// A metadata file with no "schema" field will trigger this</span>
 <span class="kw">val</span> schema = index.storedSchema <span class="cmt">// throws MissingSchemaException</span></pre></div></div>
@@ -508,7 +508,7 @@ corrupt or manually edited metadata file, since <code>Index.apply</code> always 
       <span class="symbol">
         <a title="Thrown when the schema provided for an index operation does not match the schema stored in the existing index metadata." href="SchemaMismatchException.html"><span class="name">SchemaMismatchException</span></a><span class="result"> extends <a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Thrown when the schema provided for an index operation does not match the schema stored in the existing index
 metadata.</p><div class="fullcomment"><div class="comment cmt"><p>Thrown when the schema provided for an index operation does not match the schema stored in the existing index
 metadata.</p><p>Raised by <code>Index.apply</code> when reconnecting to an existing index and the provided schema differs from the persisted
@@ -533,7 +533,7 @@ Index(<span class="lit">"myIndex"</span>, schema2, <span class="lit">"parquet"</
       <span class="symbol">
         <a title="Thrown when no existing metadata is found and no schema was provided to create a new index." href="SchemaNotProvidedException.html"><span class="name">SchemaNotProvidedException</span></a><span class="result"> extends <a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Thrown when no existing metadata is found and no schema was provided to create a new index.</p><div class="fullcomment"><div class="comment cmt"><p>Thrown when no existing metadata is found and no schema was provided to create a new index.</p><p>Raised by <code>Index.apply</code> when the index does not yet exist on storage and the caller did not supply a schema. A schema
 is required for first-time index creation so that column validation can be performed.</p><p><b>Recovery:</b> Provide a schema when creating a new index, e.g., <code>Index(&quot;myIndex&quot;, schema, &quot;parquet&quot;)</code>.</p><p><b>Thread safety:</b> Instances are immutable after construction and safe to share across threads.</p><pre><span class="cmt">// Index "newIndex" does not exist yet — schema is required</span>
 Index(<span class="lit">"newIndex"</span>)                       <span class="cmt">// throws SchemaNotProvidedException</span>
@@ -552,7 +552,7 @@ Index(<span class="lit">"newIndex"</span>, schema, <span class="lit">"parquet"</
       <span class="symbol">
         <a title="Thrown when a schema string is found in metadata but cannot be parsed into a valid Spark StructType." href="SchemaParseException.html"><span class="name">SchemaParseException</span></a><span class="result"> extends <a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Thrown when a schema string is found in metadata but cannot be parsed into a valid Spark <code>StructType</code>.</p><div class="fullcomment"><div class="comment cmt"><p>Thrown when a schema string is found in metadata but cannot be parsed into a valid Spark <code>StructType</code>.</p><p>Raised by <code>IndexFileOperations.storedSchema</code> when <code>DataType.fromJson</code> cannot deserialize the schema string stored in
 <code>IndexMetadata.schema</code>. This typically indicates a corrupt metadata file or a metadata file written by an
 incompatible version of Spark.</p><p><b>Recovery:</b> Delete and re-create the index. If the metadata was written by a different Spark version, ensure the
@@ -572,7 +572,7 @@ same Spark major version is used to read the index.</p><p><b>Thread safety:</b> 
       <span class="symbol">
         <a title="Thrown when a persisted index cannot be migrated safely to the current storage format." href="StorageMigrationException.html"><span class="name">StorageMigrationException</span></a><span class="result"> extends <a href="AriadneException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.AriadneException">AriadneException</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Thrown when a persisted index cannot be migrated safely to the current storage format.</p><div class="fullcomment"><div class="comment cmt"><p>Thrown when a persisted index cannot be migrated safely to the current storage format.</p><p>Operations abort without advancing <code>storage_format_version</code>. Correct the reported collision/corruption and retry;
 idempotent migration detection will resume from the persisted version.
 </p></div></div>
@@ -590,7 +590,7 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <a title="Thrown when an index declares a metadata schema newer than this Ariadne build supports." href="UnsupportedMetadataVersionException.html"><span class="name">UnsupportedMetadataVersionException</span></a><span class="result"> extends <a href="StorageMigrationException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.StorageMigrationException">StorageMigrationException</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Thrown when an index declares a metadata schema newer than this Ariadne build supports.</p><div class="fullcomment"><div class="comment cmt"><p>Thrown when an index declares a metadata schema newer than this Ariadne build supports.</p><p>Upgrade Ariadne before opening the index so unknown metadata semantics are not discarded or misinterpreted.
 </p></div></div>
     </li><li name="dev.cjfravel.ariadne.exceptions.UnsupportedStorageFormatVersionException" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -607,14 +607,14 @@ idempotent migration detection will resume from the persisted version.
       <span class="symbol">
         <a title="Thrown when an index declares a storage format newer than this Ariadne build supports." href="UnsupportedStorageFormatVersionException.html"><span class="name">UnsupportedStorageFormatVersionException</span></a><span class="result"> extends <a href="StorageMigrationException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.StorageMigrationException">StorageMigrationException</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Thrown when an index declares a storage format newer than this Ariadne build supports.</p><div class="fullcomment"><div class="comment cmt"><p>Thrown when an index declares a storage format newer than this Ariadne build supports.</p><p>Upgrade Ariadne to a release supporting the declared version. Never rebuild or downgrade the metadata in place,
 because the newer physical layout may not be understood safely.
 </p></div></div>
     </li></ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -633,27 +633,27 @@ because the newer physical layout may not be understood safely.
       <span class="symbol">
         <a title="Factory for IndexLockException instances." href="IndexLockException$.html"><span class="name">IndexLockException</span></a><span class="result"> extends <span class="extype" name="scala.Serializable">Serializable</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Factory for <a href="IndexLockException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.IndexLockException">IndexLockException</a> instances.</p><div class="fullcomment"><div class="comment cmt"><p>Factory for <a href="IndexLockException.html" class="extype" name="dev.cjfravel.ariadne.exceptions.IndexLockException">IndexLockException</a> instances.</p><p>Provides a convenient <code>apply</code> method to create timeout-based lock exceptions without specifying holder details.
 </p></div></div>
     </li>
               </ol>
             </div>
 
+        
 
-
-
+        
         </div>
 
         <div id="inheritedMembers">
-
-
+        
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/ariadne/index.html
+++ b/docs/api/dev/cjfravel/ariadne/index.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">cjfravel</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 current" data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <span class="name">ariadne</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev.cjfravel">cjfravel</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne.catalog" visbl="pub" class="indented4 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="catalog"></a><a id="catalog:catalog"></a>
@@ -131,8 +131,8 @@
       <span class="symbol">
         <a title="" href="catalog/index.html"><span class="name">catalog</span></a>
       </span>
-
-
+      
+      
     </li><li name="dev.cjfravel.ariadne.exceptions" visbl="pub" class="indented4 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="exceptions"></a><a id="exceptions:exceptions"></a>
       <span class="permalink">
@@ -147,8 +147,8 @@
       <span class="symbol">
         <a title="" href="exceptions/index.html"><span class="name">exceptions</span></a>
       </span>
-
-
+      
+      
     </li><li class="current-entities indented3">
                         <span class="separator"></span>
                         <a class="trait" href="AriadneContextUser.html" title="Provides Spark session context, HDFS access, and configuration for Ariadne operations."></a>
@@ -243,7 +243,7 @@
         <i class="material-icons"></i>
       </a>
     </span></h1>
-
+        
       </div>
 
       <h4 id="signature" class="signature">
@@ -256,9 +256,9 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -273,12 +273,12 @@
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
-
+              
             </ol>
           </div>
-
+          
           <div id="visbl">
               <span class="filtertype">Visibility</span>
               <ol><li class="public in"><span>Public</span></li><li class="all out"><span>All</span></li></ol>
@@ -288,7 +288,7 @@
 
       <div id="template">
         <div id="allMembers">
-
+        
 
         <div id="types" class="types members">
               <h3>Type Members</h3>
@@ -306,7 +306,7 @@
       <span class="symbol">
         <a title="Provides Spark session context, HDFS access, and configuration for Ariadne operations." href="AriadneContextUser.html"><span class="name">AriadneContextUser</span></a><span class="result"> extends <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Provides Spark session context, HDFS access, and configuration for Ariadne operations.</p><div class="fullcomment"><div class="comment cmt"><p>Provides Spark session context, HDFS access, and configuration for Ariadne operations.</p><p>Mix this trait into any class that needs access to Ariadne infrastructure. All configuration is read lazily from
 <code>SparkConf</code> properties prefixed with <code>spark.ariadne.*</code> and logged at <code>warn</code> level on first access.</p><p><b>Spark configuration keys:</b></p><pre>spark.ariadne.storagePath                 (required) Base HDFS/filesystem path <span class="kw">for</span> index storage
 spark.ariadne.largeIndexLimit             (default: <span class="num">500000</span>) Max values before a column is <span class="lit">"large"</span>
@@ -337,7 +337,7 @@ concurrency model.
       <span class="symbol">
         <a title="Trait providing bloom filter operations for Index instances." href="BloomFilterOperations.html"><span class="name">BloomFilterOperations</span></a><span class="result"> extends <a href="IndexFileOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexFileOperations">IndexFileOperations</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Trait providing bloom filter operations for <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a> instances.</p><div class="fullcomment"><div class="comment cmt"><p>Trait providing bloom filter operations for <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a> instances.</p><p>Bloom filters are probabilistic data structures used to test set membership. This trait handles the full lifecycle of
 bloom filter indexes:</p><p><b>Building</b>: During index updates, bloom filters are created per file per configured column via
 <a href="BloomFilterOperations.html#buildBloomFilterIndexes(df:org.apache.spark.sql.DataFrame):org.apache.spark.sql.DataFrame" class="extmbr" name="dev.cjfravel.ariadne.BloomFilterOperations#buildBloomFilterIndexes">buildBloomFilterIndexes</a>. Values are hashed into a Guava <code>BloomFilter[CharSequence]</code> and serialized to
@@ -363,7 +363,7 @@ ensure serializability across the Spark closure boundary.
       <span class="symbol">
         <a title="Configuration for a bloom filter index." href="BloomIndexConfig.html"><span class="name">BloomIndexConfig</span></a><span class="params">(<span name="column">column: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="fpr">fpr: <span class="extype" name="scala.Double">Double</span> = <span class="symbol">0.01</span></span>)</span><span class="result"> extends <span class="extype" name="scala.Product">Product</span> with <span class="extype" name="scala.Serializable">Serializable</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Configuration for a bloom filter index.</p><div class="fullcomment"><div class="comment cmt"><p>Configuration for a bloom filter index.</p><p>Bloom filters are probabilistic data structures that provide:</p><ul><li>Guaranteed NO false negatives (if filter says &quot;no&quot;, value definitely absent)</li><li>Configurable false positive rate (if filter says &quot;yes&quot;, value MIGHT be present)</li><li>Space-efficient storage (approximately 10 bits per element at 1% FPR)
 </li></ul></div><dl class="paramcmts block"><dt class="param">column</dt><dd class="cmt"><p>
   The column name to create a bloom filter for</p></dd><dt class="param">fpr</dt><dd class="cmt"><p>
@@ -382,7 +382,7 @@ ensure serializability across the Spark closure boundary.
       <span class="symbol">
         <a title="Represents a mapping for exploded field index configuration." href="ExplodedFieldMapping.html"><span class="name">ExplodedFieldMapping</span></a><span class="params">(<span name="array_column">array_column: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="field_path">field_path: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="as_column">as_column: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result"> extends <span class="extype" name="scala.Product">Product</span> with <span class="extype" name="scala.Serializable">Serializable</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Represents a mapping for exploded field index configuration.</p><div class="fullcomment"><div class="comment cmt"><p>Represents a mapping for exploded field index configuration.</p><p>This case class defines how to extract and index fields from array elements. It maps array elements to a flat
 structure that can be used for efficient joins by exploding the array and indexing specific fields within each
 element.
@@ -408,7 +408,7 @@ element.
       <span class="symbol">
         <a title="Manages a tracked list of files associated with an Ariadne index." href="FileList.html"><span class="name">FileList</span></a><span class="result"> extends <a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a> with <span class="extype" name="scala.Product">Product</span> with <span class="extype" name="scala.Serializable">Serializable</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Manages a tracked list of files associated with an Ariadne index.</p><div class="fullcomment"><div class="comment cmt"><p>Manages a tracked list of files associated with an Ariadne index.</p><p>Each file list is persisted as a Delta Lake table with two columns:</p><ul><li><code>filename</code> (<code>StringType</code>, not nullable) — the file path</li><li><code>addedAt</code> (<code>TimestampType</code>, not nullable) — when the file was registered</li></ul><p>The DataFrame is lazily loaded and cached in memory after the first access. Mutations (add, remove) invalidate the
 cache so the next read re-loads from the Delta table.</p><p><b>Thread safety:</b> <code>FileList</code> instances are <b>not</b> thread-safe. The mutable <code>_files</code> cache can produce
 inconsistent results if accessed concurrently from multiple threads. Each thread should use its own instance, or
@@ -428,7 +428,7 @@ external synchronization must be applied.
       <span class="symbol">
         <a title="Represents an Index for managing metadata and file-based indexes in Apache Spark." href="Index.html"><span class="name">Index</span></a><span class="result"> extends <a href="IndexQueryOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexQueryOperations">IndexQueryOperations</a> with <span class="extype" name="scala.Product">Product</span> with <span class="extype" name="scala.Serializable">Serializable</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Represents an Index for managing metadata and file-based indexes in Apache Spark.</p><div class="fullcomment"><div class="comment cmt"><p>Represents an Index for managing metadata and file-based indexes in Apache Spark.</p><p>This class provides methods to add, locate, and manage file-based indexing in Spark using Delta Lake. It supports
 schema enforcement, metadata persistence, and file tracking.
 </p></div><dl class="attributes block"> <dt>Note</dt><dd><span class="cmt"><p>
@@ -448,7 +448,7 @@ schema enforcement, metadata persistence, and file tracking.
       <span class="symbol">
         <a title="Trait providing index building and maintenance operations for Index instances." href="IndexBuildOperations.html"><span class="name">IndexBuildOperations</span></a><span class="result"> extends <a href="BloomFilterOperations.html" class="extype" name="dev.cjfravel.ariadne.BloomFilterOperations">BloomFilterOperations</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Trait providing index building and maintenance operations for <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a> instances.</p><div class="fullcomment"><div class="comment cmt"><p>Trait providing index building and maintenance operations for <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a> instances.</p><p>This trait implements the core data pipeline for building and maintaining file-level indexes. It is mixed into
 <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a> via the trait hierarchy and handles the complete update lifecycle:</p><p>Update pipeline (data flow):</p><ol class="decimal"><li><a href="IndexBuildOperations.html#analyzeFiles(files:Set[String]):Seq[IndexBuildOperations.this.FileAnalysis]" class="extmbr" name="dev.cjfravel.ariadne.IndexBuildOperations#analyzeFiles">analyzeFiles</a> — Pre-flight scan that computes per-file distinct value counts for all indexed columns. This
      information drives batching decisions.
@@ -480,7 +480,7 @@ are built for these columns in the main index to enable pre-filtering at query t
       <span class="symbol">
         <a title="Trait providing file I/O operations for Index instances." href="IndexFileOperations.html"><span class="name">IndexFileOperations</span></a><span class="result"> extends <a href="IndexMetadataOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadataOperations">IndexMetadataOperations</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Trait providing file I/O operations for <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a> instances.</p><div class="fullcomment"><div class="comment cmt"><p>Trait providing file I/O operations for <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a> instances.</p><p>Handles reading data files in supported formats (CSV, Parquet, JSON), applying computed indexes and exploded field
 transformations, and managing column selection for optimized reads.</p><p><b>Read pipeline:</b> <span class="extype" name="readFiles">readFiles</span> orchestrates the full read path:</p><ol class="decimal"><li><a href="IndexFileOperations.html#createBaseDataFrame(files:Set[String]):org.apache.spark.sql.DataFrame" class="extmbr" name="dev.cjfravel.ariadne.IndexFileOperations#createBaseDataFrame">createBaseDataFrame</a> — loads files using the stored schema, format, and read options 2.
      <a href="IndexFileOperations.html#applyComputedIndexes(df:org.apache.spark.sql.DataFrame):org.apache.spark.sql.DataFrame" class="extmbr" name="dev.cjfravel.ariadne.IndexFileOperations#applyComputedIndexes">applyComputedIndexes</a> — adds derived columns via Spark SQL expressions 3. <a href="IndexFileOperations.html#applyExplodedFields(df:org.apache.spark.sql.DataFrame):org.apache.spark.sql.DataFrame" class="extmbr" name="dev.cjfravel.ariadne.IndexFileOperations#applyExplodedFields">applyExplodedFields</a> — explodes
@@ -505,7 +505,7 @@ For single-file reads, a fallback literal is used because Spark may report an em
       <span class="symbol">
         <a title="Trait providing join operations between DataFrames and indexed data." href="IndexJoinOperations.html"><span class="name">IndexJoinOperations</span></a><span class="result"> extends <a href="IndexBuildOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexBuildOperations">IndexBuildOperations</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Trait providing join operations between DataFrames and indexed data.</p><div class="fullcomment"><div class="comment cmt"><p>Trait providing join operations between DataFrames and indexed data.</p><p>Orchestrates the join workflow:</p><ol class="decimal"><li>Maps join columns to their storage column names (regular, bloom, range, exploded) 2. Locates relevant files
      using the index (via <a href="IndexQueryOperations.html#locateFilesFromDataFrame(valuesDf:org.apache.spark.sql.DataFrame,columnMappings:Map[String,String],joinColumns:Seq[String]):Set[String]" class="extmbr" name="dev.cjfravel.ariadne.IndexQueryOperations#locateFilesFromDataFrame">IndexQueryOperations.locateFilesFromDataFrame</a>) 3. Reads only the located data files
      (file-level pruning) 4. Applies temporal deduplication if applicable (keeps latest version per value) 5.
@@ -525,7 +525,7 @@ For single-file reads, a fallback literal is used because Spark may report an em
       <span class="symbol">
         <a title="File-based distributed lock for index operations." href="IndexLock.html"><span class="name">IndexLock</span></a><span class="params">(<span name="lockPath">lockPath: <span class="extype" name="org.apache.hadoop.fs.Path">Path</span></span>, <span name="indexName">indexName: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="params">(<span class="implicit">implicit </span><span name="spark">spark: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>)</span><span class="result"> extends <a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a> with <span class="extype" name="scala.Product">Product</span> with <span class="extype" name="scala.Serializable">Serializable</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">File-based distributed lock for index operations.</p><div class="fullcomment"><div class="comment cmt"><p>File-based distributed lock for index operations.</p><p>Provides mutual exclusion for index operations (update, compact, vacuum) using lock files on HDFS or cloud-compatible
 filesystems. Lock files are JSON documents containing a <a href="LockInfo.html" class="extype" name="dev.cjfravel.ariadne.LockInfo">LockInfo</a> payload.</p><h4>Concurrency semantics</h4><p>Lock acquisition is atomic at the filesystem level: the lock file is created with <code>overwrite = false</code>, so only one
 writer can succeed. If another process already holds the lock, acquisition enters a retry loop with exponential
@@ -552,7 +552,7 @@ instance or coordinate externally.
       <span class="symbol">
         <a title="Metadata container for Ariadne index configuration and state." href="IndexMetadata.html"><span class="name">IndexMetadata</span></a><span class="params">(<span name="format">format: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="schema">schema: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="indexes">indexes: <span class="extype" name="java.util.List">List</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="computed_indexes">computed_indexes: <span class="extype" name="java.util.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="exploded_field_indexes">exploded_field_indexes: <span class="extype" name="java.util.List">List</span>[<a href="ExplodedFieldMapping.html" class="extype" name="dev.cjfravel.ariadne.ExplodedFieldMapping">ExplodedFieldMapping</a>]</span>, <span name="bloom_indexes">bloom_indexes: <span class="extype" name="java.util.List">List</span>[<a href="BloomIndexConfig.html" class="extype" name="dev.cjfravel.ariadne.BloomIndexConfig">BloomIndexConfig</a>]</span>, <span name="temporal_indexes">temporal_indexes: <span class="extype" name="java.util.List">List</span>[<a href="TemporalIndexConfig.html" class="extype" name="dev.cjfravel.ariadne.TemporalIndexConfig">TemporalIndexConfig</a>]</span>, <span name="read_options">read_options: <span class="extype" name="java.util.Map">Map</span>[<span class="extype" name="scala.Predef.String">String</span>, <span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="range_indexes">range_indexes: <span class="extype" name="java.util.List">List</span>[<a href="RangeIndexConfig.html" class="extype" name="dev.cjfravel.ariadne.RangeIndexConfig">RangeIndexConfig</a>]</span>, <span name="auto_bloom_indexes">auto_bloom_indexes: <span class="extype" name="java.util.List">List</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="total_indexed_file_size">total_indexed_file_size: <span class="extype" name="java.lang.Long">Long</span></span>, <span name="batches_since_compact">batches_since_compact: <span class="extype" name="java.lang.Integer">Integer</span></span>, <span name="metadata_version">metadata_version: <span class="extype" name="java.lang.Integer">Integer</span></span>, <span name="storage_format_version">storage_format_version: <span class="extype" name="java.lang.Integer">Integer</span></span>)</span><span class="result"> extends <span class="extype" name="scala.Product">Product</span> with <span class="extype" name="scala.Serializable">Serializable</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Metadata container for Ariadne index configuration and state.</p><div class="fullcomment"><div class="comment cmt"><p>Metadata container for Ariadne index configuration and state.</p><p>This case class stores all metadata required to manage an Ariadne index, including schema information, indexed
 columns, and format details. It supports multiple versions for backward compatibility.
 </p></div><dl class="paramcmts block"><dt class="param">format</dt><dd class="cmt"><p>
@@ -587,7 +587,7 @@ columns, and format details. It supports multiple versions for backward compatib
       <span class="symbol">
         <a title="Trait providing metadata read/write operations for Index instances." href="IndexMetadataOperations.html"><span class="name">IndexMetadataOperations</span></a><span class="result"> extends <a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Trait providing metadata read/write operations for <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a> instances.</p><div class="fullcomment"><div class="comment cmt"><p>Trait providing metadata read/write operations for <a href="Index.html" class="extype" name="dev.cjfravel.ariadne.Index">Index</a> instances.</p><p>Manages the lifecycle of <a href="IndexMetadata.html" class="extype" name="dev.cjfravel.ariadne.IndexMetadata">IndexMetadata</a> — reading from and writing to the <code>metadata.json</code> file on the
 Hadoop-compatible filesystem. Metadata is cached in memory after the first load; call <a href="IndexMetadataOperations.html#refreshMetadata():Unit" class="extmbr" name="dev.cjfravel.ariadne.IndexMetadataOperations#refreshMetadata">refreshMetadata</a> to force a
 reload.</p><p><b>Storage:</b> Metadata is persisted as a single JSON file at <code>{storagePath}/metadata.json</code>, serialized and
@@ -612,7 +612,7 @@ External synchronization is required for concurrent access.
       <span class="symbol">
         <a title="Trait providing query and file location operations for Index instances." href="IndexQueryOperations.html"><span class="name">IndexQueryOperations</span></a><span class="result"> extends <a href="IndexJoinOperations.html" class="extype" name="dev.cjfravel.ariadne.IndexJoinOperations">IndexJoinOperations</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Trait providing query and file location operations for Index instances.</p><div class="fullcomment"><div class="comment cmt"><p>Trait providing query and file location operations for Index instances.</p><p>This is the top-level trait in the Index trait hierarchy, providing:</p><ul><li>File location via regular, bloom, temporal, range, and auto-bloom indexes</li><li>Multi-column intersection with AND semantics across index types</li><li>Index statistics and diagnostics</li><li>Delta table management (repartitioning, large index loading)</li></ul><p>File location uses a staged collection strategy: distinct filenames are written to temporary CSV storage before
 collection to avoid executor memory pressure on large result sets.
 </p></div></div>
@@ -630,7 +630,7 @@ collection to avoid executor memory pressure on large result sets.
       <span class="symbol">
         <a title="Summary information for a single Ariadne index." href="IndexSummary.html"><span class="name">IndexSummary</span></a><span class="params">(<span name="name">name: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="format">format: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="columns">columns: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="regularIndexes">regularIndexes: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="bloomIndexes">bloomIndexes: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="computedIndexes">computedIndexes: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="temporalIndexes">temporalIndexes: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="rangeIndexes">rangeIndexes: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="explodedFieldIndexes">explodedFieldIndexes: <span class="extype" name="scala.Predef.Set">Set</span>[<span class="extype" name="scala.Predef.String">String</span>]</span>, <span name="fileCount">fileCount: <span class="extype" name="scala.Long">Long</span></span>, <span name="totalIndexedFileSize">totalIndexedFileSize: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result"> extends <span class="extype" name="scala.Product">Product</span> with <span class="extype" name="scala.Serializable">Serializable</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Summary information for a single Ariadne index.</p><div class="fullcomment"><div class="comment cmt"><p>Summary information for a single Ariadne index.</p><p>Captures the index name, data format, all configured index types, tracked file count, and cumulative indexed file
 size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspark:org.apache.spark.sql.SparkSession):dev.cjfravel.ariadne.IndexSummary" class="extmbr" name="dev.cjfravel.ariadne.IndexCatalog#describe">IndexCatalog.describe</a> and <a href="IndexCatalog$.html#describeAll()(implicitspark:org.apache.spark.sql.SparkSession):Seq[dev.cjfravel.ariadne.IndexSummary]" class="extmbr" name="dev.cjfravel.ariadne.IndexCatalog#describeAll">IndexCatalog.describeAll</a>.
 </p></div><dl class="paramcmts block"><dt class="param">name</dt><dd class="cmt"><p>
@@ -659,7 +659,7 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <a title="Metadata stored in lock files to track lock ownership and freshness." href="LockInfo.html"><span class="name">LockInfo</span></a><span class="params">(<span name="correlationId">correlationId: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="acquiredAt">acquiredAt: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="lastRefreshedAt">lastRefreshedAt: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="owner">owner: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result"> extends <span class="extype" name="scala.Product">Product</span> with <span class="extype" name="scala.Serializable">Serializable</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Metadata stored in lock files to track lock ownership and freshness.</p><div class="fullcomment"><div class="comment cmt"><p>Metadata stored in lock files to track lock ownership and freshness.</p><p>Each lock file is a JSON document containing these fields, serialized via Gson. The <a href="IndexLock.html" class="extype" name="dev.cjfravel.ariadne.IndexLock">IndexLock</a> reads and writes
 <a href="LockInfo.html" class="extype" name="dev.cjfravel.ariadne.LockInfo">LockInfo</a> instances to coordinate distributed access to an index.
 </p></div><dl class="paramcmts block"><dt class="param">correlationId</dt><dd class="cmt"><p>
@@ -681,7 +681,7 @@ size. Produced by <a href="IndexCatalog$.html#describe(name:String)(implicitspar
       <span class="symbol">
         <a title="Configuration for a range index." href="RangeIndexConfig.html"><span class="name">RangeIndexConfig</span></a><span class="params">(<span name="column">column: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result"> extends <span class="extype" name="scala.Product">Product</span> with <span class="extype" name="scala.Serializable">Serializable</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Configuration for a range index.</p><div class="fullcomment"><div class="comment cmt"><p>Configuration for a range index.</p><p>Range indexes store min/max values per file for a column, enabling file pruning at query time. Files whose [min, max]
 range does not overlap with the queried values are skipped.
 </p></div><dl class="paramcmts block"><dt class="param">column</dt><dd class="cmt"><p>
@@ -700,7 +700,7 @@ range does not overlap with the queried values are skipped.
       <span class="symbol">
         <a title="Configuration for a temporal index." href="TemporalIndexConfig.html"><span class="name">TemporalIndexConfig</span></a><span class="params">(<span name="column">column: <span class="extype" name="scala.Predef.String">String</span></span>, <span name="timestamp_column">timestamp_column: <span class="extype" name="scala.Predef.String">String</span></span>)</span><span class="result"> extends <span class="extype" name="scala.Product">Product</span> with <span class="extype" name="scala.Serializable">Serializable</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Configuration for a temporal index.</p><div class="fullcomment"><div class="comment cmt"><p>Configuration for a temporal index.</p><p>Temporal indexes track entity versions across files. When joining on the value column, only the row with the latest
 timestamp is returned, effectively deduplicating across files by recency.
 </p></div><dl class="paramcmts block"><dt class="param">column</dt><dd class="cmt"><p>
@@ -709,7 +709,7 @@ timestamp is returned, effectively deduplicating across files by recency.
     </li></ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -728,7 +728,7 @@ timestamp is returned, effectively deduplicating across files by recency.
       <span class="symbol">
         <a title="Factory and utility methods for FileList instances." href="FileList$.html"><span class="name">FileList</span></a><span class="result"> extends <span class="extype" name="scala.Serializable">Serializable</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Factory and utility methods for FileList instances.</p><div class="fullcomment"><div class="comment cmt"><p>Factory and utility methods for FileList instances.</p><p>Provides path resolution, existence checks, and removal operations for file lists stored as Delta tables.
 </p></div></div>
     </li><li name="dev.cjfravel.ariadne.Index" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
@@ -745,7 +745,7 @@ timestamp is returned, effectively deduplicating across files by recency.
       <span class="symbol">
         <a title="Companion object for the Index class." href="Index$.html"><span class="name">Index</span></a><span class="result"> extends <span class="extype" name="scala.Serializable">Serializable</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Companion object for the Index class.</p><div class="fullcomment"><div class="comment cmt"><p>Companion object for the Index class.</p><p>Provides factory methods for creating or reconnecting to indexes, as well as utility methods for checking existence
 and removing indexes.
 </p></div></div>
@@ -763,7 +763,7 @@ and removing indexes.
       <span class="symbol">
         <a title="Catalog for discovering, inspecting, and managing all Ariadne indexes under the configured spark.ariadne.storagePath." href="IndexCatalog$.html"><span class="name">IndexCatalog</span></a>
       </span>
-
+      
       <p class="shortcomment cmt">Catalog for discovering, inspecting, and managing all Ariadne indexes under the configured
 <code>spark.ariadne.storagePath</code>.</p><div class="fullcomment"><div class="comment cmt"><p>Catalog for discovering, inspecting, and managing all Ariadne indexes under the configured
 <code>spark.ariadne.storagePath</code>.</p><p><code>IndexCatalog</code> is stateless — every call scans the filesystem for the current set of indexes. It complements the
@@ -794,7 +794,7 @@ IndexCatalog.toDF().show()
       <span class="symbol">
         <a title="Factory object for creating IndexMetadata instances from JSON." href="IndexMetadata$.html"><span class="name">IndexMetadata</span></a><span class="result"> extends <span class="extype" name="scala.Serializable">Serializable</span></span>
       </span>
-
+      
       <p class="shortcomment cmt">Factory object for creating IndexMetadata instances from JSON.</p><div class="fullcomment"><div class="comment cmt"><p>Factory object for creating IndexMetadata instances from JSON.</p><p>Provides deserialization capabilities with automatic version migration to ensure backward compatibility across
 different metadata formats.
 </p></div></div>
@@ -812,7 +812,7 @@ different metadata formats.
       <span class="symbol">
         <a title="Utility object providing path resolution and lifecycle operations for indexes." href="IndexPathUtils$.html"><span class="name">IndexPathUtils</span></a>
       </span>
-
+      
       <p class="shortcomment cmt">Utility object providing path resolution and lifecycle operations for indexes.</p><div class="fullcomment"><div class="comment cmt"><p>Utility object providing path resolution and lifecycle operations for indexes.</p><p>All paths are resolved relative to the configured <code>spark.ariadne.storagePath</code>. This object is stateless; filesystem
 access is performed through temporary <a href="AriadneContextUser.html" class="extype" name="dev.cjfravel.ariadne.AriadneContextUser">AriadneContextUser</a> instances created from the implicit <code>SparkSession</code>.
 </p></div></div>
@@ -830,7 +830,7 @@ access is performed through temporary <a href="AriadneContextUser.html" class="e
       <span class="symbol">
         <a title="Utility object for Spark schema introspection." href="SchemaHelper$.html"><span class="name">SchemaHelper</span></a>
       </span>
-
+      
       <p class="shortcomment cmt">Utility object for Spark schema introspection.</p><div class="fullcomment"><div class="comment cmt"><p>Utility object for Spark schema introspection.</p><p>Provides methods for validating field existence within <span class="extype" name="org.apache.spark.sql.types.StructType">org.apache.spark.sql.types.StructType</span> schemas, including
 support for nested field paths using dot notation. Used throughout Ariadne to validate that indexed columns exist in
 the user-supplied schema before persisting metadata.</p><p><b>Thread safety:</b> All methods are pure functions with no mutable state; safe to call concurrently from any thread.
@@ -839,20 +839,20 @@ the user-supplied schema before persisting metadata.</p><p><b>Thread safety:</b>
               </ol>
             </div>
 
+        
 
-
-
+        
         </div>
 
         <div id="inheritedMembers">
-
-
+        
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/cjfravel/index.html
+++ b/docs/api/dev/cjfravel/index.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../index.js"></script>
       <script type="text/javascript" src="../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">dev</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 current" data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <span class="name">cjfravel</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="dev">dev</a></dd></dl></div>
     </li><li name="dev.cjfravel.ariadne" visbl="pub" class="indented3 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="ariadne"></a><a id="ariadne:ariadne"></a>
@@ -115,8 +115,8 @@
       <span class="symbol">
         <a title="" href="ariadne/index.html"><span class="name">ariadne</span></a>
       </span>
-
-
+      
+      
     </li>
               </ul>
             </div>
@@ -131,7 +131,7 @@
         <i class="material-icons"></i>
       </a>
     </span></h1>
-
+        
       </div>
 
       <h4 id="signature" class="signature">
@@ -144,36 +144,36 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"></div>
+        
 
-
-
+      
 
       <div id="template">
         <div id="allMembers">
+        
 
+        
 
+        
 
+        
 
+        
 
-
-
-
-
-
-
+        
         </div>
 
         <div id="inheritedMembers">
-
-
+        
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/dev/index.html
+++ b/docs/api/dev/index.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../index.js"></script>
       <script type="text/javascript" src="../lib/scheduler.js"></script>
       <script type="text/javascript" src="../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.dev" visbl="pub" class="indented1 current" data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <span class="name">dev</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="dev.cjfravel" visbl="pub" class="indented2 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="cjfravel"></a><a id="cjfravel:cjfravel"></a>
@@ -99,8 +99,8 @@
       <span class="symbol">
         <a title="" href="cjfravel/index.html"><span class="name">cjfravel</span></a>
       </span>
-
-
+      
+      
     </li>
               </ul>
             </div>
@@ -109,13 +109,13 @@
             <body class="package value">
       <div id="definition">
         <div class="big-circle package">p</div>
-
+        
         <h1>dev<span class="permalink">
       <a href="../dev/index.html" title="Permalink">
         <i class="material-icons"></i>
       </a>
     </span></h1>
-
+        
       </div>
 
       <h4 id="signature" class="signature">
@@ -128,36 +128,36 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"></div>
+        
 
-
-
+      
 
       <div id="template">
         <div id="allMembers">
+        
 
+        
 
+        
 
+        
 
+        
 
-
-
-
-
-
-
+        
         </div>
 
         <div id="inheritedMembers">
-
-
+        
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API " />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API " />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="index.js"></script>
       <script type="text/javascript" src="lib/scheduler.js"></script>
       <script type="text/javascript" src="lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,8 +67,8 @@
       <span class="symbol">
         <span class="name">root</span>
       </span>
-
-
+      
+      
     </li><li name="_root_.dev" visbl="pub" class="indented1 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="dev"></a><a id="dev:dev"></a>
       <span class="permalink">
@@ -83,8 +83,8 @@
       <span class="symbol">
         <a title="" href="dev/index.html"><span class="name">dev</span></a>
       </span>
-
-
+      
+      
     </li><li name="_root_.org" visbl="pub" class="indented1 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="org"></a><a id="org:org"></a>
       <span class="permalink">
@@ -99,8 +99,8 @@
       <span class="symbol">
         <a title="" href="org/index.html"><span class="name">org</span></a>
       </span>
-
-
+      
+      
     </li>
               </ul>
             </div>
@@ -109,13 +109,13 @@
             <body class="package value">
       <div id="definition">
         <div class="big-circle package">p</div>
-
+        
         <h1>root package<span class="permalink">
       <a href="index.html" title="Permalink">
         <i class="material-icons"></i>
       </a>
     </span></h1>
-
+        
       </div>
 
       <h4 id="signature" class="signature">
@@ -128,36 +128,36 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"></div>
+        
 
-
-
+      
 
       <div id="template">
         <div id="allMembers">
+        
 
+        
 
+        
 
+        
 
+        
 
-
-
-
-
-
-
+        
         </div>
 
         <div id="inheritedMembers">
-
-
+        
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/lib/index.css
+++ b/docs/api/lib/index.css
@@ -111,8 +111,8 @@
   margin: 0px;
 }
 
-u {
-  text-decoration: underline;
+u { 
+  text-decoration: underline; 
 }
 
 a {

--- a/docs/api/org/apache/index.html
+++ b/docs/api/org/apache/index.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - org.apache" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API org.apache" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../index.js"></script>
       <script type="text/javascript" src="../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.org" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="org"></a><a id="org:org"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">org</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="org.apache" visbl="pub" class="indented2 current" data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="apache"></a><a id="apache:apache"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <span class="name">apache</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="org">org</a></dd></dl></div>
     </li><li name="org.apache.spark" visbl="pub" class="indented3 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="spark"></a><a id="spark:spark"></a>
@@ -115,8 +115,8 @@
       <span class="symbol">
         <a title="" href="spark/index.html"><span class="name">spark</span></a>
       </span>
-
-
+      
+      
     </li>
               </ul>
             </div>
@@ -131,7 +131,7 @@
         <i class="material-icons"></i>
       </a>
     </span></h1>
-
+        
       </div>
 
       <h4 id="signature" class="signature">
@@ -144,36 +144,36 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"></div>
+        
 
-
-
+      
 
       <div id="template">
         <div id="allMembers">
+        
 
+        
 
+        
 
+        
 
+        
 
-
-
-
-
-
-
+        
         </div>
 
         <div id="inheritedMembers">
-
-
+        
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/org/apache/spark/index.html
+++ b/docs/api/org/apache/spark/index.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - org.apache.spark" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API org.apache.spark" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../index.js"></script>
       <script type="text/javascript" src="../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.org" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="org"></a><a id="org:org"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">org</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="org.apache" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="apache"></a><a id="apache:apache"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">apache</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="org">org</a></dd></dl></div>
     </li><li name="org.apache.spark" visbl="pub" class="indented3 current" data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="spark"></a><a id="spark:spark"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <span class="name">spark</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="org.apache">apache</a></dd></dl></div>
     </li><li name="org.apache.spark.sql" visbl="pub" class="indented4 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="sql"></a><a id="sql:sql"></a>
@@ -131,8 +131,8 @@
       <span class="symbol">
         <a title="" href="sql/index.html"><span class="name">sql</span></a>
       </span>
-
-
+      
+      
     </li>
               </ul>
             </div>
@@ -147,7 +147,7 @@
         <i class="material-icons"></i>
       </a>
     </span></h1>
-
+        
       </div>
 
       <h4 id="signature" class="signature">
@@ -160,14 +160,14 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="toggleContainer block">
           <span class="toggle">
             Linear Supertypes
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -182,7 +182,7 @@
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -209,11 +209,11 @@
 
       <div id="template">
         <div id="allMembers">
+        
 
+        
 
-
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -232,8 +232,8 @@
       <span class="symbol">
         <span class="name">SPARK_BRANCH</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="org.apache.spark#SPARK_BUILD_DATE" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="SPARK_BUILD_DATE:String"></a>
       <span class="permalink">
@@ -248,8 +248,8 @@
       <span class="symbol">
         <span class="name">SPARK_BUILD_DATE</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="org.apache.spark#SPARK_BUILD_USER" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="SPARK_BUILD_USER:String"></a>
       <span class="permalink">
@@ -264,8 +264,8 @@
       <span class="symbol">
         <span class="name">SPARK_BUILD_USER</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="org.apache.spark#SPARK_DOC_ROOT" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="SPARK_DOC_ROOT:String"></a>
       <span class="permalink">
@@ -280,8 +280,8 @@
       <span class="symbol">
         <span class="name">SPARK_DOC_ROOT</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="org.apache.spark#SPARK_REPO_URL" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="SPARK_REPO_URL:String"></a>
       <span class="permalink">
@@ -296,8 +296,8 @@
       <span class="symbol">
         <span class="name">SPARK_REPO_URL</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="org.apache.spark#SPARK_REVISION" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="SPARK_REVISION:String"></a>
       <span class="permalink">
@@ -312,8 +312,8 @@
       <span class="symbol">
         <span class="name">SPARK_REVISION</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="org.apache.spark#SPARK_VERSION" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="SPARK_VERSION:String"></a>
       <span class="permalink">
@@ -328,8 +328,8 @@
       <span class="symbol">
         <span class="name">SPARK_VERSION</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li><li name="org.apache.spark#SPARK_VERSION_SHORT" visbl="pub" class="indented0 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="SPARK_VERSION_SHORT:String"></a>
       <span class="permalink">
@@ -344,15 +344,15 @@
       <span class="symbol">
         <span class="name">SPARK_VERSION_SHORT</span><span class="result">: <span class="extype" name="scala.Predef.String">String</span></span>
       </span>
-
-
+      
+      
     </li>
               </ol>
             </div>
 
+        
 
-
-
+        
         </div>
 
         <div id="inheritedMembers">
@@ -361,13 +361,13 @@
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/org/apache/spark/sql/AriadneInternalHelper$.html
+++ b/docs/api/org/apache/spark/sql/AriadneInternalHelper$.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - org.apache.spark.sql.AriadneInternalHelper" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API org.apache.spark.sql.AriadneInternalHelper" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.org" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="org"></a><a id="org:org"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">org</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="org.apache" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="apache"></a><a id="apache:apache"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">apache</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="org">org</a></dd></dl></div>
     </li><li name="org.apache.spark" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="spark"></a><a id="spark:spark"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">spark</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="org.apache">apache</a></dd></dl></div>
     </li><li name="org.apache.spark.sql" visbl="pub" class="indented4 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="sql"></a><a id="sql:sql"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <a title="" href="index.html"><span class="name">sql</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="org.apache.spark">spark</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -164,7 +164,7 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="comment cmt"><p>Bridge helper to access <code>private[sql]</code> Spark APIs from Ariadne.</p><p>This follows the standard pattern used by Delta Lake and other Spark connectors: placing a helper in the
 <code>org.apache.spark.sql</code> package to access <code>private[sql]</code> members like <code>Dataset.ofRows</code>.
 </p></div><dl class="attributes block"> <dt>See also</dt><dd><span class="cmt"><p>
@@ -174,7 +174,7 @@
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -189,7 +189,7 @@
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -216,11 +216,11 @@
 
       <div id="template">
         <div id="allMembers">
+        
 
+        
 
-
-
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -239,7 +239,7 @@
       <span class="symbol">
         <span title="gt4s: $bang$eq" class="name">!=</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef###" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="##():Int"></a>
@@ -255,7 +255,7 @@
       <span class="symbol">
         <span title="gt4s: $hash$hash" class="name">##</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#==" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="==(x$1:Any):Boolean"></a><a id="==(Any):Boolean"></a>
@@ -271,7 +271,7 @@
       <span class="symbol">
         <span title="gt4s: $eq$eq" class="name">==</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
@@ -287,7 +287,7 @@
       <span class="symbol">
         <span class="name">asInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Any.asInstanceOf.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#clone" visbl="prt" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="clone():Object"></a><a id="clone():AnyRef"></a>
@@ -303,17 +303,17 @@
       <span class="symbol">
         <span class="name">clone</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.AnyRef">AnyRef</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.CloneNotSupportedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="org.apache.spark.sql.AriadneInternalHelper#dataFrameFromPlan" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="dataFrameFromPlan(spark:org.apache.spark.sql.SparkSession,plan:org.apache.spark.sql.catalyst.plans.logical.LogicalPlan):org.apache.spark.sql.DataFrame"></a><a id="dataFrameFromPlan(SparkSession,LogicalPlan):DataFrame"></a>
@@ -329,7 +329,7 @@
       <span class="symbol">
         <span class="name">dataFrameFromPlan</span><span class="params">(<span name="spark">spark: <span class="extype" name="org.apache.spark.sql.SparkSession">SparkSession</span></span>, <span name="plan">plan: <span class="extype" name="org.apache.spark.sql.catalyst.plans.logical.LogicalPlan">LogicalPlan</span></span>)</span><span class="result">: <a href="index.html#DataFrame=org.apache.spark.sql.Dataset[org.apache.spark.sql.Row]" class="extmbr" name="org.apache.spark.sql.DataFrame">DataFrame</a></span>
       </span>
-
+      
       <p class="shortcomment cmt">Creates a DataFrame from a resolved LogicalPlan.</p><div class="fullcomment"><div class="comment cmt"><p>Creates a DataFrame from a resolved LogicalPlan.</p><p>Wraps <code>Dataset.ofRows()</code> which is <code>private[sql]</code>.
 </p></div><dl class="paramcmts block"><dt class="param">spark</dt><dd class="cmt"><p>
   the active SparkSession</p></dd><dt class="param">plan</dt><dd class="cmt"><p>
@@ -349,7 +349,7 @@
       <span class="symbol">
         <span class="name">eq</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#equals" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="equals(x$1:Any):Boolean"></a><a id="equals(Any):Boolean"></a>
@@ -365,7 +365,7 @@
       <span class="symbol">
         <span class="name">equals</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Any">Any</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#getClass" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="getClass():Class[_]"></a>
@@ -381,12 +381,12 @@
       <span class="symbol">
         <span class="name">getClass</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.Class">Class</span>[_]</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#hashCode" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="hashCode():Int"></a>
@@ -402,12 +402,12 @@
       <span class="symbol">
         <span class="name">hashCode</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.Any#isInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="isInstanceOf[T0]:Boolean"></a>
@@ -423,7 +423,7 @@
       <span class="symbol">
         <span class="name">isInstanceOf</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>Any</dd></dl></div>
     </li><li name="scala.AnyRef#ne" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="ne(x$1:AnyRef):Boolean"></a><a id="ne(AnyRef):Boolean"></a>
@@ -439,7 +439,7 @@
       <span class="symbol">
         <span class="name">ne</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.AnyRef">AnyRef</span></span>)</span><span class="result">: <span class="extype" name="scala.Boolean">Boolean</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#notify" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notify():Unit"></a>
@@ -455,12 +455,12 @@
       <span class="symbol">
         <span class="name">notify</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#notifyAll" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="notifyAll():Unit"></a>
@@ -476,12 +476,12 @@
       <span class="symbol">
         <span class="name">notifyAll</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@native</span><span class="args">()</span>
-
+              
                 <span class="name">@HotSpotIntrinsicCandidate</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#synchronized" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="synchronized[T0](x$1:=&gt;T0):T0"></a><a id="synchronized[T0](⇒T0):T0"></a>
@@ -497,7 +497,7 @@
       <span class="symbol">
         <span class="name">synchronized</span><span class="tparams">[<span name="T0">T0</span>]</span><span class="params">(<span name="arg0">arg0: ⇒ <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>)</span><span class="result">: <span class="extype" name="java.lang.AnyRef.synchronized.T0">T0</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd></dl></div>
     </li><li name="scala.AnyRef#toString" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="toString():String"></a>
@@ -513,7 +513,7 @@
       <span class="symbol">
         <span class="name">toString</span><span class="params">()</span><span class="result">: <span class="extype" name="java.lang.String">String</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef → Any</dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long,x$2:Int):Unit"></a><a id="wait(Long,Int):Unit"></a>
@@ -529,13 +529,13 @@
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>, <span name="arg1">arg1: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait(x$1:Long):Unit"></a><a id="wait(Long):Unit"></a>
@@ -551,15 +551,15 @@
       <span class="symbol">
         <span class="name">wait</span><span class="params">(<span name="arg0">arg0: <span class="extype" name="scala.Long">Long</span></span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
                 <span class="name">@native</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li><li name="scala.AnyRef#wait" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="wait():Unit"></a>
@@ -575,19 +575,19 @@
       <span class="symbol">
         <span class="name">wait</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="defval" name="classOf[java.lang.InterruptedException]">...</span>
     </span>)</span>
-
+              
         </dd></dl></div>
     </li>
               </ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Deprecated Value Members</h3>
@@ -605,15 +605,15 @@
       <span class="symbol">
         <span class="name deprecated" title="Deprecated: ">finalize</span><span class="params">()</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Attributes</dt><dd>protected[<span class="extype" name="java.lang">lang</span>] </dd><dt>Definition Classes</dt><dd>AnyRef</dd><dt>Annotations</dt><dd>
                 <span class="name">@throws</span><span class="args">(<span>
-
+      
       <span class="symbol">classOf[java.lang.Throwable]</span>
     </span>)</span>
-
+              
                 <span class="name">@Deprecated</span>
-
+              
         </dd><dt>Deprecated</dt><dd class="cmt"></dd></dl></div>
     </li></ol>
             </div>
@@ -625,13 +625,13 @@
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/org/apache/spark/sql/index.html
+++ b/docs/api/org/apache/spark/sql/index.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - org.apache.spark.sql" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API org.apache.spark.sql" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../../../../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../../../../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../../../../index.js"></script>
       <script type="text/javascript" src="../../../../lib/scheduler.js"></script>
       <script type="text/javascript" src="../../../../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../../../../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../../../../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.org" visbl="pub" class="indented1 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="org"></a><a id="org:org"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <a title="" href="../../../index.html"><span class="name">org</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="org.apache" visbl="pub" class="indented2 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="apache"></a><a id="apache:apache"></a>
@@ -99,7 +99,7 @@
       <span class="symbol">
         <a title="" href="../../index.html"><span class="name">apache</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../../index.html" class="extype" name="org">org</a></dd></dl></div>
     </li><li name="org.apache.spark" visbl="pub" class="indented3 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="spark"></a><a id="spark:spark"></a>
@@ -115,7 +115,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">spark</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../../index.html" class="extype" name="org.apache">apache</a></dd></dl></div>
     </li><li name="org.apache.spark.sql" visbl="pub" class="indented4 current" data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="sql"></a><a id="sql:sql"></a>
@@ -131,7 +131,7 @@
       <span class="symbol">
         <span class="name">sql</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="org.apache.spark">spark</a></dd></dl></div>
     </li><li class="current-entities indented4">
                         <span class="separator"></span>
@@ -151,7 +151,7 @@
         <i class="material-icons"></i>
       </a>
     </span></h1>
-
+        
       </div>
 
       <h4 id="signature" class="signature">
@@ -164,14 +164,14 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"><div class="toggleContainer block">
           <span class="toggle">
             Linear Supertypes
           </span>
           <div class="superTypes hiddenContent"><span class="extype" name="scala.AnyRef">AnyRef</span>, <span class="extype" name="scala.Any">Any</span></div>
         </div></div>
-
+        
 
       <div id="mbrsel">
         <div class="toggle"></div>
@@ -186,7 +186,7 @@
           <div id="order">
             <span class="filtertype">Ordering</span>
             <ol>
-
+              
               <li class="alpha in"><span>Alphabetic</span></li>
               <li class="inherit out"><span>By Inheritance</span></li>
             </ol>
@@ -213,7 +213,7 @@
 
       <div id="template">
         <div id="allMembers">
-
+        
 
         <div id="types" class="types members">
               <h3>Type Members</h3>
@@ -231,8 +231,8 @@
       <span class="symbol">
         <span class="name">DataFrame</span><span class="result alias"> = <span class="extype" name="org.apache.spark.sql.Dataset">Dataset</span>[<span class="extype" name="org.apache.spark.sql.Row">Row</span>]</span>
       </span>
-
-
+      
+      
     </li><li name="org.apache.spark.sql.Strategy" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="Strategy=org.apache.spark.sql.execution.SparkStrategy"></a><a id="Strategy:Strategy"></a>
       <span class="permalink">
@@ -247,17 +247,17 @@
       <span class="symbol">
         <span class="name">Strategy</span><span class="result alias"> = <span class="extype" name="org.apache.spark.sql.execution.SparkStrategy">SparkStrategy</span></span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Annotations</dt><dd>
                 <span class="name">@DeveloperApi</span><span class="args">()</span>
-
+              
                 <span class="name">@Unstable</span><span class="args">()</span>
-
+              
         </dd></dl></div>
     </li></ol>
             </div>
 
-
+        
 
         <div class="values members">
               <h3>Value Members</h3>
@@ -276,7 +276,7 @@
       <span class="symbol">
         <a title="Bridge helper to access private[sql] Spark APIs from Ariadne." href="AriadneInternalHelper$.html"><span class="name">AriadneInternalHelper</span></a>
       </span>
-
+      
       <p class="shortcomment cmt">Bridge helper to access <code>private[sql]</code> Spark APIs from Ariadne.</p><div class="fullcomment"><div class="comment cmt"><p>Bridge helper to access <code>private[sql]</code> Spark APIs from Ariadne.</p><p>This follows the standard pattern used by Delta Lake and other Spark connectors: placing a helper in the
 <code>org.apache.spark.sql</code> package to access <code>private[sql]</code> members like <code>Dataset.ofRows</code>.
 </p></div><dl class="attributes block"> <dt>See also</dt><dd><span class="cmt"><p>
@@ -285,9 +285,9 @@
               </ol>
             </div>
 
+        
 
-
-
+        
         </div>
 
         <div id="inheritedMembers">
@@ -296,13 +296,13 @@
             </div><div class="parent" name="scala.Any">
               <h3>Inherited from <span class="extype" name="scala.Any">Any</span></h3>
             </div>
-
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/docs/api/org/index.html
+++ b/docs/api/org/index.html
@@ -7,8 +7,8 @@
           <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - org" />
           <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API org" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-
+          
+      
       <link href="../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../lib/template.css" media="screen" type="text/css" rel="stylesheet" />
       <link href="../lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
@@ -19,12 +19,12 @@
       <script type="text/javascript" src="../index.js"></script>
       <script type="text/javascript" src="../lib/scheduler.js"></script>
       <script type="text/javascript" src="../lib/template.js"></script>
-
+      
       <script type="text/javascript">
         /* this variable can be used by the JS to determine the path to the root document */
         var toRoot = '../';
       </script>
-
+    
         </head>
         <body>
       <div id="search">
@@ -67,7 +67,7 @@
       <span class="symbol">
         <a title="" href="../index.html"><span class="name">root</span></a>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="_root_.org" visbl="pub" class="indented1 current" data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="org"></a><a id="org:org"></a>
@@ -83,7 +83,7 @@
       <span class="symbol">
         <span class="name">org</span>
       </span>
-
+      
       <div class="fullcomment"><dl class="attributes block"> <dt>Definition Classes</dt><dd><a href="../index.html" class="extype" name="_root_">root</a></dd></dl></div>
     </li><li name="org.apache" visbl="pub" class="indented2 " data-isabs="false" fullComment="no" group="Ungrouped">
       <a id="apache"></a><a id="apache:apache"></a>
@@ -99,8 +99,8 @@
       <span class="symbol">
         <a title="" href="apache/index.html"><span class="name">apache</span></a>
       </span>
-
-
+      
+      
     </li>
               </ul>
             </div>
@@ -109,13 +109,13 @@
             <body class="package value">
       <div id="definition">
         <div class="big-circle package">p</div>
-
+        
         <h1>org<span class="permalink">
       <a href="../org/index.html" title="Permalink">
         <i class="material-icons"></i>
       </a>
     </span></h1>
-
+        
       </div>
 
       <h4 id="signature" class="signature">
@@ -128,36 +128,36 @@
       </span>
       </h4>
 
-
+      
           <div id="comment" class="fullcommenttop"></div>
+        
 
-
-
+      
 
       <div id="template">
         <div id="allMembers">
+        
 
+        
 
+        
 
+        
 
+        
 
-
-
-
-
-
-
+        
         </div>
 
         <div id="inheritedMembers">
-
-
+        
+        
         </div>
 
         <div id="groupedMembers">
         <div class="group" name="Ungrouped">
               <h3>Ungrouped</h3>
-
+              
             </div>
         </div>
 

--- a/pom.xml
+++ b/pom.xml
@@ -289,6 +289,50 @@
                             </arguments>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>test-api-docs-drift</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <skip>false</skip>
+                            <executable>bash</executable>
+                            <arguments>
+                                <argument>dev/scripts/api-docs-drift-tests.sh</argument>
+                                <argument>${spark.compat}</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>clean-api-docs-output</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <skip>false</skip>
+                            <executable>bash</executable>
+                            <arguments>
+                                <argument>dev/scripts/clean-api-docs-output.sh</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-package-contents</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <skip>false</skip>
+                            <executable>bash</executable>
+                            <arguments>
+                                <argument>dev/scripts/package-contents-tests.sh</argument>
+                                <argument>${project.build.directory}/${project.build.finalName}.jar</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 


### PR DESCRIPTION
## Summary
- enforce exact coordinated versions for both supported Spark artifacts
- reject stale generated API documentation, including dirty cross-profile output
- verify shaded JAR contents exclude provided and unrelocated dependencies
- regenerate canonical Spark 3.5 Scaladoc

## TDD evidence
**RED:** `bash dev/scripts/readme-has-version-tests.sh` accepted substring and mismatched artifact versions; `bash dev/scripts/repository-readiness-tests.sh` reported missing contracts; cross-profile Scaladoc drift was reproduced after Spark 4 output contaminated the Spark 3 target.

**GREEN:** `JAVA_HOME=/usr/lib/jvm/java-11-openjdk mvn -B -q verify -DskipTests -Dgpg.skip=true`; Spark 4 package verification also passed locally with the available newer JDK (CI validates Java 21).

## Scope
No GitHub Actions workflows or publication behavior are changed.