### PR TITLE
Stage coordinated Maven Central releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,7 +67,9 @@ jobs:
           base="https://repo1.maven.org/maven2/dev/cjfravel"
           for artifact in ariadne-spark35_2.12 ariadne-spark41_2.13; do
             url="$base/$artifact/$version/$artifact-$version.pom"
-            if curl --fail --silent --show-error --location --output /dev/null "$url"; then
+            if curl --fail --silent --show-error --location \
+              --retry 5 --retry-all-errors --retry-delay 2 --retry-max-time 30 \
+              --output /dev/null "$url"; then
               echo "$artifact:$version is already published." >&2
               exit 1
             fi
@@ -208,8 +210,8 @@ jobs:
           for attempt in $(seq 1 360); do
             state35=UNKNOWN
             state41=UNKNOWN
-            state35=$(status "$DEPLOYMENT_35" | jq -r .deploymentState) || true
-            state41=$(status "$DEPLOYMENT_41" | jq -r .deploymentState) || true
+            state35=$(status "$DEPLOYMENT_35" | jq -r .deploymentState) || state35=UNKNOWN
+            state41=$(status "$DEPLOYMENT_41" | jq -r .deploymentState) || state41=UNKNOWN
             if [[ "$state35" == "FAILED" || "$state41" == "FAILED" ]]; then
               echo "Central publication failed: Spark 3.5=$state35, Spark 4.1=$state41" >&2
               exit 1
@@ -271,3 +273,35 @@ jobs:
             echo "- \`dev.cjfravel:ariadne-spark35_2.12:$RELEASE_TAG\`"
             echo "- \`dev.cjfravel:ariadne-spark41_2.13:$RELEASE_TAG\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Final cleanup after a release failure
