### PR TITLE
Bound driver memory during file tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ All notable changes to this project are documented here. The format is based on
 
 ### Changed
 
+- FileList duplicate detection now uses a distributed Delta merge, and legacy `file_size` migration processes bounded
+  batches instead of materializing every tracked filename in driver memory.
 - The examples image pins both base images by digest and verifies Spark SHA-512 plus Delta JAR SHA-256 checksums before
   extraction or use.
 - Release version checks now cover the changelog and include a shell regression test in the Maven test phase.

--- a/dev/scripts/driver-collection-tests.sh
+++ b/dev/scripts/driver-collection-tests.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+FILE_LIST=src/main/scala/dev/cjfravel/ariadne/FileList.scala
+INDEX_BUILD=src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+
+if grep -Fq '.collect().toSet' "$FILE_LIST"; then
+    echo "FileList duplicate detection must not collect all tracked filenames"
+    exit 1
+fi
+
+if ! grep -A45 'private def migrateFileSizeColumns' "$INDEX_BUILD" | grep -Fq '.mapPartitions'; then
+    echo "file_size migration must resolve source sizes on executors"
+    exit 1
+fi
+
+if grep -A60 'private def migrateFileSizeColumns' "$INDEX_BUILD" | grep -Fq '.toLocalIterator()'; then
+    echo "file_size migration must not stream Spark partitions through driver memory"
+    exit 1
+fi
+
+if ! grep -A60 'private def migrateFileSizeColumns' "$INDEX_BUILD" | grep -Fq 'checkHeartbeat()'; then
+    echo "file_size migration must check lock ownership between batch writes"
+    exit 1
+fi

--- a/dev/scripts/driver-collection-tests.sh
+++ b/dev/scripts/driver-collection-tests.sh
@@ -6,7 +6,7 @@ FILE_LIST=src/main/scala/dev/cjfravel/ariadne/FileList.scala
 INDEX_BUILD=src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
 MIGRATION_METHOD=$(sed -n '/private def migrateFileSizeColumns/,/private def verifyFileSizeColumns/p' "$INDEX_BUILD")
 
-if grep -Fq '.collect' "$FILE_LIST"; then
+if grep -Eq '\.collect(\(|\.|AsList\(|[[:space:]]*$)' "$FILE_LIST"; then
     echo "FileList duplicate detection must not collect all tracked filenames"
     exit 1
 fi

--- a/dev/scripts/driver-collection-tests.sh
+++ b/dev/scripts/driver-collection-tests.sh
@@ -4,23 +4,24 @@ set -euo pipefail
 
 FILE_LIST=src/main/scala/dev/cjfravel/ariadne/FileList.scala
 INDEX_BUILD=src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+MIGRATION_METHOD=$(sed -n '/private def migrateFileSizeColumns/,/private def verifyFileSizeColumns/p' "$INDEX_BUILD")
 
 if grep -Fq '.collect().toSet' "$FILE_LIST"; then
     echo "FileList duplicate detection must not collect all tracked filenames"
     exit 1
 fi
 
-if ! grep -A45 'private def migrateFileSizeColumns' "$INDEX_BUILD" | grep -Fq '.mapPartitions'; then
+if ! grep -Fq '.mapPartitions' <<<"$MIGRATION_METHOD"; then
     echo "file_size migration must resolve source sizes on executors"
     exit 1
 fi
 
-if grep -A60 'private def migrateFileSizeColumns' "$INDEX_BUILD" | grep -Fq '.toLocalIterator()'; then
+if grep -Fq '.toLocalIterator()' <<<"$MIGRATION_METHOD"; then
     echo "file_size migration must not stream Spark partitions through driver memory"
     exit 1
 fi
 
-if ! grep -A60 'private def migrateFileSizeColumns' "$INDEX_BUILD" | grep -Fq 'checkHeartbeat()'; then
+if ! grep -Fq 'checkHeartbeat()' <<<"$MIGRATION_METHOD"; then
     echo "file_size migration must check lock ownership between batch writes"
     exit 1
 fi

