### PR TITLE
Prepare 0.1.5-beta release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [0.1.5-beta]
+
 ### Added
 
 - Automated coordinated Maven Central releases: a published GitHub Release signs and validates the

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,6 +8,6 @@ authors:
 repository-code: "https://github.com/cjfravel-dev/ariadne"
 url: "https://cjfravel-dev.github.io/ariadne/"
 license-url: "https://github.com/cjfravel-dev/ariadne/blob/main/LICENSE.md"
-version: 0.1.4-beta
-date-released: 2026-07-08
+version: 0.1.5-beta
+date-released: 2026-07-12
 abstract: "A Spark library that builds Delta-backed file-level indexes for efficient data lake joins."

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@
 <dependency>
     <groupId>dev.cjfravel</groupId>
     <artifactId>ariadne-spark35_2.12</artifactId>
-    <version>0.1.4-beta</version>
+    <version>0.1.5-beta</version>
 </dependency>
 
 <!-- Spark 4.1 / Delta 4.1 (Scala 2.13, Java 21) -->
 <dependency>
     <groupId>dev.cjfravel</groupId>
     <artifactId>ariadne-spark41_2.13</artifactId>
-    <version>0.1.4-beta</version>
+    <version>0.1.5-beta</version>
 </dependency>
 ```
 

--- a/docs/api/dev/cjfravel/ariadne/AriadneContextUser.html
+++ b/docs/api/dev/cjfravel/ariadne/AriadneContextUser.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.AriadneContextUser</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.AriadneContextUser" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.AriadneContextUser" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.AriadneContextUser</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.AriadneContextUser" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.AriadneContextUser" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/BloomFilterOperations.html
+++ b/docs/api/dev/cjfravel/ariadne/BloomFilterOperations.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.BloomFilterOperations</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.BloomFilterOperations" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.BloomFilterOperations" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.BloomFilterOperations</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.BloomFilterOperations" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.BloomFilterOperations" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/BloomIndexConfig.html
+++ b/docs/api/dev/cjfravel/ariadne/BloomIndexConfig.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.BloomIndexConfig</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.BloomIndexConfig" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.BloomIndexConfig" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.BloomIndexConfig</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.BloomIndexConfig" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.BloomIndexConfig" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/ExplodedFieldMapping.html
+++ b/docs/api/dev/cjfravel/ariadne/ExplodedFieldMapping.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.ExplodedFieldMapping</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.ExplodedFieldMapping" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.ExplodedFieldMapping" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.ExplodedFieldMapping</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.ExplodedFieldMapping" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.ExplodedFieldMapping" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/FileList$.html
+++ b/docs/api/dev/cjfravel/ariadne/FileList$.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.FileList</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.FileList" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.FileList" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.FileList</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.FileList" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.FileList" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/FileList.html
+++ b/docs/api/dev/cjfravel/ariadne/FileList.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.FileList</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.FileList" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.FileList" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.FileList</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.FileList" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.FileList" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/Index$$DataFrameOps.html
+++ b/docs/api/dev/cjfravel/ariadne/Index$$DataFrameOps.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.Index.DataFrameOps</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.Index.DataFrameOps" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.Index.DataFrameOps" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.Index.DataFrameOps</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.Index.DataFrameOps" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.Index.DataFrameOps" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/Index$.html
+++ b/docs/api/dev/cjfravel/ariadne/Index$.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.Index</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.Index" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.Index" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.Index</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.Index" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.Index" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/Index.html
+++ b/docs/api/dev/cjfravel/ariadne/Index.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.Index</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.Index" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.Index" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.Index</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.Index" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.Index" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/IndexBuildOperations$FileAnalysis.html
+++ b/docs/api/dev/cjfravel/ariadne/IndexBuildOperations$FileAnalysis.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.IndexBuildOperations.FileAnalysis</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.IndexBuildOperations.FileAnalysis" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.IndexBuildOperations.FileAnalysis" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.IndexBuildOperations.FileAnalysis</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.IndexBuildOperations.FileAnalysis" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.IndexBuildOperations.FileAnalysis" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/IndexBuildOperations.html
+++ b/docs/api/dev/cjfravel/ariadne/IndexBuildOperations.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.IndexBuildOperations</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.IndexBuildOperations" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.IndexBuildOperations" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.IndexBuildOperations</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.IndexBuildOperations" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.IndexBuildOperations" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/IndexCatalog$.html
+++ b/docs/api/dev/cjfravel/ariadne/IndexCatalog$.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.IndexCatalog</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.IndexCatalog" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.IndexCatalog" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.IndexCatalog</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.IndexCatalog" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.IndexCatalog" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/IndexFileOperations.html
+++ b/docs/api/dev/cjfravel/ariadne/IndexFileOperations.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.IndexFileOperations</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.IndexFileOperations" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.IndexFileOperations" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.IndexFileOperations</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.IndexFileOperations" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.IndexFileOperations" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/IndexJoinOperations.html
+++ b/docs/api/dev/cjfravel/ariadne/IndexJoinOperations.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.IndexJoinOperations</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.IndexJoinOperations" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.IndexJoinOperations" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.IndexJoinOperations</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.IndexJoinOperations" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.IndexJoinOperations" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/IndexLock.html
+++ b/docs/api/dev/cjfravel/ariadne/IndexLock.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.IndexLock</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.IndexLock" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.IndexLock" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.IndexLock</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.IndexLock" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.IndexLock" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/IndexMetadata$.html
+++ b/docs/api/dev/cjfravel/ariadne/IndexMetadata$.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.IndexMetadata</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.IndexMetadata" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.IndexMetadata" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.IndexMetadata</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.IndexMetadata" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.IndexMetadata" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/IndexMetadata.html
+++ b/docs/api/dev/cjfravel/ariadne/IndexMetadata.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.IndexMetadata</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.IndexMetadata" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.IndexMetadata" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.IndexMetadata</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.IndexMetadata" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.IndexMetadata" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/IndexMetadataOperations.html
+++ b/docs/api/dev/cjfravel/ariadne/IndexMetadataOperations.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.IndexMetadataOperations</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.IndexMetadataOperations" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.IndexMetadataOperations" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.IndexMetadataOperations</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.IndexMetadataOperations" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.IndexMetadataOperations" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/IndexPathUtils$.html
+++ b/docs/api/dev/cjfravel/ariadne/IndexPathUtils$.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.IndexPathUtils</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.IndexPathUtils" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.IndexPathUtils" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.IndexPathUtils</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.IndexPathUtils" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.IndexPathUtils" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/IndexQueryOperations.html
+++ b/docs/api/dev/cjfravel/ariadne/IndexQueryOperations.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.IndexQueryOperations</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.IndexQueryOperations" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.IndexQueryOperations" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.IndexQueryOperations</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.IndexQueryOperations" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.IndexQueryOperations" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/IndexSummary.html
+++ b/docs/api/dev/cjfravel/ariadne/IndexSummary.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.IndexSummary</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.IndexSummary" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.IndexSummary" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.IndexSummary</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.IndexSummary" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.IndexSummary" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/LockInfo.html
+++ b/docs/api/dev/cjfravel/ariadne/LockInfo.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.LockInfo</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.LockInfo" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.LockInfo" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.LockInfo</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.LockInfo" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.LockInfo" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/RangeIndexConfig.html
+++ b/docs/api/dev/cjfravel/ariadne/RangeIndexConfig.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.RangeIndexConfig</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.RangeIndexConfig" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.RangeIndexConfig" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.RangeIndexConfig</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.RangeIndexConfig" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.RangeIndexConfig" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/SchemaHelper$.html
+++ b/docs/api/dev/cjfravel/ariadne/SchemaHelper$.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.SchemaHelper</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.SchemaHelper" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.SchemaHelper" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.SchemaHelper</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.SchemaHelper" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.SchemaHelper" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/TemporalIndexConfig.html
+++ b/docs/api/dev/cjfravel/ariadne/TemporalIndexConfig.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.TemporalIndexConfig</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.TemporalIndexConfig" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.TemporalIndexConfig" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.TemporalIndexConfig</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.TemporalIndexConfig" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.TemporalIndexConfig" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/catalog/AriadneBaseRelation.html
+++ b/docs/api/dev/cjfravel/ariadne/catalog/AriadneBaseRelation.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.catalog.AriadneBaseRelation</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.catalog.AriadneBaseRelation" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.catalog.AriadneBaseRelation" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.catalog.AriadneBaseRelation</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.catalog.AriadneBaseRelation" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.catalog.AriadneBaseRelation" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/catalog/AriadneCatalog.html
+++ b/docs/api/dev/cjfravel/ariadne/catalog/AriadneCatalog.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.catalog.AriadneCatalog</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.catalog.AriadneCatalog" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.catalog.AriadneCatalog" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.catalog.AriadneCatalog</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.catalog.AriadneCatalog" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.catalog.AriadneCatalog" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/catalog/AriadneJoinRule.html
+++ b/docs/api/dev/cjfravel/ariadne/catalog/AriadneJoinRule.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.catalog.AriadneJoinRule</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.catalog.AriadneJoinRule" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.catalog.AriadneJoinRule" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.catalog.AriadneJoinRule</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.catalog.AriadneJoinRule" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.catalog.AriadneJoinRule" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/catalog/AriadneScanBuilder.html
+++ b/docs/api/dev/cjfravel/ariadne/catalog/AriadneScanBuilder.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.catalog.AriadneScanBuilder</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.catalog.AriadneScanBuilder" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.catalog.AriadneScanBuilder" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.catalog.AriadneScanBuilder</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.catalog.AriadneScanBuilder" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.catalog.AriadneScanBuilder" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/catalog/AriadneSparkExtension.html
+++ b/docs/api/dev/cjfravel/ariadne/catalog/AriadneSparkExtension.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.catalog.AriadneSparkExtension</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.catalog.AriadneSparkExtension" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.catalog.AriadneSparkExtension" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.catalog.AriadneSparkExtension</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.catalog.AriadneSparkExtension" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.catalog.AriadneSparkExtension" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/catalog/AriadneTable.html
+++ b/docs/api/dev/cjfravel/ariadne/catalog/AriadneTable.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.catalog.AriadneTable</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.catalog.AriadneTable" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.catalog.AriadneTable" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.catalog.AriadneTable</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.catalog.AriadneTable" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.catalog.AriadneTable" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/catalog/AriadneV1Scan.html
+++ b/docs/api/dev/cjfravel/ariadne/catalog/AriadneV1Scan.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.catalog.AriadneV1Scan</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.catalog.AriadneV1Scan" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.catalog.AriadneV1Scan" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.catalog.AriadneV1Scan</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.catalog.AriadneV1Scan" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.catalog.AriadneV1Scan" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/catalog/index.html
+++ b/docs/api/dev/cjfravel/ariadne/catalog/index.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.catalog</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.catalog" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.catalog" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.catalog</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.catalog" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.catalog" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/exceptions/AriadneException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/AriadneException.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.exceptions.AriadneException</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.AriadneException" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.AriadneException" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.exceptions.AriadneException</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.exceptions.AriadneException" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.exceptions.AriadneException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/exceptions/ColumnNotFoundException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/ColumnNotFoundException.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.exceptions.ColumnNotFoundException</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.ColumnNotFoundException" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.ColumnNotFoundException" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.exceptions.ColumnNotFoundException</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.exceptions.ColumnNotFoundException" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.exceptions.ColumnNotFoundException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/exceptions/FileListNotFoundException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/FileListNotFoundException.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.exceptions.FileListNotFoundException</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.FileListNotFoundException" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.FileListNotFoundException" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.exceptions.FileListNotFoundException</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.exceptions.FileListNotFoundException" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.exceptions.FileListNotFoundException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/exceptions/FormatMismatchException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/FormatMismatchException.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.exceptions.FormatMismatchException</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.FormatMismatchException" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.FormatMismatchException" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.exceptions.FormatMismatchException</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.exceptions.FormatMismatchException" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.exceptions.FormatMismatchException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/exceptions/IndexLockException$.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/IndexLockException$.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.exceptions.IndexLockException</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.IndexLockException" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.IndexLockException" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.exceptions.IndexLockException</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.exceptions.IndexLockException" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.exceptions.IndexLockException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/exceptions/IndexLockException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/IndexLockException.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.exceptions.IndexLockException</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.IndexLockException" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.IndexLockException" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.exceptions.IndexLockException</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.exceptions.IndexLockException" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.exceptions.IndexLockException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/exceptions/IndexNotFoundException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/IndexNotFoundException.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.exceptions.IndexNotFoundException</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.IndexNotFoundException" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.IndexNotFoundException" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.exceptions.IndexNotFoundException</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.exceptions.IndexNotFoundException" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.exceptions.IndexNotFoundException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/exceptions/IndexNotFoundInNewSchemaException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/IndexNotFoundInNewSchemaException.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.exceptions.IndexNotFoundInNewSchemaException</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.IndexNotFoundInNewSchemaException" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.IndexNotFoundInNewSchemaException" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.exceptions.IndexNotFoundInNewSchemaException</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.exceptions.IndexNotFoundInNewSchemaException" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.exceptions.IndexNotFoundInNewSchemaException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/exceptions/MetadataMissingOrCorruptException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/MetadataMissingOrCorruptException.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.exceptions.MetadataMissingOrCorruptException</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.MetadataMissingOrCorruptException" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.MetadataMissingOrCorruptException" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.exceptions.MetadataMissingOrCorruptException</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.exceptions.MetadataMissingOrCorruptException" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.exceptions.MetadataMissingOrCorruptException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/exceptions/MissingFormatException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/MissingFormatException.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.exceptions.MissingFormatException</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.MissingFormatException" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.MissingFormatException" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.exceptions.MissingFormatException</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.exceptions.MissingFormatException" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.exceptions.MissingFormatException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/exceptions/MissingSchemaException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/MissingSchemaException.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.exceptions.MissingSchemaException</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.MissingSchemaException" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.MissingSchemaException" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.exceptions.MissingSchemaException</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.exceptions.MissingSchemaException" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.exceptions.MissingSchemaException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/exceptions/SchemaMismatchException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/SchemaMismatchException.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.exceptions.SchemaMismatchException</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.SchemaMismatchException" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.SchemaMismatchException" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.exceptions.SchemaMismatchException</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.exceptions.SchemaMismatchException" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.exceptions.SchemaMismatchException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/exceptions/SchemaNotProvidedException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/SchemaNotProvidedException.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.exceptions.SchemaNotProvidedException</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.SchemaNotProvidedException" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.SchemaNotProvidedException" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.exceptions.SchemaNotProvidedException</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.exceptions.SchemaNotProvidedException" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.exceptions.SchemaNotProvidedException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/exceptions/SchemaParseException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/SchemaParseException.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.exceptions.SchemaParseException</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.SchemaParseException" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.SchemaParseException" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.exceptions.SchemaParseException</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.exceptions.SchemaParseException" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.exceptions.SchemaParseException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/exceptions/StorageMigrationException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/StorageMigrationException.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.exceptions.StorageMigrationException</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.StorageMigrationException" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.StorageMigrationException" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.exceptions.StorageMigrationException</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.exceptions.StorageMigrationException" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.exceptions.StorageMigrationException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/exceptions/UnsupportedMetadataVersionException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/UnsupportedMetadataVersionException.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.exceptions.UnsupportedMetadataVersionException</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.UnsupportedMetadataVersionException" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.UnsupportedMetadataVersionException" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.exceptions.UnsupportedMetadataVersionException</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.exceptions.UnsupportedMetadataVersionException" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.exceptions.UnsupportedMetadataVersionException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/exceptions/UnsupportedStorageFormatVersionException.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/UnsupportedStorageFormatVersionException.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.exceptions.UnsupportedStorageFormatVersionException</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions.UnsupportedStorageFormatVersionException" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions.UnsupportedStorageFormatVersionException" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.exceptions.UnsupportedStorageFormatVersionException</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.exceptions.UnsupportedStorageFormatVersionException" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.exceptions.UnsupportedStorageFormatVersionException" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/exceptions/index.html
+++ b/docs/api/dev/cjfravel/ariadne/exceptions/index.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne.exceptions</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne.exceptions" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne.exceptions" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne.exceptions</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne.exceptions" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne.exceptions" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/ariadne/index.html
+++ b/docs/api/dev/cjfravel/ariadne/index.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel.ariadne</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel.ariadne" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel.ariadne" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel.ariadne</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel.ariadne" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel.ariadne" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/cjfravel/index.html
+++ b/docs/api/dev/cjfravel/index.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev.cjfravel</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev.cjfravel" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev.cjfravel" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev.cjfravel</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev.cjfravel" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev.cjfravel" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/dev/index.html
+++ b/docs/api/dev/index.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - dev</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - dev" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API dev" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - dev</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - dev" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API dev" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API </title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API " />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API " />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API </title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API " />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API " />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/org/apache/index.html
+++ b/docs/api/org/apache/index.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - org.apache</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - org.apache" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API org.apache" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - org.apache</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - org.apache" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API org.apache" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/org/apache/spark/index.html
+++ b/docs/api/org/apache/spark/index.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - org.apache.spark</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - org.apache.spark" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API org.apache.spark" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - org.apache.spark</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - org.apache.spark" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API org.apache.spark" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/org/apache/spark/sql/AriadneInternalHelper$.html
+++ b/docs/api/org/apache/spark/sql/AriadneInternalHelper$.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - org.apache.spark.sql.AriadneInternalHelper</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - org.apache.spark.sql.AriadneInternalHelper" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API org.apache.spark.sql.AriadneInternalHelper" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - org.apache.spark.sql.AriadneInternalHelper</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - org.apache.spark.sql.AriadneInternalHelper" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API org.apache.spark.sql.AriadneInternalHelper" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/org/apache/spark/sql/index.html
+++ b/docs/api/org/apache/spark/sql/index.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - org.apache.spark.sql</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - org.apache.spark.sql" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API org.apache.spark.sql" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - org.apache.spark.sql</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - org.apache.spark.sql" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API org.apache.spark.sql" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/api/org/index.html
+++ b/docs/api/org/index.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API  - org</title>
-          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.4 - beta API - org" />
-          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.4 beta API org" />
+          <title>dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API  - org</title>
+          <meta name="description" content="dev.cjfravel ariadne - spark35 2.12 0.1.5 - beta API - org" />
+          <meta name="keywords" content="dev.cjfravel ariadne spark35 2.12 0.1.5 beta API org" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
           
       
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.4-beta API<span id="doc-version"></span></span>
+        <span id="doc-title">dev.cjfravel:ariadne-spark35_2.12 0.1.5-beta API<span id="doc-version"></span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/docs/contributors/architecture.html
+++ b/docs/contributors/architecture.html
@@ -302,7 +302,7 @@ Index(name)  // reconnect to an existing index — metadata must exist</code></p
         </thead>
         <tbody>
           <tr><td><code>0.0.1-alpha-37</code> through <code>0.0.1-alpha44</code></td><td>Supported</td><td>Validates the unversioned v1 baseline, backfills file sizes, normalizes exploded aliases, verifies the result, then records v3.</td></tr>
-          <tr><td><code>0.1.0-beta</code> through <code>0.1.4-beta</code></td><td>Supported</td><td>Structurally validates the unversioned layout, applies only missing steps, verifies the result, then records v3.</td></tr>
+          <tr><td><code>0.1.0-beta</code> through <code>0.1.5-beta</code></td><td>Supported</td><td>Structurally validates the unversioned layout, applies only missing steps, verifies the result, then records v3.</td></tr>
           <tr><td>Explicit storage v1 or v2</td><td>Supported</td><td>Resumes the ordered, idempotent migration from the declared checkpoint.</td></tr>
           <tr><td>Explicit storage v3</td><td>Current</td><td>Uses the declared current layout without repeating historical schema inspection.</td></tr>
           <tr><td>Earlier than <code>0.0.1-alpha-37</code></td><td>Unsupported</td><td>Rebuild from source data with a current Ariadne version.</td></tr>
@@ -310,7 +310,7 @@ Index(name)  // reconnect to an existing index — metadata must exist</code></p
         </tbody>
       </table>
     </div>
-    <p>This build supports persisted indexes from <strong>0.0.1-alpha-37 through 0.1.4-beta</strong>. Storage v2 and v3 are migration checkpoints, not promises that every historical release wrote an explicit version. All releases before the version framework wrote unversioned metadata and are classified by the validated physical layout. Future releases may introduce newer formats that require a newer Ariadne build.</p>
+    <p>This build supports persisted indexes from <strong>0.0.1-alpha-37 through 0.1.5-beta</strong>. Storage v2 and v3 are migration checkpoints, not promises that every historical release wrote an explicit version. All releases before the version framework wrote unversioned metadata and are classified by the validated physical layout. Future releases may introduce newer formats that require a newer Ariadne build.</p>
 
     <h2 id="concurrency">Thread safety</h2>
 

--- a/docs/users/getting-started.html
+++ b/docs/users/getting-started.html
@@ -62,22 +62,22 @@
 &lt;dependency&gt;
     &lt;groupId&gt;dev.cjfravel&lt;/groupId&gt;
     &lt;artifactId&gt;ariadne-spark35_2.12&lt;/artifactId&gt;
-    &lt;version&gt;0.1.4-beta&lt;/version&gt;
+    &lt;version&gt;0.1.5-beta&lt;/version&gt;
 &lt;/dependency&gt;
 
 &lt;!-- Spark 4.1 / Delta 4.1 (Scala 2.13, Java 21) --&gt;
 &lt;dependency&gt;
     &lt;groupId&gt;dev.cjfravel&lt;/groupId&gt;
     &lt;artifactId&gt;ariadne-spark41_2.13&lt;/artifactId&gt;
-    &lt;version&gt;0.1.4-beta&lt;/version&gt;
+    &lt;version&gt;0.1.5-beta&lt;/version&gt;
 &lt;/dependency&gt;</code></pre>
 
     <h3>SBT</h3>
 <pre><code class="language-scala">// Spark 3.5 / Delta 3.2 (Scala 2.12)
-libraryDependencies += "dev.cjfravel" %% "ariadne-spark35" % "0.1.4-beta"
+libraryDependencies += "dev.cjfravel" %% "ariadne-spark35" % "0.1.5-beta"
 
 // Spark 4.1 / Delta 4.1 (Scala 2.13)
-libraryDependencies += "dev.cjfravel" %% "ariadne-spark41" % "0.1.4-beta"</code></pre>
+libraryDependencies += "dev.cjfravel" %% "ariadne-spark41" % "0.1.5-beta"</code></pre>
 
     <div class="callout note">
       <p><strong>Match your Spark line.</strong> The <code>spark35</code> artifacts target Spark 3.5 / Delta 3.2 on Scala 2.12 and Java 11; the <code>spark41</code> artifacts target Spark 4.1 / Delta 4.1 on Scala 2.13 and Java 21. Pick the artifact whose Scala version matches your cluster's Spark.</p>

--- a/docs/users/troubleshooting.html
+++ b/docs/users/troubleshooting.html
@@ -92,7 +92,7 @@ try {
     </div>
 
     <h2 id="compatibility">Persisted-index compatibility</h2>
-    <p>This Ariadne build supports indexes created by <code>0.0.1-alpha-37</code> through <code>0.1.4-beta</code>. Queries and other operational methods migrate supported older layouts under the update lock; plain <code>Index(name)</code> construction remains read-only. Indexes written by later releases may require a newer library.</p>
+    <p>This Ariadne build supports indexes created by <code>0.0.1-alpha-37</code> through <code>0.1.5-beta</code>. Queries and other operational methods migrate supported older layouts under the update lock; plain <code>Index(name)</code> construction remains read-only. Indexes written by later releases may require a newer library.</p>
     <div class="table-scroll">
       <table>
         <thead>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>dev.cjfravel</groupId>
     <artifactId>ariadne-spark${spark.suffix}_${scala.binary.version}</artifactId>
-    <version>0.1.4-beta</version>
+    <version>0.1.5-beta</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
## Summary
- coordinate version `0.1.5-beta` across both Maven artifacts and installation docs
- promote the accumulated Unreleased changelog
- update citation release metadata and supported compatibility range
- regenerate canonical Spark 3.5 API documentation

## TDD evidence
**RED:** after updating only the POM, `readme-has-version.sh` failed on CHANGELOG, CITATION, README, and both artifact snippets.

**GREEN:** 310 tests pass; version, release pipeline, migration support, repository readiness, and API drift contracts pass; both Spark profiles package successfully.

## Compatibility
- Synapse: Spark 3.5 / Delta 3.2 / Scala 2.12.17 / Java 11
- Fabric Runtime 2.0: Spark 4.1.1 / Delta 4.1 / Scala 2.13.17 / Java 21
- storage format remains v3 with support from `0.0.1-alpha-37` through `0.1.5-beta`