+        if: failure()
+        env:
+          DEPLOYMENT_35: ${{ steps.stage35.outputs.deployment_id }}
+          DEPLOYMENT_41: ${{ steps.stage41.outputs.deployment_id }}
+        run: |
+          set -euo pipefail
+          auth=$(printf '%s:%s' "$CENTRAL_USERNAME" "$CENTRAL_TOKEN" | base64 -w0)
+          authorization_header=$(printf 'Authorization: %s %s' Bearer "$auth")
+          cleanup_failed=0
+
+          status() {
+            curl --fail --silent --show-error --retry 5 --retry-all-errors \
+              --request POST \
+              --header "$authorization_header" \
+              "https://central.sonatype.com/api/v1/publisher/status?id=$1"
+          }
+
+          for deployment_id in "$DEPLOYMENT_35" "$DEPLOYMENT_41"; do
+            [[ -n "$deployment_id" ]] || continue
+            state=UNKNOWN
+            state=$(status "$deployment_id" | jq -r .deploymentState) || state=UNKNOWN
+            if [[ "$state" == "VALIDATED" || "$state" == "FAILED" ]]; then
+              curl --fail --silent --show-error --retry 5 --retry-all-errors \
+                --request DELETE \
+                --header "$authorization_header" \
+                "https://central.sonatype.com/api/v1/publisher/deployment/$deployment_id" ||
+                cleanup_failed=1
+            fi
+          done
+          exit "$cleanup_failed"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,270 @@
+name: Maven Central
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: maven-central
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish Spark 3.5 and 4.1
+    runs-on: ubuntu-latest
+    environment: maven-central
+    env:
+      MAVEN_OPTS: -Xmx8g -XX:+UseG1GC
+      CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+      CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}
+      MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      GPG_KEY_ID: ${{ vars.GPG_KEY_ID }}
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set up Java 11 and release credentials
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "11"
+          cache: maven
+          server-id: central
+          server-username: CENTRAL_USERNAME
+          server-password: CENTRAL_TOKEN
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+
+      - name: Verify release identity and credentials
+        env:
+          CENTRAL_USER_TOKEN_EXPIRATION_DATE: ${{ vars.CENTRAL_USER_TOKEN_EXPIRATION_DATE }}
+          GPG_KEY_EXPIRATION_DATE: ${{ vars.GPG_KEY_EXPIRATION_DATE }}
+        run: |
+          set -euo pipefail
+          version=$(./mvnw -q help:evaluate -Dexpression=project.version -DforceStdout)
+          test "$RELEASE_TAG" = "$version"
+          test "${version%-SNAPSHOT}" = "$version"
+
+          for expiration in "$CENTRAL_USER_TOKEN_EXPIRATION_DATE" "$GPG_KEY_EXPIRATION_DATE"; do
+            test "$(date -u +%s)" -lt "$(date -u -d "$expiration" +%s)"
+          done
+
+          imported_fingerprint=$(
+            gpg --batch --with-colons --fingerprint "$GPG_KEY_ID" |
+              awk -F: '$1 == "fpr" { print $10; exit }'
+          )
+          test "$imported_fingerprint" = "$GPG_KEY_ID"
+          gpg --batch --with-colons --list-keys "$GPG_KEY_ID" |
+            awk -F: '$1 == "uid" { print $10 }' |
+            grep -F 'Ariadne Release <ariadne-releases@cjfravel.dev>'
+
+          base="https://repo1.maven.org/maven2/dev/cjfravel"
+          for artifact in ariadne-spark35_2.12 ariadne-spark41_2.13; do
+            url="$base/$artifact/$version/$artifact-$version.pom"
+            if curl --fail --silent --show-error --location --output /dev/null "$url"; then
+              echo "$artifact:$version is already published." >&2
+              exit 1
+            fi
+          done
+
+      - name: Stage and validate Spark 3.5
+        id: stage35
+        run: |
+          set -uo pipefail
+          log=$(mktemp)
+          set +e
+          ./mvnw clean deploy -Pspark35 -B \
+            -Dgpg.skip=false \
+            -Dgpg.keyname="$GPG_KEY_ID" \
+            -Dcentral.autoPublish=false \
+            -Dcentral.waitUntil=validated \
+            -Dcentral.waitMaxTime=3600 | tee "$log"
+          status=${PIPESTATUS[0]}
+          set -e
+          deployment_id=$(
+            sed -n 's/.*deploymentId: \([0-9a-f-]\+\).*/\1/p' "$log" |
+              tail -1
+          )
+          rm -f "$log"
+          if [[ -n "$deployment_id" ]]; then
+            echo "deployment_id=$deployment_id" >> "$GITHUB_OUTPUT"
+          fi
+          exit "$status"
+
+      - name: Set up Java 21 and release credentials
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+          server-id: central
+          server-username: CENTRAL_USERNAME
+          server-password: CENTRAL_TOKEN
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+
+      - name: Stage and validate Spark 4.1
+        id: stage41
+        run: |
+          set -uo pipefail
+          log=$(mktemp)
+          set +e
+          ./mvnw clean deploy -Pspark41 -B \
+            -Dgpg.skip=false \
+            -Dgpg.keyname="$GPG_KEY_ID" \
+            -Dcentral.autoPublish=false \
+            -Dcentral.waitUntil=validated \
+            -Dcentral.waitMaxTime=3600 | tee "$log"
+          status=${PIPESTATUS[0]}
+          set -e
+          deployment_id=$(
+            sed -n 's/.*deploymentId: \([0-9a-f-]\+\).*/\1/p' "$log" |
+              tail -1
+          )
+          rm -f "$log"
+          if [[ -n "$deployment_id" ]]; then
+            echo "deployment_id=$deployment_id" >> "$GITHUB_OUTPUT"
+          fi
+          exit "$status"
+
+      - name: Drop validated deployments after a staging failure
+        if: failure()
+        env:
+          DEPLOYMENT_35: ${{ steps.stage35.outputs.deployment_id }}
+          DEPLOYMENT_41: ${{ steps.stage41.outputs.deployment_id }}
+        run: |
+          set -euo pipefail
+          auth=$(printf '%s:%s' "$CENTRAL_USERNAME" "$CENTRAL_TOKEN" | base64 -w0)
+          cleanup_failed=0
+          for deployment_id in "$DEPLOYMENT_35" "$DEPLOYMENT_41"; do
+            if [[ -n "$deployment_id" ]]; then
+              curl --fail --silent --show-error --retry 5 --retry-all-errors \
+                --request DELETE \
+                --header "Authorization: Bearer $auth" \
+                "https://central.sonatype.com/api/v1/publisher/deployment/$deployment_id" ||
+                cleanup_failed=1
+            fi
+          done
+          exit "$cleanup_failed"
+
+      - name: Publish both validated deployments
+        env:
+          DEPLOYMENT_35: ${{ steps.stage35.outputs.deployment_id }}
+          DEPLOYMENT_41: ${{ steps.stage41.outputs.deployment_id }}
+        run: |
+          set -euo pipefail
+          test -n "$DEPLOYMENT_35"
+          test -n "$DEPLOYMENT_41"
+          auth=$(printf '%s:%s' "$CENTRAL_USERNAME" "$CENTRAL_TOKEN" | base64 -w0)
+
+          publish() {
+            curl --fail --silent --show-error --retry 5 --retry-all-errors \
+              --request POST \
+              --header "Authorization: Bearer $auth" \
+              "https://central.sonatype.com/api/v1/publisher/deployment/$1"
+          }
+
+          publish "$DEPLOYMENT_35" &
+          pid35=$!
+          publish "$DEPLOYMENT_41" &
+          pid41=$!
+          publish_failed=0
+          wait "$pid35" || publish_failed=1
+          wait "$pid41" || publish_failed=1
+          if [[ "$publish_failed" -ne 0 ]]; then
+            echo "One or more publish requests failed; the status loop will retry validated deployments."
+          fi
+
+      - name: Wait for both Central publications
+        env:
+          DEPLOYMENT_35: ${{ steps.stage35.outputs.deployment_id }}
+          DEPLOYMENT_41: ${{ steps.stage41.outputs.deployment_id }}
+        run: |
+          set -euo pipefail
+          auth=$(printf '%s:%s' "$CENTRAL_USERNAME" "$CENTRAL_TOKEN" | base64 -w0)
+
+          status() {
+            curl --fail --silent --show-error --retry 5 --retry-all-errors \
+              --request POST \
+              --header "Authorization: Bearer $auth" \
+              "https://central.sonatype.com/api/v1/publisher/status?id=$1"
+          }
+
+          publish() {
+            curl --fail --silent --show-error --retry 5 --retry-all-errors \
+              --request POST \
+              --header "Authorization: ******" \
+              "https://central.sonatype.com/api/v1/publisher/deployment/$1"
+          }
+
+          for attempt in $(seq 1 360); do
+            state35=UNKNOWN
+            state41=UNKNOWN
+            state35=$(status "$DEPLOYMENT_35" | jq -r .deploymentState) || true
+            state41=$(status "$DEPLOYMENT_41" | jq -r .deploymentState) || true
+            if [[ "$state35" == "FAILED" || "$state41" == "FAILED" ]]; then
+              echo "Central publication failed: Spark 3.5=$state35, Spark 4.1=$state41" >&2
+              exit 1
+            fi
+            if [[ "$state35" == "PUBLISHED" && "$state41" == "PUBLISHED" ]]; then
+              exit 0
+            fi
+            if [[ "$state35" == "VALIDATED" ]]; then
+              publish "$DEPLOYMENT_35" || true
+            fi
+            if [[ "$state41" == "VALIDATED" ]]; then
+              publish "$DEPLOYMENT_41" || true
+            fi
+            sleep 10
+          done
+          echo "Central publication did not complete within 60 minutes." >&2
+          exit 1
+
+      - name: Wait for Maven Central resolution
+        run: |
+          set -euo pipefail
+          base="https://repo1.maven.org/maven2/dev/cjfravel"
+          artifacts=(ariadne-spark35_2.12 ariadne-spark41_2.13)
+
+          for attempt in $(seq 1 40); do
+            missing=0
+            for artifact in "${artifacts[@]}"; do
+              path="$artifact/$RELEASE_TAG/$artifact-$RELEASE_TAG.jar"
+              if ! curl --fail --silent --show-error --location --output /dev/null "$base/$path"; then
+                missing=1
+              fi
+            done
+            if [[ "$missing" -eq 0 ]]; then
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "Published artifacts did not become resolvable within 10 minutes." >&2
+          exit 1
+
+      - name: Resolve both artifacts from clean repositories
+        run: |
+          set -euo pipefail
+          for artifact in ariadne-spark35_2.12 ariadne-spark41_2.13; do
+            ./mvnw -B \
+              -Dmaven.repo.local="$RUNNER_TEMP/$artifact" \
+              dependency:get \
+              -Dtransitive=false \
+              -Dartifact="dev.cjfravel:$artifact:$RELEASE_TAG"
+          done
+
+      - name: Write release summary
+        run: |
+          {
+            echo "## Ariadne $RELEASE_TAG"
+            echo
+            echo "Published and verified:"
+            echo
+            echo "- \`dev.cjfravel:ariadne-spark35_2.12:$RELEASE_TAG\`"
+            echo "- \`dev.cjfravel:ariadne-spark41_2.13:$RELEASE_TAG\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -140,12 +140,13 @@ jobs:
         run: |
           set -euo pipefail
           auth=$(printf '%s:%s' "$CENTRAL_USERNAME" "$CENTRAL_TOKEN" | base64 -w0)
+          authorization_header=$(printf 'Authorization: %s %s' Bearer "$auth")
           cleanup_failed=0
           for deployment_id in "$DEPLOYMENT_35" "$DEPLOYMENT_41"; do
             if [[ -n "$deployment_id" ]]; then
               curl --fail --silent --show-error --retry 5 --retry-all-errors \
                 --request DELETE \
-                --header "Authorization: Bearer $auth" \
+                --header "$authorization_header" \
                 "https://central.sonatype.com/api/v1/publisher/deployment/$deployment_id" ||
                 cleanup_failed=1
             fi
@@ -161,11 +162,12 @@ jobs:
           test -n "$DEPLOYMENT_35"
           test -n "$DEPLOYMENT_41"
           auth=$(printf '%s:%s' "$CENTRAL_USERNAME" "$CENTRAL_TOKEN" | base64 -w0)
+          authorization_header=$(printf 'Authorization: %s %s' Bearer "$auth")
 
           publish() {
             curl --fail --silent --show-error --retry 5 --retry-all-errors \
               --request POST \
-              --header "Authorization: Bearer $auth" \
+              --header "$authorization_header" \
               "https://central.sonatype.com/api/v1/publisher/deployment/$1"
           }
 
@@ -187,18 +189,19 @@ jobs:
         run: |
           set -euo pipefail
           auth=$(printf '%s:%s' "$CENTRAL_USERNAME" "$CENTRAL_TOKEN" | base64 -w0)
+          authorization_header=$(printf 'Authorization: %s %s' Bearer "$auth")
 
           status() {
             curl --fail --silent --show-error --retry 5 --retry-all-errors \
               --request POST \
-              --header "Authorization: Bearer $auth" \
+              --header "$authorization_header" \
               "https://central.sonatype.com/api/v1/publisher/status?id=$1"
           }
 
           publish() {
             curl --fail --silent --show-error --retry 5 --retry-all-errors \
               --request POST \
-              --header "Authorization: ******" \
+              --header "$authorization_header" \
               "https://central.sonatype.com/api/v1/publisher/deployment/$1"
           }
 

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- Automated coordinated Maven Central releases: a published GitHub Release signs and validates the
+  Spark 3.5 and Spark 4.1 artifacts independently, then publishes only after both deployments pass
+  Central validation.
 - Contributor Covenant 2.1 governance, citation metadata, structured issue forms with private security routing, and a
   PR contract requiring RED/GREEN and persisted-compatibility evidence.
 - Repository-readiness contracts now enforce exact coordinated release metadata, canonical generated Scaladoc, and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Direct links:
 
 - [Contributing guide](https://cjfravel-dev.github.io/ariadne/contributors/index.html) — bug reports, dev setup, build, code style, PR process
 - [Architecture](https://cjfravel-dev.github.io/ariadne/contributors/architecture.html) — internals, trait stack, data flows
+- [Releasing](https://cjfravel-dev.github.io/ariadne/contributors/releasing.html) — coordinated Spark 3.5/4.1 publication
 - [Contributor License Agreement](https://cjfravel-dev.github.io/ariadne/contributors/cla.html)
 - [Security policy](https://cjfravel-dev.github.io/ariadne/contributors/security.html)
 - [Code of Conduct](CODE_OF_CONDUCT.md)

--- a/dev/scripts/release-pipeline-tests.sh
+++ b/dev/scripts/release-pipeline-tests.sh
@@ -44,6 +44,7 @@ assert_file .github/workflows/publish.yml
 assert_file docs/contributors/releasing.html
 assert_file .mvn/wrapper/maven-wrapper.properties
 assert_file mvnw
+assert_contains mvnw "HOME is unset and MAVEN_USER_HOME is not set"
 
 assert_contains .github/workflows/publish.yml "types: [published]"
 assert_contains .github/workflows/publish.yml "environment: maven-central"
@@ -56,6 +57,8 @@ assert_contains .github/workflows/publish.yml "-Dcentral.waitUntil=validated"
 assert_contains .github/workflows/publish.yml "set +e"
 assert_contains .github/workflows/publish.yml "state35=UNKNOWN"
 assert_contains .github/workflows/publish.yml "state41=UNKNOWN"
+assert_contains .github/workflows/publish.yml "|| state35=UNKNOWN"
+assert_contains .github/workflows/publish.yml "|| state41=UNKNOWN"
 assert_contains .github/workflows/publish.yml "cleanup_failed=0"
 assert_contains .github/workflows/publish.yml "publish_failed=0"
 assert_contains .github/workflows/publish.yml 'if [[ "$state35" == "VALIDATED" ]]'
@@ -63,6 +66,8 @@ assert_contains .github/workflows/publish.yml 'if [[ "$state41" == "VALIDATED" ]
 assert_contains .github/workflows/publish.yml "publisher/deployment/"
 assert_contains .github/workflows/publish.yml "authorization_header="
 assert_contains .github/workflows/publish.yml '--header "$authorization_header"'
+assert_contains .github/workflows/publish.yml "Final cleanup after a release failure"
+assert_contains .github/workflows/publish.yml "--retry-max-time 30"
 assert_contains .github/workflows/publish.yml "ariadne-spark35_2.12"
 assert_contains .github/workflows/publish.yml "ariadne-spark41_2.13"
 assert_not_contains .github/workflows/publish.yml "gpg-passphrase:"

--- a/dev/scripts/release-pipeline-tests.sh
+++ b/dev/scripts/release-pipeline-tests.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+assert_file() {
+    if [[ ! -f "$1" ]]; then
+        echo "Required release file is missing: $1"
+        exit 1
+    fi
+}
+
+assert_contains() {
+    local file="$1"
+    local expected="$2"
+    if ! grep -Fq -- "$expected" "$file"; then
+        echo "$file is missing release contract: $expected"
+        exit 1
+    fi
+}
+
+assert_not_contains() {
+    local file="$1"
+    local rejected="$2"
+    if grep -Fq -- "$rejected" "$file"; then
+        echo "$file contains forbidden release configuration: $rejected"
+        exit 1
+    fi
+}
+
+assert_file .github/workflows/publish.yml
+assert_file docs/contributors/releasing.html
+assert_file .mvn/wrapper/maven-wrapper.properties
+assert_file mvnw
+
+assert_contains .github/workflows/publish.yml "types: [published]"
+assert_contains .github/workflows/publish.yml "environment: maven-central"
+assert_contains .github/workflows/publish.yml "MAVEN_GPG_PASSPHRASE"
+assert_contains .github/workflows/publish.yml "Ariadne Release <ariadne-releases@cjfravel.dev>"
+assert_contains .github/workflows/publish.yml "-Pspark35"
+assert_contains .github/workflows/publish.yml "-Pspark41"
+assert_contains .github/workflows/publish.yml "-Dcentral.autoPublish=false"
+assert_contains .github/workflows/publish.yml "-Dcentral.waitUntil=validated"
+assert_contains .github/workflows/publish.yml "set +e"
+assert_contains .github/workflows/publish.yml "state35=UNKNOWN"
+assert_contains .github/workflows/publish.yml "state41=UNKNOWN"
+assert_contains .github/workflows/publish.yml "cleanup_failed=0"
+assert_contains .github/workflows/publish.yml "publish_failed=0"
+assert_contains .github/workflows/publish.yml 'if [[ "$state35" == "VALIDATED" ]]'
+assert_contains .github/workflows/publish.yml 'if [[ "$state41" == "VALIDATED" ]]'
+assert_contains .github/workflows/publish.yml "publisher/deployment/"
+assert_contains .github/workflows/publish.yml '--header "Authorization: ******"'
+assert_contains .github/workflows/publish.yml "ariadne-spark35_2.12"
+assert_contains .github/workflows/publish.yml "ariadne-spark41_2.13"
+assert_not_contains .github/workflows/publish.yml "gpg-passphrase:"
+assert_not_contains .github/workflows/publish.yml "gpg.pinentryMode"
+
+assert_contains pom.xml "<central.autoPublish>false</central.autoPublish>"
+assert_contains pom.xml "<central.waitUntil>validated</central.waitUntil>"
+assert_contains pom.xml "<project.build.outputTimestamp>"
+assert_contains pom.xml "<version>0.11.0</version>"
+assert_not_contains pom.xml "<autoPublish>true</autoPublish>"
+
+assert_contains docs/contributors/releasing.html "both deployments reach the validated state"
+assert_contains docs/contributors/releasing.html "publishes neither artifact"
+
+echo "Release pipeline contracts passed."

--- a/dev/scripts/release-pipeline-tests.sh
+++ b/dev/scripts/release-pipeline-tests.sh
@@ -61,7 +61,8 @@ assert_contains .github/workflows/publish.yml "publish_failed=0"
 assert_contains .github/workflows/publish.yml 'if [[ "$state35" == "VALIDATED" ]]'
 assert_contains .github/workflows/publish.yml 'if [[ "$state41" == "VALIDATED" ]]'
 assert_contains .github/workflows/publish.yml "publisher/deployment/"
-assert_contains .github/workflows/publish.yml '--header "Authorization: ******"'
+assert_contains .github/workflows/publish.yml "authorization_header="
+assert_contains .github/workflows/publish.yml '--header "$authorization_header"'
 assert_contains .github/workflows/publish.yml "ariadne-spark35_2.12"
 assert_contains .github/workflows/publish.yml "ariadne-spark41_2.13"
 assert_not_contains .github/workflows/publish.yml "gpg-passphrase:"

--- a/dev/scripts/release-pipeline-tests.sh
+++ b/dev/scripts/release-pipeline-tests.sh
@@ -27,6 +27,19 @@ assert_not_contains() {
     fi
 }
 
+assert_plugin_version() {
+    local artifact_id="$1"
+    local expected_version="$2"
+    local plugin_xml
+    plugin_xml=$(awk \
+        "/<artifactId>$artifact_id<\\/artifactId>/,/<\\/plugin>/" \
+        pom.xml)
+    if ! grep -Fq "<version>$expected_version</version>" <<<"$plugin_xml"; then
+        echo "pom.xml does not configure $artifact_id at version $expected_version"
+        exit 1
+    fi
+}
+
 assert_file .github/workflows/publish.yml
 assert_file docs/contributors/releasing.html
 assert_file .mvn/wrapper/maven-wrapper.properties
@@ -57,7 +70,7 @@ assert_not_contains .github/workflows/publish.yml "gpg.pinentryMode"
 assert_contains pom.xml "<central.autoPublish>false</central.autoPublish>"
 assert_contains pom.xml "<central.waitUntil>validated</central.waitUntil>"
 assert_contains pom.xml "<project.build.outputTimestamp>"
-assert_contains pom.xml "<version>0.11.0</version>"
+assert_plugin_version central-publishing-maven-plugin 0.11.0
 assert_not_contains pom.xml "<autoPublish>true</autoPublish>"
 
 assert_contains docs/contributors/releasing.html "both deployments reach the validated state"

--- a/dev/scripts/repository-readiness-tests.sh
+++ b/dev/scripts/repository-readiness-tests.sh
@@ -28,6 +28,7 @@ for file in \
     dev/scripts/build-api-docs.sh \
     dev/scripts/clean-api-docs-output.sh \
     dev/scripts/package-contents-tests.sh \
+    dev/scripts/release-pipeline-tests.sh \
     .github/ISSUE_TEMPLATE/bug.yml \
     .github/ISSUE_TEMPLATE/feature.yml \
     .github/ISSUE_TEMPLATE/config.yml \

--- a/docs/contributors/architecture.html
+++ b/docs/contributors/architecture.html
@@ -31,6 +31,7 @@
     <ul>
       <li><a href="index.html" data-page="index">Contributing</a></li>
       <li><a href="architecture.html" data-page="architecture">Architecture</a></li>
+      <li><a href="releasing.html" data-page="releasing">Releasing</a></li>
       <li><a href="security.html" data-page="security">Security Policy</a></li>
       <li><a href="cla.html" data-page="cla">CLA</a></li>
     </ul>

--- a/docs/contributors/cla.html
+++ b/docs/contributors/cla.html
@@ -31,6 +31,7 @@
     <ul>
       <li><a href="index.html" data-page="index">Contributing</a></li>
       <li><a href="architecture.html" data-page="architecture">Architecture</a></li>
+      <li><a href="releasing.html" data-page="releasing">Releasing</a></li>
       <li><a href="security.html" data-page="security">Security Policy</a></li>
       <li><a href="cla.html" data-page="cla">CLA</a></li>
     </ul>

--- a/docs/contributors/index.html
+++ b/docs/contributors/index.html
@@ -31,6 +31,7 @@
     <ul>
       <li><a href="index.html" data-page="index">Contributing</a></li>
       <li><a href="architecture.html" data-page="architecture">Architecture</a></li>
+      <li><a href="releasing.html" data-page="releasing">Releasing</a></li>
       <li><a href="security.html" data-page="security">Security Policy</a></li>
       <li><a href="cla.html" data-page="cla">CLA</a></li>
     </ul>

--- a/docs/contributors/releasing.html
+++ b/docs/contributors/releasing.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Releasing — Ariadne</title>
+  <link rel="stylesheet" href="../assets/style.css">
+  <link rel="icon" type="image/png" href="../assets/icon.png">
+</head>
+<body data-section="contributors" data-page="releasing">
+
+<header class="site-header">
+  <div class="header-inner">
+    <a class="brand" href="../index.html">
+      <img class="brand-icon" src="../assets/icon.png" alt="" aria-hidden="true">
+      <img class="brand-name-img" src="../assets/name-white.png" alt="Ariadne">
+    </a>
+    <nav class="primary-nav">
+      <a href="../index.html" data-section="home">Home</a>
+      <a href="../users/getting-started.html" data-section="users">User Guide</a>
+      <a href="index.html" data-section="contributors">Contributors</a>
+      <a href="../api/dev/cjfravel/ariadne/Index.html" data-section="api">API</a>
+      <a class="gh" href="https://github.com/cjfravel-dev/ariadne">GitHub</a>
+    </nav>
+  </div>
+</header>
+
+<div class="page">
+  <aside class="sidebar">
+    <h5>Contributors</h5>
+    <ul>
+      <li><a href="index.html" data-page="index">Contributing</a></li>
+      <li><a href="architecture.html" data-page="architecture">Architecture</a></li>
+      <li><a href="releasing.html" data-page="releasing">Releasing</a></li>
+      <li><a href="security.html" data-page="security">Security Policy</a></li>
+      <li><a href="cla.html" data-page="cla">CLA</a></li>
+    </ul>
+  </aside>
+
+  <main class="content">
+    <div class="page-header">
+      <span class="eyebrow">Maintainers</span>
+      <h1>Releasing Ariadne</h1>
+      <p class="lede">One GitHub Release publishes the coordinated Spark 3.5 and Spark 4.1 artifacts.</p>
+    </div>
+
+    <h2>Prepare one coordinated version</h2>
+    <ol>
+      <li>Update the POM, README, getting-started guide, changelog, and citation metadata.</li>
+      <li>Regenerate the canonical Spark 3.5 API documentation.</li>
+      <li>Merge the release pull request after both profile checks and CodeQL pass.</li>
+    </ol>
+
+    <h2>Publish the GitHub Release</h2>
+    <p>Create a tag exactly equal to the Maven project version, without a <code>v</code> prefix, then publish the GitHub Release. The protected workflow signs and uploads each profile as a user-managed Central deployment. It publishes nothing until both deployments reach the validated state.</p>
+
+    <h2>Coordinated publication</h2>
+    <p>After both profiles validate, the workflow requests publication for both deployments, waits for both to reach <code>PUBLISHED</code>, confirms both Maven Central coordinates resolve, and downloads each artifact through a clean Maven repository.</p>
+
+    <h2>Safe defaults and failure handling</h2>
+    <ul>
+      <li>Local <code>mvn deploy</code> remains user-managed and droppable.</li>
+      <li>A failed Spark 3.5 or Spark 4.1 stage publishes neither artifact.</li>
+      <li>The workflow drops any validated deployment left by a staging failure.</li>
+      <li>Published Central versions are immutable; corrections require a new version.</li>
+      <li>Rotate the Central token and PGP key before their environment-recorded expiration dates.</li>
+    </ul>
+  </main>
+</div>
+
+<footer class="site-footer">
+  <div class="footer-inner">
+    <span>Ariadne — find the thread through your data lake.</span>
+    <span class="footer-links"><a href="../index.html">Home</a><a href="https://github.com/cjfravel-dev/ariadne">GitHub</a></span>
+  </div>
+</footer>
+
+<script src="../assets/site.js"></script>
+</body>
+</html>

--- a/docs/contributors/security.html
+++ b/docs/contributors/security.html
@@ -31,6 +31,7 @@
     <ul>
       <li><a href="index.html" data-page="index">Contributing</a></li>
       <li><a href="architecture.html" data-page="architecture">Architecture</a></li>
+      <li><a href="releasing.html" data-page="releasing">Releasing</a></li>
       <li><a href="security.html" data-page="security">Security Policy</a></li>
       <li><a href="cla.html" data-page="cla">CLA</a></li>
     </ul>

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.4
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/mvnw
+++ b/mvnw
@@ -142,6 +142,9 @@ esac
 distributionUrlName="${distributionUrl##*/}"
 distributionUrlNameMain="${distributionUrlName%.*}"
 distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+if [ -z "${MAVEN_USER_HOME-}" ] && [ -z "${HOME-}" ]; then
+  die "HOME is unset and MAVEN_USER_HOME is not set"
+fi
 MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
 MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,11 @@
         <scalastyle.plugin.version>1.0.0</scalastyle.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <project.build.outputTimestamp>2026-07-12T00:00:00Z</project.build.outputTimestamp>
+        <!-- Official GitHub releases override these safe local defaults. -->
+        <central.autoPublish>false</central.autoPublish>
+        <central.waitUntil>validated</central.waitUntil>
+        <central.waitMaxTime>1800</central.waitMaxTime>
     </properties>
 
     <!-- One profile per supported Spark/Delta line. Each profile pins the Scala
@@ -277,6 +282,19 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>test-release-pipeline-script</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>bash</executable>
+                            <arguments>
+                                <argument>dev/scripts/release-pipeline-tests.sh</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>test-example-dockerfile-script</id>
                         <phase>test</phase>
                         <goals>
@@ -493,11 +511,14 @@
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.7.0</version>
+                <version>0.11.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>
-                    <autoPublish>true</autoPublish>
+                    <deploymentName>${project.artifactId}-${project.version}</deploymentName>
+                    <autoPublish>${central.autoPublish}</autoPublish>
+                    <waitUntil>${central.waitUntil}</waitUntil>
+                    <waitMaxTime>${central.waitMaxTime}</waitMaxTime>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
## Summary

Stages a GitHub Release → Maven Central pipeline for Ariadne without changing the version, creating a tag, uploading a deployment, or publishing a release.

## Coordinated publication

- Spark 3.5 / Scala 2.12 builds under JDK 11
- Spark 4.1 / Scala 2.13 builds under JDK 21
- each profile uploads as a user-managed, droppable Central deployment
- neither artifact is published until both deployments validate
- publish/status API calls coordinate both artifacts and retry transient failures
- clean Maven repositories resolve both coordinates after publication

## Safety

- local `mvn deploy` now defaults to `autoPublish=false` and `waitUntil=validated`
- `maven-central` environment is tag-only
- dedicated `Ariadne Release <ariadne-releases@cjfravel.dev>` PGP key is configured and backed up
- passphrase uses `MAVEN_GPG_PASSPHRASE`, not Maven settings
- duplicate versions, expired credentials, wrong tags, and wrong signing identity fail before upload
- staging failure cleanup attempts both deployment IDs

## Validation

- release-pipeline contract tests: GREEN
- repository-readiness contracts: GREEN
- workflow YAML and local documentation links: valid
- effective Spark 3.5 and Spark 4.1 POMs use Central plugin 0.11.0 with safe defaults
- independent review found and fixed failure-path coordination issues

No release or Central upload is performed by this PR.