--- a/dev/scripts/driver-collection-tests.sh
+++ b/dev/scripts/driver-collection-tests.sh
@@ -6,7 +6,7 @@ FILE_LIST=src/main/scala/dev/cjfravel/ariadne/FileList.scala
 INDEX_BUILD=src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
 MIGRATION_METHOD=$(sed -n '/private def migrateFileSizeColumns/,/private def verifyFileSizeColumns/p' "$INDEX_BUILD")
 
-if grep -Fq '.collect().toSet' "$FILE_LIST"; then
+if grep -Fq '.collect' "$FILE_LIST"; then
     echo "FileList duplicate detection must not collect all tracked filenames"
     exit 1
 fi
@@ -16,7 +16,7 @@ if ! grep -Fq '.mapPartitions' <<<"$MIGRATION_METHOD"; then
     exit 1
 fi
 
-if grep -Fq '.toLocalIterator()' <<<"$MIGRATION_METHOD"; then
+if grep -Fq '.toLocalIterator' <<<"$MIGRATION_METHOD"; then
     echo "file_size migration must not stream Spark partitions through driver memory"
     exit 1
 fi

--- a/docs/api/dev/cjfravel/ariadne/FileList.html
+++ b/docs/api/dev/cjfravel/ariadne/FileList.html
@@ -386,7 +386,7 @@ external synchronization must be applied.
       <p class="shortcomment cmt">Registers new files in the file list.</p><div class="fullcomment"><div class="comment cmt"><p>Registers new files in the file list.</p><p>Files already present are silently skipped. Candidate filenames are merged into Delta so duplicate detection stays
 distributed instead of collecting the complete existing file list to the driver.
 </p></div><dl class="paramcmts block"><dt class="param">fileNames</dt><dd class="cmt"><p>
-  one or more file paths to add</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
+  zero or more file paths to add; an empty sequence is a no-op</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
   if fileNames is null or any individual file name is null or blank</p></span></dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>

--- a/docs/api/dev/cjfravel/ariadne/FileList.html
+++ b/docs/api/dev/cjfravel/ariadne/FileList.html
@@ -383,13 +383,11 @@ external synchronization must be applied.
         <span class="name">addFile</span><span class="params">(<span name="fileNames">fileNames: <span class="extype" name="scala.Predef.String">String</span>*</span>)</span><span class="result">: <span class="extype" name="scala.Unit">Unit</span></span>
       </span>
       
-      <p class="shortcomment cmt">Registers new files in the file list.</p><div class="fullcomment"><div class="comment cmt"><p>Registers new files in the file list.</p><p>Files already present are silently skipped. The additions are written to the Delta table immediately; if the write
-fails, the in-memory cache is rolled back to its previous state.
+      <p class="shortcomment cmt">Registers new files in the file list.</p><div class="fullcomment"><div class="comment cmt"><p>Registers new files in the file list.</p><p>Files already present are silently skipped. Candidate filenames are merged into Delta so duplicate detection stays
+distributed instead of collecting the complete existing file list to the driver.
 </p></div><dl class="paramcmts block"><dt class="param">fileNames</dt><dd class="cmt"><p>
   one or more file paths to add</p></dd></dl><dl class="attributes block"> <dt>Exceptions thrown</dt><dd><span class="cmt"><p><span class="extype" name="IllegalArgumentException"><code>IllegalArgumentException</code></span> 
-  if fileNames is null or any individual file name is null or blank</p></span></dd><dt>Note</dt><dd><span class="cmt"><p>
-  Collects all existing filenames to the driver for duplicate detection. May cause driver OOM for indexes tracking
-  millions of files.</p></span></dd></dl></div>
+  if fileNames is null or any individual file name is null or blank</p></span></dd></dl></div>
     </li><li name="scala.Any#asInstanceOf" visbl="pub" class="indented0 " data-isabs="false" fullComment="yes" group="Ungrouped">
       <a id="asInstanceOf[T0]:T0"></a>
       <span class="permalink">

--- a/pom.xml
+++ b/pom.xml
@@ -303,6 +303,19 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>test-driver-collections</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>bash</executable>
+                            <arguments>
+                                <argument>dev/scripts/driver-collection-tests.sh</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>test-api-docs-drift</id>
                         <phase>verify</phase>
                         <goals>

