### PR TITLE
Fix release artifact smoke resolution

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -255,8 +255,9 @@ jobs:
       - name: Resolve both artifacts from clean repositories
         run: |
           set -euo pipefail
+          cd "$RUNNER_TEMP"
           for artifact in ariadne-spark35_2.12 ariadne-spark41_2.13; do
-            ./mvnw -B \
+            "$GITHUB_WORKSPACE/mvnw" -B \
               -Dmaven.repo.local="$RUNNER_TEMP/$artifact" \
               dependency:get \
               -Dtransitive=false \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed
+
+- Maven Central post-publication smoke checks now resolve artifacts from a neutral directory instead of parsing
+  Ariadne's profile-interpolated source POM.
+
 ## [0.1.5-beta]
 
 ### Added

--- a/dev/scripts/release-pipeline-tests.sh
+++ b/dev/scripts/release-pipeline-tests.sh
@@ -70,6 +70,8 @@ assert_contains .github/workflows/publish.yml "Final cleanup after a release fai
 assert_contains .github/workflows/publish.yml "--retry-max-time 30"
 assert_contains .github/workflows/publish.yml "ariadne-spark35_2.12"
 assert_contains .github/workflows/publish.yml "ariadne-spark41_2.13"
+assert_contains .github/workflows/publish.yml 'cd "$RUNNER_TEMP"'
+assert_contains .github/workflows/publish.yml '"$GITHUB_WORKSPACE/mvnw"'
 assert_not_contains .github/workflows/publish.yml "gpg-passphrase:"
 assert_not_contains .github/workflows/publish.yml "gpg.pinentryMode"
 


### PR DESCRIPTION
## Summary
- run post-publication Maven smoke resolution outside Ariadne source POM
- invoke the checked-out Maven wrapper through `GITHUB_WORKSPACE`
- preserve isolated clean repositories for each published artifact
- add a release pipeline regression contract

## TDD evidence
**RED:** release workflow run 29211631724 published both artifacts but dependency:get failed while parsing unresolved source-POM profile properties. The new contract failed before the workflow fix.

**GREEN:** both published coordinates resolve from a neutral temporary directory; release pipeline and repository readiness contracts pass; workflow YAML parses.

## Release status
`0.1.5-beta` is already published for both Spark coordinates. This hotfix corrects the final verification step for future releases.