### PR TITLE
Enforce dependency convergence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      spark-delta:
+        patterns:
+          - "org.apache.spark:*"
+          - "io.delta:*"
+      shaded-runtime:
+        patterns:
+          - "com.google.code.gson:gson"
+          - "com.google.guava:guava"
+          - "com.google.errorprone:error_prone_annotations"
+      test-libraries:
+        dependency-type: "development"
+        patterns:
+          - "org.scalatest:*"
+          - "org.scalatestplus:*"
+      maven-plugins:
+        patterns:
+          - "org.apache.maven.plugins:*"
+          - "org.codehaus.mojo:*"
+    ignore:
+      - dependency-name: "org.apache.spark:*"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "io.delta:*"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "org.scala-lang:*"
+      - dependency-name: "com.fasterxml.jackson.*:*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project are documented here. The format is based on
   shaded JAR contents for both supported Spark artifacts without invoking publication.
 - A tested persisted-index support matrix now documents alpha37+ release cohorts, migration checkpoints, failure
   behavior, and when operators must upgrade, retry, restore, or rebuild.
+- Maven now enforces dependency convergence for both Spark profiles, while grouped weekly Dependabot updates keep
+  Spark/Delta, shaded runtime dependencies, tests, and build plugins reviewable without crossing Spark or Scala majors.
 - Explicit `metadata_version` and `storage_format_version` markers with lock-safe, ordered, idempotent migration
   preflight for the alpha37 compatibility floor. Queries, catalog scans, metadata mutations, updates, deletes,
   compaction, and vacuum migrate `file_size` and exploded-field storage before use; future versions fail explicitly.

--- a/dev/scripts/dependency-policy-tests.sh
+++ b/dev/scripts/dependency-policy-tests.sh
@@ -11,9 +11,19 @@ assert_contains() {
     fi
 }
 
-assert_contains pom.xml '<artifactId>maven-enforcer-plugin</artifactId>'
-assert_contains pom.xml '<dependencyConvergence'
-assert_contains pom.xml '<phase>validate</phase>'
+assert_text() {
+    local text="$1"
+    local expected="$2"
+    if ! grep -Fq -- "$expected" <<<"$text"; then
+        echo "Maven Enforcer configuration is missing dependency policy: $expected"
+        exit 1
+    fi
+}
+
+ENFORCER_PLUGIN=$(sed -n '/<artifactId>maven-enforcer-plugin<\/artifactId>/,/<\/plugin>/p' pom.xml)
+assert_text "$ENFORCER_PLUGIN" '<artifactId>maven-enforcer-plugin</artifactId>'
+assert_text "$ENFORCER_PLUGIN" '<dependencyConvergence'
+assert_text "$ENFORCER_PLUGIN" '<phase>validate</phase>'
 assert_contains pom.xml 'dev/scripts/dependency-policy-tests.sh'
 assert_contains .github/dependabot.yml 'package-ecosystem: "maven"'
 assert_contains .github/dependabot.yml 'spark-delta'

--- a/dev/scripts/dependency-policy-tests.sh
+++ b/dev/scripts/dependency-policy-tests.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+assert_contains() {
+    local file="$1"
+    local expected="$2"
+    if [[ ! -f "$file" ]] || ! grep -Fq -- "$expected" "$file"; then
+        echo "$file is missing dependency policy: $expected"
+        exit 1
+    fi
+}
+
+assert_contains pom.xml '<artifactId>maven-enforcer-plugin</artifactId>'
+assert_contains pom.xml '<dependencyConvergence'
+assert_contains pom.xml '<phase>validate</phase>'
+assert_contains pom.xml 'dev/scripts/dependency-policy-tests.sh'
+assert_contains .github/dependabot.yml 'package-ecosystem: "maven"'
+assert_contains .github/dependabot.yml 'spark-delta'
+assert_contains .github/dependabot.yml 'shaded-runtime'
+assert_contains .github/dependabot.yml 'org.apache.spark:*'
+assert_contains .github/dependabot.yml 'io.delta:*'
+assert_contains .github/dependabot.yml 'com.fasterxml.jackson.*:*'
+assert_contains .github/dependabot.yml 'org.scala-lang:*'

--- a/dev/scripts/repository-readiness-tests.sh
+++ b/dev/scripts/repository-readiness-tests.sh
@@ -27,6 +27,7 @@ for file in \
     dev/scripts/api-docs-drift-tests.sh \
     dev/scripts/build-api-docs.sh \
     dev/scripts/clean-api-docs-output.sh \
+    dev/scripts/dependency-policy-tests.sh \
     dev/scripts/migration-support-policy-tests.sh \
     dev/scripts/package-contents-tests.sh \
     dev/scripts/release-pipeline-tests.sh \

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,16 @@
         </profile>
     </profiles>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_annotations</artifactId>
+                <version>2.41.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- Spark Core and SQL for DataFrame API -->
         <dependency>
@@ -159,7 +169,6 @@
             <artifactId>guava</artifactId>
             <version>33.5.0-jre</version>
         </dependency>
-
         <!-- Log4J (version tracks the Spark line's log4j via the active profile so the
              log4j-api we compile against matches the log4j-core Spark provides at runtime). -->
         <dependency>
@@ -186,6 +195,26 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.6.3</version>
+                <executions>
+                    <execution>
+                        <id>enforce-dependency-convergence</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <dependencyConvergence />
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <!-- Adds the Spark-major-version-specific source root (${spark.compat} is set per
                  profile: spark3 or spark4) so Ariadne can bridge to Spark internals whose package
                  moved between Spark 3.x and 4.x (e.g. Dataset.ofRows). -->
@@ -330,6 +359,19 @@
                             <executable>bash</executable>
                             <arguments>
                                 <argument>dev/scripts/driver-collection-tests.sh</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-dependency-policy-script</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>bash</executable>
+                            <arguments>
+                                <argument>dev/scripts/dependency-policy-tests.sh</argument>
                             </arguments>
                         </configuration>
                     </execution>


### PR DESCRIPTION
## Summary
- enforce Maven dependency convergence during validate for both Spark profiles
- align Gson and Guava transitive error-prone annotations through dependency management
- group weekly Dependabot updates by Spark/Delta, shaded runtime, tests, and Maven plugins
- prevent automated Spark/Delta major, Scala, and Spark-provided Jackson drift

## TDD evidence
**RED:** `mvn validate` exposed Gson 2.12.1 requesting `error_prone_annotations` 2.36.0 while Guava 33.5.0 requested 2.41.0.

**GREEN:** Both profile validate and verify lifecycles pass; dependency trees resolve both paths to managed 2.41.0; repository dependency-policy contracts and six FileList tests pass.

## Scope
No GitHub Actions workflow or release behavior changed.