--- a/src/main/scala/dev/cjfravel/ariadne/FileList.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/FileList.scala
@@ -135,7 +135,7 @@ case class FileList private (name: String)(implicit val spark: SparkSession) ext
    * distributed instead of collecting the complete existing file list to the driver.
    *
    * @param fileNames
-   *   one or more file paths to add
+   *   zero or more file paths to add; an empty sequence is a no-op
    * @throws IllegalArgumentException
    *   if fileNames is null or any individual file name is null or blank
    */

--- a/src/main/scala/dev/cjfravel/ariadne/FileList.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/FileList.scala
@@ -96,49 +96,48 @@ case class FileList private (name: String)(implicit val spark: SparkSession) ext
     require(fileNames != null, "fileNames must not be null")
     fileNames.foreach(fn => require(fn != null && fn.trim.nonEmpty, "Each fileName must be non-null and non-blank"))
     logger.warn(s"addFile called on FileList '$name' with ${fileNames.size} file(s)")
-    import spark.implicits._
-    val existing = files.select("filename").as[String].collect().toSet
-    val toAdd = fileNames.toSet.diff(existing)
-    if (toAdd.isEmpty) {
-      logger.warn("All files were already added")
+    if (fileNames.isEmpty) {
+      logger.warn("No files were provided")
     } else {
       val ts = Timestamp.from(Instant.now())
-      val newFilesData = toAdd.toList.map(filename => Row(filename, ts))
-      val newFiles =
+      val candidatesData = fileNames.distinct.map(filename => Row(filename, ts))
+      val candidates =
         spark.createDataFrame(
-          spark.sparkContext.parallelize(newFilesData),
+          spark.sparkContext.parallelize(candidatesData),
           StructType(
             Seq(
               StructField("filename", StringType, nullable = false),
               StructField("addedAt", TimestampType, nullable = false))))
 
-      val originalFiles = _files
-      _files = _files.union(newFiles)
-      try {
-        write
-      } catch {
-        case e: Exception =>
-          logger.warn(s"Failed to write FileList '$name', rolling back in-memory state: ${e.getMessage}")
-          _files = originalFiles
-          throw e
+      delta(storagePath) match {
+        case Some(table) =>
+          table
+            .as("target")
+            .merge(candidates.as("source"), "target.filename = source.filename")
+            .whenNotMatched()
+            .insertAll()
+            .execute()
+        case None =>
+          candidates.write
+            .format("delta")
+            .mode("overwrite")
+            .save(storagePath.toString)
       }
-      logger.warn(s"Added ${toAdd.size} files to FileList $name")
+      _files = null
+      logger.warn(s"Merged ${candidatesData.size} file candidate(s) into FileList $name")
     }
   }
 
   /**
    * Registers new files in the file list.
    *
-   * Files already present are silently skipped. The additions are written to the Delta table immediately; if the write
-   * fails, the in-memory cache is rolled back to its previous state.
+   * Files already present are silently skipped. Candidate filenames are merged into Delta so duplicate detection stays
+   * distributed instead of collecting the complete existing file list to the driver.
    *
    * @param fileNames
    *   one or more file paths to add
    * @throws IllegalArgumentException
    *   if fileNames is null or any individual file name is null or blank
-   * @note
-   *   Collects all existing filenames to the driver for duplicate detection. May cause driver OOM for indexes tracking
-   *   millions of files.
    */
   def addFile(fileNames: String*): Unit = addFile(spark, fileNames: _*)
 
@@ -185,33 +184,6 @@ case class FileList private (name: String)(implicit val spark: SparkSession) ext
   def hasFile(fileName: String): Boolean = {
     require(fileName != null && fileName.trim.nonEmpty, "fileName must not be null or blank")
     !files.filter(col("filename") === fileName).isEmpty
-  }
-
-  /**
-   * Persists the current in-memory file list to the Delta table.
-   *
-   * Uses a merge (upsert) if the table already exists, or a full overwrite for first-time creation. Invalidates the
-   * in-memory cache after writing.
-   */
-  private def write: Unit = {
-    delta(storagePath) match {
-      case Some(delta) =>
-        delta
-          .as("target")
-          .merge(files.as("source"), "target.filename = source.filename")
-          .whenMatched()
-          .updateExpr(Map("addedAt" -> "target.addedAt"))
-          .whenNotMatched()
-          .insertAll()
-          .execute()
-      case None =>
-        files.write
-          .format("delta")
-          .mode("overwrite")
-          .save(storagePath.toString)
-    }
-    _files = null
-    logger.warn(s"Wrote out FileList $name")
   }
 
 }

