### PR TITLE
Fix red release runs: import GPG key in a single setup-java step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,7 +108,6 @@ jobs:
           server-id: central
           server-username: CENTRAL_USERNAME
           server-password: CENTRAL_TOKEN
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
 
       - name: Stage and validate Spark 4.1
         id: stage41

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed
+
+- The Maven Central publish workflow now imports the GPG signing key in a single `setup-java` step. Importing it in both
+  the Java 11 and Java 21 steps registered duplicate post-job cleanups that raced to delete the key, marking otherwise
+  successful releases as failed (`gpg` exit 2). Release artifacts were unaffected.
+
 ## [0.1.6-beta]
 
 ### Fixed

--- a/dev/scripts/release-pipeline-tests.sh
+++ b/dev/scripts/release-pipeline-tests.sh
@@ -75,6 +75,15 @@ assert_contains .github/workflows/publish.yml '"$GITHUB_WORKSPACE/mvnw"'
 assert_not_contains .github/workflows/publish.yml "gpg-passphrase:"
 assert_not_contains .github/workflows/publish.yml "gpg.pinentryMode"
 
+# The GPG key is imported into the runner keyring once and persists across the job. Importing it in more than one
+# setup-java step registers duplicate post-job cleanups that race to delete the key, failing the run with gpg exit 2
+# even though the release itself succeeds. Keep exactly one gpg-private-key import.
+gpg_import_count=$(grep -c "gpg-private-key:" .github/workflows/publish.yml)
+if [[ "$gpg_import_count" -ne 1 ]]; then
+    echo ".github/workflows/publish.yml must import gpg-private-key exactly once (found $gpg_import_count)"
+    exit 1
+fi
+
 assert_contains pom.xml "<central.autoPublish>false</central.autoPublish>"
 assert_contains pom.xml "<central.waitUntil>validated</central.waitUntil>"
 assert_contains pom.xml "<project.build.outputTimestamp>"

--- a/dev/scripts/release-pipeline-tests.sh
+++ b/dev/scripts/release-pipeline-tests.sh
@@ -78,7 +78,7 @@ assert_not_contains .github/workflows/publish.yml "gpg.pinentryMode"
 # The GPG key is imported into the runner keyring once and persists across the job. Importing it in more than one
 # setup-java step registers duplicate post-job cleanups that race to delete the key, failing the run with gpg exit 2
 # even though the release itself succeeds. Keep exactly one gpg-private-key import.
-gpg_import_count=$(grep -c "gpg-private-key:" .github/workflows/publish.yml)
+gpg_import_count=$(grep -c "gpg-private-key:" .github/workflows/publish.yml || true)
 if [[ "$gpg_import_count" -ne 1 ]]; then
     echo ".github/workflows/publish.yml must import gpg-private-key exactly once (found $gpg_import_count)"
     exit 1


### PR DESCRIPTION
Fixes #97.

## Problem
The Maven Central publish workflow completes the release successfully (stage, validate, publish, and Central resolution all pass for both Spark 3.5 and 4.1), but the run is marked **failure** by a post-job step:
```
Post Set up Java 11 and release credentials
##[error]Failed to remove private key due to: The process '/usr/bin/gpg' failed with exit code 2
```
Both `setup-java` steps (Java 11 for spark35, Java 21 for spark41) imported `gpg-private-key`. Each registers a post-job `gpg --delete-secret-keys` cleanup. Post steps run in reverse, so the Java 21 cleanup deletes the key first and succeeds; the Java 11 cleanup then fails because the key is already gone. Observed on `0.1.6-beta` and `0.1.5-beta`.

## Fix
Import `gpg-private-key` only in the first `setup-java` step. The key is imported into the runner keyring once and persists across the job, so Spark 4.1 signing (Java 21) still works via `-Dgpg.keyname`. The second step keeps the Central server credentials but no longer re-imports the key, so only one post-cleanup runs.

## TDD
Added a `release-pipeline-tests.sh` guard asserting `gpg-private-key` is imported **exactly once**. Confirmed **RED** (found 2) before the fix, **GREEN** after. Full readiness/managed-runtime governance suites pass.

Cosmetic CI hygiene only — no artifact or library behavior change. No release is triggered by this PR.