--- a/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
@@ -337,12 +337,14 @@ trait IndexBuildOperations extends BloomFilterOperations {
               s"Cannot migrate file_size for index '$name': source file '${failures.head.getString(0)}' " +
                 s"is missing or unreadable (${failures.head.getString(1)})")
           }
+          checkHeartbeat()
           table
             .as("target")
             .merge(sizeResults.select("filename", "file_size").as("source"), "target.filename = source.filename")
             .whenMatched()
             .update(Map("file_size" -> col("source.file_size")))
             .execute()
+          checkHeartbeat()
         } finally {
           sizeResults.unpersist()
         }

--- a/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.{Executors, TimeUnit}
 
 import scala.collection.JavaConverters._
+import scala.util.control.NonFatal
 
 import dev.cjfravel.ariadne.exceptions._
 import io.delta.tables.DeltaTable
@@ -318,6 +319,9 @@ trait IndexBuildOperations extends BloomFilterOperations {
                     (filename, null: java.lang.Long, "file not found")
                   case e: java.io.IOException =>
                     (filename, null: java.lang.Long, s"I/O error: ${e.getMessage}")
+                  case NonFatal(e) =>
+                    val message = Option(e.getMessage).getOrElse("no message")
+                    (filename, null: java.lang.Long, s"${e.getClass.getSimpleName}: $message")
                 }
               }
             }

--- a/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
@@ -13,6 +13,8 @@ import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.LongType
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.util.SerializableConfiguration
 
 /**
  * Trait providing index building and maintenance operations for [[Index]] instances.
@@ -199,7 +201,7 @@ trait IndexBuildOperations extends BloomFilterOperations {
       val explodedMigrationNeeded =
         initialStorageVersion < StorageFormat.CurrentStorageVersion || needsExplodedFieldMigration
 
-      if (fileSizeMigrationNeeded) migrateFileSizeColumns()
+      if (fileSizeMigrationNeeded) migrateFileSizeColumns(checkHeartbeat)
       checkHeartbeat()
       verifyFileSizeColumns()
       if (explodedMigrationNeeded) migrateExplodedFieldColumns()
@@ -284,7 +286,7 @@ trait IndexBuildOperations extends BloomFilterOperations {
       }
     }
 
-  private def migrateFileSizeColumns(): Unit = {
+  private def migrateFileSizeColumns(checkHeartbeat: () => Unit): Unit = {
     Seq(indexFilePath -> "main table", stagingFilePath -> "staging table").foreach { case (path, tableName) =>
       migrationDelta(path, tableName).foreach { table =>
         if (!table.toDF.columns.contains("file_size")) {
@@ -295,39 +297,54 @@ trait IndexBuildOperations extends BloomFilterOperations {
       }
 
       migrationDelta(path, tableName).foreach { table =>
-        val nullSizeFiles =
+        import spark.implicits._
+        val pendingFiles =
           table.toDF
             .where(col("file_size").isNull)
             .select("filename")
-            .toLocalIterator()
-            .asScala
-            .map(_.getString(0))
-            .toSet
-        if (nullSizeFiles.nonEmpty) {
-          val sizes = getFileSizes(nullSizeFiles)
-          val missingSizes = nullSizeFiles -- sizes.keySet
-          if (missingSizes.nonEmpty) {
+            .distinct()
+        val serializableConfiguration = new SerializableConfiguration(spark.sparkContext.hadoopConfiguration)
+        val sizeResults =
+          pendingFiles
+            .as[String]
+            .mapPartitions { filenames =>
+              filenames.map { filename =>
+                val path = new Path(filename)
+                try {
+                  val length = path.getFileSystem(serializableConfiguration.value).getFileStatus(path).getLen
+                  (filename, java.lang.Long.valueOf(length), null: String)
+                } catch {
+                  case _: java.io.FileNotFoundException =>
+                    (filename, null: java.lang.Long, "file not found")
+                  case e: java.io.IOException =>
+                    (filename, null: java.lang.Long, s"I/O error: ${e.getMessage}")
+                }
+              }
+            }
+            .toDF("filename", "file_size", "error")
+            .persist(StorageLevel.DISK_ONLY)
+        try {
+          checkHeartbeat()
+          val failures =
+            sizeResults
+              .where(col("error").isNotNull)
+              .select("filename", "error")
+              .limit(1)
+              .collect()
+          checkHeartbeat()
+          if (failures.nonEmpty) {
             throw new StorageMigrationException(
-              s"Cannot migrate file_size for index '$name': ${missingSizes.size} source file(s) " +
-                s"are missing or unreadable, including '${missingSizes.head}'")
+              s"Cannot migrate file_size for index '$name': source file '${failures.head.getString(0)}' " +
+                s"is missing or unreadable (${failures.head.getString(1)})")
           }
-          val sizesBroadcast = spark.sparkContext.broadcast(sizes)
-          try {
-            val sizeUdf = udf((filename: String) => sizesBroadcast.value.getOrElse(filename, 0L))
-            import spark.implicits._
-            val updates =
-              nullSizeFiles.toSeq
-                .toDF("filename")
-                .withColumn("file_size", sizeUdf(col("filename")))
-            table
-              .as("target")
-              .merge(updates.as("source"), "target.filename = source.filename")
-              .whenMatched()
-              .update(Map("file_size" -> col("source.file_size")))
-              .execute()
-          } finally {
-            safeDestroyBroadcast(sizesBroadcast)
-          }
+          table
+            .as("target")
+            .merge(sizeResults.select("filename", "file_size").as("source"), "target.filename = source.filename")
+            .whenMatched()
+            .update(Map("file_size" -> col("source.file_size")))
+            .execute()
+        } finally {
+          sizeResults.unpersist()
         }
       }
     }

--- a/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
+++ b/src/main/scala/dev/cjfravel/ariadne/IndexBuildOperations.scala
@@ -310,8 +310,8 @@ trait IndexBuildOperations extends BloomFilterOperations {
             .as[String]
             .mapPartitions { filenames =>
               filenames.map { filename =>
-                val path = new Path(filename)
                 try {
+                  val path = new Path(filename)
                   val length = path.getFileSystem(serializableConfiguration.value).getFileStatus(path).getLen
                   (filename, java.lang.Long.valueOf(length), null: String)
                 } catch {

--- a/src/test/scala/dev/cjfravel/ariadne/FileListTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/FileListTests.scala
@@ -51,7 +51,11 @@ class FileListTests extends SparkTests {
 
     refreshedFilelist.addFile(existing, added)
 
-    val timestamps = refreshedFilelist.files.collect().map(row => row.getString(0) -> row.getAs[Timestamp](1)).toMap
+    val timestamps =
+      refreshedFilelist.files
+        .collect()
+        .map(row => row.getAs[String]("filename") -> row.getAs[Timestamp]("addedAt"))
+        .toMap
     assert(timestamps.keySet === Set(existing, added))
     assert(timestamps(existing) === originalTimestamp)
   }

--- a/src/test/scala/dev/cjfravel/ariadne/FileListTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/FileListTests.scala
@@ -2,6 +2,8 @@ package dev.cjfravel.ariadne
 
 import java.sql.Timestamp
 
+import io.delta.tables.DeltaTable
+
 /**
  * Tests for [[FileList]] covering file addition (single and batch), existence checks, and removal from the tracked file
  * list.
@@ -37,13 +39,18 @@ class FileListTests extends SparkTests {
     val existing = resourcePath("/data/table1_part0.csv")
     val added = resourcePath("/data/table1_part1.csv")
     filelist.addFile(existing)
+    val expectedTimestamp = Timestamp.valueOf("2000-01-01 00:00:00")
+    DeltaTable
+      .forPath(spark, filelist.storagePath.toString)
+      .updateExpr(Map("addedAt" -> "CAST('2000-01-01 00:00:00' AS TIMESTAMP)"))
+    val refreshedFilelist = FileList("mixed_add")
     val originalTimestamp =
-      filelist.files.where(s"filename = '$existing'").select("addedAt").head().getAs[Timestamp](0)
+      refreshedFilelist.files.where(s"filename = '$existing'").select("addedAt").head().getAs[Timestamp](0)
+    assert(originalTimestamp === expectedTimestamp)
 
-    Thread.sleep(10)
-    filelist.addFile(existing, added)
+    refreshedFilelist.addFile(existing, added)
 
-    val timestamps = filelist.files.collect().map(row => row.getString(0) -> row.getAs[Timestamp](1)).toMap
+    val timestamps = refreshedFilelist.files.collect().map(row => row.getString(0) -> row.getAs[Timestamp](1)).toMap
     assert(timestamps.keySet === Set(existing, added))
     assert(timestamps(existing) === originalTimestamp)
   }

--- a/src/test/scala/dev/cjfravel/ariadne/FileListTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/FileListTests.scala
@@ -3,6 +3,7 @@ package dev.cjfravel.ariadne
 import java.sql.Timestamp
 
 import io.delta.tables.DeltaTable
+import org.apache.spark.sql.functions.col
 
 /**
  * Tests for [[FileList]] covering file addition (single and batch), existence checks, and removal from the tracked file
@@ -45,7 +46,7 @@ class FileListTests extends SparkTests {
       .updateExpr(Map("addedAt" -> "CAST('2000-01-01 00:00:00' AS TIMESTAMP)"))
     val refreshedFilelist = FileList("mixed_add")
     val originalTimestamp =
-      refreshedFilelist.files.where(s"filename = '$existing'").select("addedAt").head().getAs[Timestamp](0)
+      refreshedFilelist.files.where(col("filename") === existing).select("addedAt").head().getAs[Timestamp](0)
     assert(originalTimestamp === expectedTimestamp)
 
     refreshedFilelist.addFile(existing, added)

--- a/src/test/scala/dev/cjfravel/ariadne/FileListTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/FileListTests.scala
@@ -1,5 +1,7 @@
 package dev.cjfravel.ariadne
 
+import java.sql.Timestamp
+
 /**
  * Tests for [[FileList]] covering file addition (single and batch), existence checks, and removal from the tracked file
  * list.
@@ -13,6 +15,12 @@ class FileListTests extends SparkTests {
     assert(filelist.hasFile(path) === true)
   }
 
+  test("addFile with no filenames remains a no-op") {
+    val name = "empty_add"
+    FileList(name).addFile()
+    assert(FileList.exists(name) === false)
+  }
+
   test("addFile(s)") {
     val filelist = FileList("test2")
     val paths = Array(resourcePath("/data/table1_part0.csv"), resourcePath("/data/table1_part1.csv"))
@@ -22,6 +30,22 @@ class FileListTests extends SparkTests {
 
     // manual logger test
     filelist.addFile(paths: _*)
+  }
+
+  test("addFile preserves the original timestamp when a batch mixes existing and new files") {
+    val filelist = FileList("mixed_add")
+    val existing = resourcePath("/data/table1_part0.csv")
+    val added = resourcePath("/data/table1_part1.csv")
+    filelist.addFile(existing)
+    val originalTimestamp =
+      filelist.files.where(s"filename = '$existing'").select("addedAt").head().getAs[Timestamp](0)
+
+    Thread.sleep(10)
+    filelist.addFile(existing, added)
+
+    val timestamps = filelist.files.collect().map(row => row.getString(0) -> row.getAs[Timestamp](1)).toMap
+    assert(timestamps.keySet === Set(existing, added))
+    assert(timestamps(existing) === originalTimestamp)
   }
 
   test("exists") {

--- a/src/test/scala/dev/cjfravel/ariadne/StorageMigrationTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/StorageMigrationTests.scala
@@ -1,5 +1,6 @@
 package dev.cjfravel.ariadne
 
+import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Paths, StandardCopyOption}
 
@@ -8,11 +9,24 @@ import scala.collection.JavaConverters._
 import com.google.gson.{Gson, JsonObject, JsonParser}
 import dev.cjfravel.ariadne.exceptions.{AriadneException, IndexLockException, StorageMigrationException}
 import io.delta.tables.DeltaTable
-import org.apache.hadoop.fs.Path
+import org.apache.hadoop.fs.{FileStatus, Path, RawLocalFileSystem}
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.scalatest.matchers.should.Matchers
+
+/**
+ * Test-only filesystem that deterministically fails source-size lookups without using an IOException.
+ *
+ * Instances are created by Hadoop through a no-argument constructor and are safe for concurrent test lookups because
+ * they contain no mutable state.
+ */
+class FailingFileStatusFileSystem extends RawLocalFileSystem {
+  override def getUri: URI = URI.create("failing:///")
+
+  override def getFileStatus(path: Path): FileStatus =
+    throw new IllegalStateException(s"Injected file-status failure for $path")
+}
 
 /**
  * Tests explicit storage-format versioning and alpha37+ physical migration preflight.
@@ -521,5 +535,35 @@ class StorageMigrationTests extends SparkTests with Matchers {
     }
 
     readMetadataJson(indexName).get("storage_format_version") shouldBe null
+  }
+
+  test("malformed source paths fail file-size migration with a controlled error") {
+    val schema = StructType(Seq(StructField("Id", IntegerType, nullable = false)))
+    val indexName = "malformed_file_size_source"
+    Index(indexName, schema, "parquet")
+    val sparkSession = spark
+    import sparkSession.implicits._
+    val hadoopConfiguration = spark.sparkContext.hadoopConfiguration
+    hadoopConfiguration.setClass(
+      "fs.failing.impl",
+      classOf[FailingFileStatusFileSystem],
+      classOf[org.apache.hadoop.fs.FileSystem])
+    try {
+      Seq(("failing:///source.parquet", Seq(1)))
+        .toDF("filename", "Id")
+        .write
+        .format("delta")
+        .mode("overwrite")
+        .save(new Path(new Path(IndexPathUtils.storagePath, indexName), "index").toString)
+      makeUnversioned(indexName)
+
+      intercept[StorageMigrationException] {
+        Index(indexName).locateFiles(Map("Id" -> Array[Any](1)))
+      }
+
+      readMetadataJson(indexName).get("storage_format_version") shouldBe null
+    } finally {
+      hadoopConfiguration.unset("fs.failing.impl")
+    }
   }
 }

--- a/src/test/scala/dev/cjfravel/ariadne/StorageMigrationTests.scala
+++ b/src/test/scala/dev/cjfravel/ariadne/StorageMigrationTests.scala
@@ -537,7 +537,7 @@ class StorageMigrationTests extends SparkTests with Matchers {
     readMetadataJson(indexName).get("storage_format_version") shouldBe null
   }
 
-  test("malformed source paths fail file-size migration with a controlled error") {
+  test("unexpected file status failures produce a controlled migration error") {
     val schema = StructType(Seq(StructField("Id", IntegerType, nullable = false)))
     val indexName = "malformed_file_size_source"
     Index(indexName, schema, "parquet")


### PR DESCRIPTION
## Summary
- replace FileList full existing-name collection with candidate-only Delta merge
- compute legacy file sizes on executors and merge distributed updates
- collect only one explicit migration failure sample
- preserve empty-add no-op and original timestamps for duplicate candidates
- check migration lock ownership around distributed sizing and clean persisted results in finally

## TDD evidence
**RED:** `bash dev/scripts/driver-collection-tests.sh` detected full FileList collection and unbounded migration materialization. `FileListTests` also reproduced empty-input persistence.

**GREEN:** 23 targeted FileList/storage-migration tests pass; both Spark profile verify lifecycles pass; canonical API docs and package contracts pass.

## Compatibility
Migration failure still leaves the storage version unadvanced. Missing/unreadable sources fail before the distributed Delta merge. No GitHub Actions or release behavior changed.